### PR TITLE
Address from arb script

### DIFF
--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -4,6 +4,7 @@ namespace BitWasp\Bitcoin\Tests\Address;
 
 use BitWasp\Bitcoin\Address\AddressFactory;
 use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Bitcoin\Script\ScriptFactory;
@@ -73,5 +74,28 @@ class AddressTest extends AbstractTestCase
         $add = 'LPjNgqp43ATwzMTJPM2SFoEYeyJV6pq6By';
         $network = Bitcoin::getNetwork();
         AddressFactory::fromString($add, $network);
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Script type is not associated with an address
+     */
+    public function testFromOutputScript()
+    {
+        $outputScriptFactory = ScriptFactory::scriptPubKey();
+        $privateKey = PrivateKeyFactory::create();
+        $publicKey = $privateKey->getPublicKey();
+
+        $pubkeyHash = $outputScriptFactory->payToPubKeyHash($publicKey);
+        $scriptHash = $outputScriptFactory->payToScriptHash(ScriptFactory::multisig(1, [$publicKey]));
+
+        $p2pkhAddress = AddressFactory::fromOutputScript($pubkeyHash);
+        $this->assertInstanceOf('BitWasp\Bitcoin\Address\PayToPubKeyHashAddress', $p2pkhAddress);
+
+        $scriptAddress = AddressFactory::fromOutputScript($scriptHash);
+        $this->assertInstanceOf('BitWasp\Bitcoin\Address\ScriptHashAddress', $scriptAddress);
+
+        $unknownScript = ScriptFactory::create()->op('OP_0')->op('OP_1');
+        AddressFactory::fromOutputScript($unknownScript);
     }
 }


### PR DESCRIPTION
Adds a function to AddressFactory which initializes an Address type for a given Script, so long as it can be classified by OutputClassifier to be either pay-to-pubkey-hash, or pay-to-script-hash. 