### PR TITLE
Improve block classes

### DIFF
--- a/src/Block/Block.php
+++ b/src/Block/Block.php
@@ -58,7 +58,7 @@ class Block extends Serializable implements BlockInterface
      */
     public function getMerkleRoot()
     {
-        $root = new MerkleRoot($this->math, $this);
+        $root = new MerkleRoot($this->math, $this->getTransactions());
         return $root->calculateHash();
     }
 

--- a/src/Block/Block.php
+++ b/src/Block/Block.php
@@ -30,11 +30,11 @@ class Block extends Serializable implements BlockInterface
      * Instantiate class
      * @param Math $math
      */
-    public function __construct(Math $math)
+    public function __construct(Math $math, BlockHeaderInterface $header = null, TransactionCollection $transactions = null)
     {
-        $this->header = new BlockHeader();
         $this->math = $math;
-        $this->transactions = new TransactionCollection();
+        $this->header = $header ?: new BlockHeader();
+        $this->transactions = $transactions ?: new TransactionCollection();
     }
 
     /**

--- a/src/Block/Block.php
+++ b/src/Block/Block.php
@@ -68,16 +68,6 @@ class Block extends Serializable implements BlockInterface
     }
 
     /**
-     * @param TransactionCollection $collection
-     * @return $this
-     */
-    public function setTransactions(TransactionCollection $collection)
-    {
-        $this->transactions = $collection;
-        return $this;
-    }
-
-    /**
      * {@inheritdoc}
      * @see \BitWasp\Buffertools\SerializableInterface::getBuffer()
      */

--- a/src/Block/Block.php
+++ b/src/Block/Block.php
@@ -29,11 +29,13 @@ class Block extends Serializable implements BlockInterface
     /**
      * Instantiate class
      * @param Math $math
+     * @param BlockHeaderInterface $header
+     * @param TransactionCollection $transactions
      */
     public function __construct(Math $math, BlockHeaderInterface $header = null, TransactionCollection $transactions = null)
     {
         $this->math = $math;
-        $this->header = $header ?: new BlockHeader();
+        $this->header = $header;
         $this->transactions = $transactions ?: new TransactionCollection();
     }
 
@@ -46,18 +48,6 @@ class Block extends Serializable implements BlockInterface
     public function getHeader()
     {
         return $this->header;
-    }
-
-    /**
-     * Set the header for this block
-     *
-     * @param BlockHeaderInterface $header
-     * @return $this
-     */
-    public function setHeader(BlockHeaderInterface $header)
-    {
-        $this->header = $header;
-        return $this;
     }
 
     /**

--- a/src/Block/Block.php
+++ b/src/Block/Block.php
@@ -14,25 +14,24 @@ class Block extends Serializable implements BlockInterface
     /**
      * @var Math
      */
-    protected $math;
+    private $math;
 
     /**
      * @var BlockHeaderInterface
      */
-    protected $header;
+    private $header;
 
     /**
      * @var TransactionCollection
      */
-    protected $transactions;
+    private $transactions;
 
     /**
-     * Instantiate class
      * @param Math $math
      * @param BlockHeaderInterface $header
      * @param TransactionCollection $transactions
      */
-    public function __construct(Math $math, BlockHeaderInterface $header = null, TransactionCollection $transactions = null)
+    public function __construct(Math $math, BlockHeaderInterface $header, TransactionCollection $transactions = null)
     {
         $this->math = $math;
         $this->header = $header;
@@ -40,10 +39,8 @@ class Block extends Serializable implements BlockInterface
     }
 
     /**
-     * Return the blocks header
-     * TODO: Perhaps these should only be instantiated from a full block?
-     *
-     * @return BlockHeaderInterface
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockInterface::getHeader()
      */
     public function getHeader()
     {
@@ -51,10 +48,9 @@ class Block extends Serializable implements BlockInterface
     }
 
     /**
-     * Calculate the merkle root of this block
-     *
-     * @return string
-     * @throws \Exception
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockInterface::getMerkleRoot()
+     * @throws \BitWasp\Bitcoin\Exceptions\MerkleTreeEmpty
      */
     public function getMerkleRoot()
     {
@@ -63,9 +59,8 @@ class Block extends Serializable implements BlockInterface
     }
 
     /**
-     * Return the array of transactions from this block
-     *
-     * @return TransactionCollection
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockInterface::getTransactions()
      */
     public function getTransactions()
     {
@@ -83,7 +78,8 @@ class Block extends Serializable implements BlockInterface
     }
 
     /**
-     * @return \BitWasp\Buffertools\Buffer
+     * {@inheritdoc}
+     * @see \BitWasp\Buffertools\SerializableInterface::getBuffer()
      */
     public function getBuffer()
     {

--- a/src/Block/BlockFactory.php
+++ b/src/Block/BlockFactory.php
@@ -7,7 +7,6 @@ use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Serializer\Block\HexBlockHeaderSerializer;
 use BitWasp\Bitcoin\Serializer\Block\HexBlockSerializer;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializer;
-use BitWasp\Bitcoin\Transaction\TransactionCollection;
 
 class BlockFactory
 {

--- a/src/Block/BlockFactory.php
+++ b/src/Block/BlockFactory.php
@@ -7,20 +7,10 @@ use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Serializer\Block\HexBlockHeaderSerializer;
 use BitWasp\Bitcoin\Serializer\Block\HexBlockSerializer;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializer;
+use BitWasp\Bitcoin\Transaction\TransactionCollection;
 
 class BlockFactory
 {
-    /**
-     * @param Math $math
-     * @return Block
-     */
-    public static function create(Math $math = null)
-    {
-        $math = $math ?: Bitcoin::getMath();
-        $block = new Block($math);
-        return $block;
-    }
-
     /**
      * @param $string
      * @param Math $math
@@ -28,9 +18,12 @@ class BlockFactory
      */
     public static function fromHex($string, Math $math = null)
     {
-        $math = $math ?: Bitcoin::getMath();
-        $serializer = new HexBlockSerializer($math, new HexBlockHeaderSerializer(), new TransactionSerializer());
-        $block = $serializer->parse($string);
-        return $block;
+        $serializer = new HexBlockSerializer(
+            $math ?: Bitcoin::getMath(),
+            new HexBlockHeaderSerializer(),
+            new TransactionSerializer()
+        );
+
+        return $serializer->parse($string);
     }
 }

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -26,7 +26,7 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     protected $merkleRoot;
 
     /**
-     * @var int
+     * @var int|string
      */
     protected $timestamp;
 

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -40,7 +40,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
      */
     protected $nonce;
 
-
     /**
      * @var null|string
      */
@@ -56,6 +55,10 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
      */
     public function __construct($version, $prevBlock, $merkleRoot, $timestamp, Buffer $bits, $nonce)
     {
+        if (!is_numeric($version)) {
+            throw new \InvalidArgumentException('Block header version must be numeric');
+        }
+
         $this->version = $version;
         $this->prevBlock = $prevBlock;
         $this->merkleRoot = $merkleRoot;
@@ -67,7 +70,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * Return the bits for this block
      *
-     * @return null|Buffer
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getBits()
      */
     public function getBits()
     {
@@ -75,7 +79,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     }
 
     /**
-     * @return mixed
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getBlockHash()
      */
     public function getBlockHash()
     {
@@ -89,7 +94,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * Return the Merkle root from the header
      *
-     * @return null|string
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getMerkleRoot()
      */
     public function getMerkleRoot()
     {
@@ -99,7 +105,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * Return the previous blocks hash
      *
-     * @return null|string
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getPrevBlock()
      */
     public function getPrevBlock()
     {
@@ -107,9 +114,11 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     }
 
     /**
-     * Get the next block hash
+     * Get the next block hash. Cannot be required at constructor, not always known.
      *
-     * @return string
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getNextBlock()
+     * @throws \RuntimeException
      */
     public function getNextBlock()
     {
@@ -123,8 +132,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * Set the next block hash
      *
-     * @param $nextBlock
-     * @return $this
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::setNextBlock()
      */
     public function setNextBlock($nextBlock)
     {
@@ -136,7 +145,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
      * Return the nonce from this block. This is the value which
      * is iterated while mining.
      *
-     * @return null|integer
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getNonce()
      */
     public function getNonce()
     {
@@ -146,8 +156,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * Set the nonce for this block
      *
-     * @param $nonce
-     * @return $this
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::setNonce()
      */
     public function setNonce($nonce)
     {
@@ -158,7 +168,8 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * Get the timestamp for this block
      *
-     * @return int
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getTimestamp()
      */
     public function getTimestamp()
     {
@@ -168,18 +179,17 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * Get the version for this block
      *
-     * @return int
+     * {@inheritdoc}
+     * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getVersion()
      */
     public function getVersion()
     {
-        if ($this->version === null) {
-            return BlockHeaderInterface::CURRENT_VERSION;
-        }
         return $this->version;
     }
 
     /**
-     * @return Buffer
+     * {@inheritdoc}
+     * @see \BitWasp\Buffertools\SerializableInterface::getBuffer()
      */
     public function getBuffer()
     {

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -48,17 +48,16 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * @param null $version
      * @param null $prevBlock
-     * @param null $nextBlock
+
      * @param null $merkleRoot
      * @param null $timestamp
      * @param null $bits
      * @param null $nonce
      */
-    public function __construct($version = null, $prevBlock = null, $nextBlock = null, $merkleRoot = null, $timestamp = null, $bits = null, $nonce = null)
+    public function __construct($version, $prevBlock, $merkleRoot, $timestamp, $bits, $nonce)
     {
         $this->version = $version;
         $this->prevBlock = $prevBlock;
-        $this->nextBlock = $nextBlock;
         $this->merkleRoot = $merkleRoot;
         $this->timestamp = $timestamp;
         $this->bits = $bits;

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -36,7 +36,7 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     protected $bits;
 
     /**
-     * @var int
+     * @var int|string
      */
     protected $nonce;
 
@@ -113,7 +113,7 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
      */
     public function getNextBlock()
     {
-        if (null == $this->nextBlock) {
+        if (null === $this->nextBlock) {
             throw new \RuntimeException('Next block not known');
         }
 

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -11,14 +11,35 @@ use BitWasp\Bitcoin\Serializer\Block\HexBlockHeaderSerializer;
 class BlockHeader extends Serializable implements BlockHeaderInterface
 {
     /**
-     * @var null|int
+     * @var int|string
      */
     protected $version;
 
     /**
-     * @var null|string
+     * @var string
      */
     protected $prevBlock;
+
+    /**
+     * @var string
+     */
+    protected $merkleRoot;
+
+    /**
+     * @var int
+     */
+    protected $timestamp;
+
+    /**
+     * @var Buffer
+     */
+    protected $bits;
+
+    /**
+     * @var int
+     */
+    protected $nonce;
+
 
     /**
      * @var null|string
@@ -26,35 +47,14 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     protected $nextBlock;
 
     /**
-     * @var null|string
+     * @param int|string $version
+     * @param string $prevBlock
+     * @param string $merkleRoot
+     * @param int|string $timestamp
+     * @param Buffer $bits
+     * @param int|string $nonce
      */
-    protected $merkleRoot;
-
-    /**
-     * @var null|int
-     */
-    protected $timestamp;
-
-    /**
-     * @var null|Buffer
-     */
-    protected $bits;
-
-    /**
-     * @var null|int
-     */
-    protected $nonce;
-
-    /**
-     * @param null $version
-     * @param null $prevBlock
-
-     * @param null $merkleRoot
-     * @param null $timestamp
-     * @param null $bits
-     * @param null $nonce
-     */
-    public function __construct($version, $prevBlock, $merkleRoot, $timestamp, $bits, $nonce)
+    public function __construct($version, $prevBlock, $merkleRoot, $timestamp, Buffer $bits, $nonce)
     {
         $this->version = $version;
         $this->prevBlock = $prevBlock;
@@ -147,6 +147,10 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
      */
     public function getNextBlock()
     {
+        if (null == $this->nextBlock) {
+            throw new \RuntimeException('Next block not known');
+        }
+
         return $this->nextBlock;
     }
 

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -75,16 +75,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     }
 
     /**
-     * @param Buffer $bits
-     * @return $this
-     */
-    public function setBits(Buffer $bits)
-    {
-        $this->bits = $bits;
-        return $this;
-    }
-
-    /**
      * @return mixed
      */
     public function getBlockHash()
@@ -107,18 +97,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     }
 
     /**
-     * Set the merkle root.
-     *
-     * @param $merkleRoot
-     * @return $this
-     */
-    public function setMerkleRoot($merkleRoot)
-    {
-        $this->merkleRoot = $merkleRoot;
-        return $this;
-    }
-
-    /**
      * Return the previous blocks hash
      *
      * @return null|string
@@ -126,18 +104,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     public function getPrevBlock()
     {
         return $this->prevBlock;
-    }
-
-    /**
-     * Set the previous blocks hash
-     *
-     * @param string $prevBlock
-     * @return $this
-     */
-    public function setPrevBlock($prevBlock)
-    {
-        $this->prevBlock = $prevBlock;
-        return $this;
     }
 
     /**
@@ -200,18 +166,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     }
 
     /**
-     * Set the timestamp for this block
-     *
-     * @param $timestamp
-     * @return $this
-     */
-    public function setTimestamp($timestamp)
-    {
-        $this->timestamp = $timestamp;
-        return $this;
-    }
-
-    /**
      * Get the version for this block
      *
      * @return int
@@ -222,18 +176,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
             return BlockHeaderInterface::CURRENT_VERSION;
         }
         return $this->version;
-    }
-
-    /**
-     * Set the version of this block
-     *
-     * @param $version
-     * @return BlockHeaderInterface
-     */
-    public function setVersion($version)
-    {
-        $this->version = $version;
-        return $this;
     }
 
     /**

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -13,37 +13,37 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     /**
      * @var int|string
      */
-    protected $version;
+    private $version;
 
     /**
      * @var string
      */
-    protected $prevBlock;
+    private $prevBlock;
 
     /**
      * @var string
      */
-    protected $merkleRoot;
+    private $merkleRoot;
 
     /**
      * @var int|string
      */
-    protected $timestamp;
+    private $timestamp;
 
     /**
      * @var Buffer
      */
-    protected $bits;
+    private $bits;
 
     /**
      * @var int|string
      */
-    protected $nonce;
+    private $nonce;
 
     /**
      * @var null|string
      */
-    protected $nextBlock;
+    private $nextBlock;
 
     /**
      * @param int|string $version

--- a/src/Block/BlockHeaderInterface.php
+++ b/src/Block/BlockHeaderInterface.php
@@ -15,23 +15,13 @@ interface BlockHeaderInterface extends SerializableInterface
     public function getVersion();
 
     /**
-     * @param $version
-     * @return BlockHeaderInterface
-     */
-    public function setVersion($version);
-
-    /**
      * @return string
      */
     public function getPrevBlock();
 
     /**
-     * @param $prevBlock
-     * @return BlockHeaderInterface
-     */
-    public function setPrevBlock($prevBlock);
-    /**
      * @return string
+     * @throws \RuntimeException
      */
     public function getNextBlock();
 
@@ -47,32 +37,14 @@ interface BlockHeaderInterface extends SerializableInterface
     public function getMerkleRoot();
 
     /**
-     * @param $merkleRoot
-     * @return BlockHeaderInterface
-     */
-    public function setMerkleRoot($merkleRoot);
-
-    /**
      * @return string
      */
     public function getTimestamp();
 
     /**
-     * @param $timestamp
-     * @return BlockHeaderInterface
-     */
-    public function setTimestamp($timestamp);
-
-    /**
      * @return Buffer|null
      */
     public function getBits();
-
-    /**
-     * @param Buffer $bits
-     * @return BlockHeaderInterface
-     */
-    public function setBits(Buffer $bits);
 
     /**
      * @return string

--- a/src/Block/BlockHeaderInterface.php
+++ b/src/Block/BlockHeaderInterface.php
@@ -10,54 +10,73 @@ interface BlockHeaderInterface extends SerializableInterface
     const CURRENT_VERSION = 2;
 
     /**
-     * @return int
+     * Return the version of this block.
+     *
+     * @return int|string
      */
     public function getVersion();
 
     /**
+     * Return the previous blocks hash.
+     *
      * @return string
      */
     public function getPrevBlock();
 
     /**
+     * Return the next block hash. Note this may not always be set.
+     *
      * @return string
-     * @throws \RuntimeException
      */
     public function getNextBlock();
 
     /**
-     * @param $nextBlock
+     * Set next block, to the provided $nextBlock hash.
+     *
+     * @param string $nextBlock
      * @return BlockHeaderInterface
      */
     public function setNextBlock($nextBlock);
 
     /**
+     * Return the merkle root of the transactions in the block.
+     *
      * @return string
      */
     public function getMerkleRoot();
 
     /**
+     * Get the timestamp of the block.
+     *
      * @return string
      */
     public function getTimestamp();
 
     /**
-     * @return Buffer|null
+     * Return the buffer containing the short representation of the difficulty
+     *
+     * @return Buffer
      */
     public function getBits();
 
     /**
+     * Return the nonce of the block header.
+     *
      * @return string
      */
     public function getNonce();
 
     /**
+     * Set the nonce of the block header. Used in mining.
+     *
      * @param $nonce
      * @return BlockHeaderInterface
      */
     public function setNonce($nonce);
 
     /**
+     * Calculate the hash of this header.
+     *
      * @return string
      */
     public function getBlockHash();

--- a/src/Block/BlockInterface.php
+++ b/src/Block/BlockInterface.php
@@ -11,16 +11,22 @@ interface BlockInterface extends SerializableInterface
     const MAX_BLOCK_SIZE = 1000000;
 
     /**
+     * Get the header of this block.
+     *
      * @return BlockHeaderInterface
      */
     public function getHeader();
 
     /**
-     * @return mixed
+     * Calculate the merkle root of the transactions in the block.
+     *
+     * @return string
      */
     public function getMerkleRoot();
 
     /**
+     * Return the TransactionCollection from the block.
+     * 
      * @return TransactionCollection
      */
     public function getTransactions();

--- a/src/Block/BlockInterface.php
+++ b/src/Block/BlockInterface.php
@@ -26,7 +26,7 @@ interface BlockInterface extends SerializableInterface
 
     /**
      * Return the TransactionCollection from the block.
-     * 
+     *
      * @return TransactionCollection
      */
     public function getTransactions();

--- a/src/Block/GenesisMiningBlockHeader.php
+++ b/src/Block/GenesisMiningBlockHeader.php
@@ -4,6 +4,11 @@ namespace BitWasp\Bitcoin\Block;
 
 class GenesisMiningBlockHeader extends BlockHeader
 {
+    public function __construct()
+    {
+        
+    }
+
     /**
      * @return string
      */

--- a/src/Rpc/Client/Bitcoind.php
+++ b/src/Rpc/Client/Bitcoind.php
@@ -2,7 +2,11 @@
 
 namespace BitWasp\Bitcoin\Rpc\Client;
 
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Block\Block;
 use BitWasp\Bitcoin\Block\BlockFactory;
+use BitWasp\Bitcoin\Block\BlockHeader;
+use BitWasp\Bitcoin\Transaction\TransactionCollection;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\JsonRpc\JsonRpcClient;
 use BitWasp\Bitcoin\Transaction\TransactionFactory;
@@ -64,19 +68,9 @@ class Bitcoind
     public function getblock($blockhash)
     {
         $blockArray = $this->client->execute('getblock', array($blockhash, true));
-        $block = BlockFactory::create();
-
-        // Build block header
-        $block->getHeader()
-            ->setVersion($blockArray['version'])
-            ->setBits(Buffer::hex($blockArray['bits']))
-            ->setTimestamp($blockArray['time'])
-            ->setMerkleRoot($blockArray['merkleroot'])
-            ->setNonce($blockArray['nonce'])
-            ->setPrevBlock(@$blockArray['previousblockhash']) // only @ this because of genesis block
-            ->setNextBlock(@$blockArray['nextblockhash']);
 
         // Establish batch query for loading transactions
+        $txs = [];
         if (count($blockArray['tx']) > 0) {
             $this->client->batch();
             foreach ($blockArray['tx'] as $txid) {
@@ -85,15 +79,33 @@ class Bitcoind
             $result = $this->client->send();
 
             // Build the transactions
-            $block->getTransactions()->addTransactions(
-                array_map(function ($value) {
+            $txs = array_map(
+                function ($value) {
                     return TransactionFactory::fromHex($value);
-                }, $result)
+                },
+                $result
             );
-
         }
 
-        return $block;
+        // Build block header$
+        $header = new BlockHeader(
+            $blockArray['version'],
+            @$blockArray['previousblockhash'],
+            $blockArray['merkleroot'],
+            $blockArray['time'],
+            Buffer::hex($blockArray['bits']),
+            $blockArray['nonce']
+        );
+
+        if (isset($blockArray['nextblockhash'])) {
+            $header->setNextBlock($blockArray['nextblockhash']);
+        }
+
+        return new Block(
+            Bitcoin::getMath(),
+            $header,
+            new TransactionCollection($txs)
+        );
     }
 
     /**

--- a/src/Rpc/Client/Bitcoind.php
+++ b/src/Rpc/Client/Bitcoind.php
@@ -68,6 +68,7 @@ class Bitcoind
     public function getblock($blockhash)
     {
         $blockArray = $this->client->execute('getblock', array($blockhash, true));
+        $this->checkNotNull($blockArray);
 
         // Establish batch query for loading transactions
         $txs = [];
@@ -77,6 +78,7 @@ class Bitcoind
                 $this->client->execute('getrawtransaction', array($txid));
             }
             $result = $this->client->send();
+            $this->checkNotNull($result);
 
             // Build the transactions
             $txs = array_map(

--- a/src/Serializer/Block/HexBlockHeaderSerializer.php
+++ b/src/Serializer/Block/HexBlockHeaderSerializer.php
@@ -9,7 +9,6 @@ use BitWasp\Bitcoin\Block\BlockHeaderInterface;
 
 class HexBlockHeaderSerializer
 {
-
     /**
      * @param $string
      * @return BlockHeader

--- a/src/Serializer/Block/HexBlockHeaderSerializer.php
+++ b/src/Serializer/Block/HexBlockHeaderSerializer.php
@@ -28,15 +28,17 @@ class HexBlockHeaderSerializer
      */
     public function fromParser(Parser & $parser)
     {
-        $header = new BlockHeader();
+
         try {
-            $header
-                ->setVersion($parser->readBytes(4, true)->getInt())
-                ->setPrevBlock($parser->readBytes(32, true))
-                ->setMerkleRoot($parser->readBytes(32, true))
-                ->setTimestamp($parser->readBytes(4, true)->getInt())
-                ->setBits($parser->readBytes(4, true))
-                ->setNonce($parser->readBytes(4, true)->getInt());
+            $header = new BlockHeader(
+                $parser->readBytes(4, true)->getInt(),
+                $parser->readBytes(32, true)->getHex(),
+                $parser->readBytes(32, true)->getHex(),
+                $parser->readBytes(4, true)->getInt(),
+                $parser->readBytes(4, true),
+                $parser->readBytes(4, true)->getInt()
+            );
+
         } catch (ParserOutOfRange $e) {
             throw new ParserOutOfRange('Failed to extract full block header from parser');
         }

--- a/src/Serializer/Block/HexBlockSerializer.php
+++ b/src/Serializer/Block/HexBlockSerializer.php
@@ -46,7 +46,6 @@ class HexBlockSerializer
     public function fromParser(Parser & $parser)
     {
         try {
-
             $block = new Block(
                 $this->math,
                 $this->headerSerializer->fromParser($parser)

--- a/src/Serializer/Block/HexBlockSerializer.php
+++ b/src/Serializer/Block/HexBlockSerializer.php
@@ -46,8 +46,12 @@ class HexBlockSerializer
     public function fromParser(Parser & $parser)
     {
         try {
-            $block = new Block($this->math);
-            $block->setHeader($this->headerSerializer->fromParser($parser));
+
+            $block = new Block(
+                $this->math,
+                $this->headerSerializer->fromParser($parser)
+            );
+
             $block->getTransactions()->addTransactions(
                 $parser->getArray(
                     function () use (&$parser) {

--- a/tests/Block/BlockHeaderTest.php
+++ b/tests/Block/BlockHeaderTest.php
@@ -75,6 +75,7 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
     {
         $header = new BlockHeader(null, null, null, null, new Buffer(), '20229302');
         $this->assertEquals('20229302', $header->getNonce());
+        $this->assertEquals('20229304', $header->setNonce('20229304')->getNonce());
     }
 
     /**
@@ -120,6 +121,8 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
         $result = BlockHeaderFactory::fromHex($this->getGenesisHex());
         $this->assertSame($this->getGenesisHex(), $result->getHex());
     }
+
+
 
     public function testGetBlockHash()
     {

--- a/tests/Block/BlockHeaderTest.php
+++ b/tests/Block/BlockHeaderTest.php
@@ -122,7 +122,14 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($this->getGenesisHex(), $result->getHex());
     }
 
-
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Block header version must be numeric
+     */
+    public function testInvalidVersion()
+    {
+        new BlockHeader(null, null, null, null, new Buffer(), null);
+    }
 
     public function testGetBlockHash()
     {

--- a/tests/Block/BlockHeaderTest.php
+++ b/tests/Block/BlockHeaderTest.php
@@ -17,7 +17,7 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
     /**
      * @var string
      */
-    protected $headerType;
+    protected $headerType = 'BitWasp\Bitcoin\Block\BlockHeader';
 
     /**
      * @var string
@@ -26,7 +26,6 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
 
     public function __construct()
     {
-        $this->headerType = 'BitWasp\Bitcoin\Block\BlockHeader';
         $this->bufferType = 'BitWasp\Buffertools\Buffer';
     }
 
@@ -35,97 +34,65 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
         return '0100000000000000000000000000000000000000000000000000000000000000000000003ba3edfd7a7b12b27ac72c3e67768f617fc81bc3888a51323a9fb8aa4b1e5e4a29ab5f49ffff001d1dac2b7c';
     }
 
-    public function setUp()
+    public function testNewHeader()
     {
-        $this->header = new BlockHeader();
-    }
+        //old: public function __construct($version = null, $prevBlock = null, $nextBlock = null, $merkleRoot = null, $timestamp = null, $bits = null, $nonce = null)
+        $version = 2;
+        $prevBlock = '4141414141414141414141414141414141414141414141414141414141414141';
+        $merkleRoot = '4242424241414141414141414141414141414141414141414141414141414141';
+        $time ='191230123';
+        $bits = Buffer::hex('1d00ffff');
+        $nonce = '666';
 
-    public function testCreateHeader()
-    {
-        $this->assertInstanceOf($this->headerType, $this->header);
+        $header = new BlockHeader(
+            $version,
+            $prevBlock,
+            $merkleRoot,
+            $time,
+            $bits,
+            $nonce
+        );
+
+        $this->assertEquals($version, $header->getVersion());
+        $this->assertEquals($prevBlock, $header->getPrevBlock());
+        $this->assertEquals($merkleRoot, $header->getMerkleRoot());
+        $this->assertEquals($time, $header->getTimestamp());
+        $this->assertEquals($nonce, $header->getNonce());
+
+        $nextBlock = '8080808080808080808080808080808080808080808080808080808080808080';
+        $header->setNextBlock($nextBlock);
+
+        $this->assertEquals($nextBlock, $header->getNextBlock());
     }
 
     public function testGetVersionDefault()
     {
-        $this->assertEquals(BlockHeaderInterface::CURRENT_VERSION, $this->header->getVersion());
-    }
-
-    public function testSetVersion()
-    {
-        $this->header->setVersion('1');
-        $this->assertEquals('1', $this->header->getVersion());
-    }
-
-    public function testGetTimestamp()
-    {
-        $this->assertNull($this->header->getTimestamp());
-    }
-
-    public function testSetTimestamp()
-    {
-        $this->header->setTimestamp('1420158469');
-        $this->assertEquals('1420158469', $this->header->getTimestamp());
-    }
-
-    public function testGetNonce()
-    {
-        $this->assertNull($this->header->getNonce());
+        $header = new BlockHeader(null, null, null, null, null, null);
+        $this->assertEquals(BlockHeaderInterface::CURRENT_VERSION, $header->getVersion());
     }
 
     public function testSetNonce()
     {
-        $this->header->setNonce('20229302');
-        $this->assertEquals('20229302', $this->header->getNonce());
-    }
-
-    public function testGetPrevBlock()
-    {
-        $this->assertNull($this->header->getPrevBlock());
-    }
-
-    public function testSetPrevBlock()
-    {
-        $this->header->setPrevBlock('000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f');
-        $this->assertEquals('000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f', $this->header->getPrevBlock());
+        $header = new BlockHeader();
+        $header->setNonce('20229302');
+        $this->assertEquals('20229302', $header->getNonce());
     }
 
     public function testGetNextBlock()
     {
-        $this->assertNull($this->header->getNextBlock());
+        $header = new BlockHeader();
+        $this->assertNull($header->getNextBlock());
     }
 
     public function testSetNextBlock()
     {
-        $this->header->setNextBlock('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048');
-        $this->assertEquals('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048', $this->header->getNextBlock());
-    }
-
-    public function testGetMerkleRoot()
-    {
-        $this->assertNull($this->header->getMerkleRoot());
-    }
-
-    public function testSetMerkleRoot()
-    {
-        $this->header->setMerkleRoot('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b');
-        $this->assertEquals('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b', $this->header->getMerkleRoot());
-    }
-
-    public function testGetBits()
-    {
-        $this->assertNull($this->header->getBits());
-    }
-
-    public function testSetBits()
-    {
-        $bits = Buffer::hex('1effffff');
-        $this->header->setBits($bits);
-        $this->assertSame($bits, $this->header->getBits());
+        $header = new BlockHeader();
+        $header->setNextBlock('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048');
+        $this->assertEquals('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048', $header->getNextBlock());
     }
 
     public function testFromParser()
     {
-
         $result = BlockHeaderFactory::fromHex($this->getGenesisHex());
 
         $this->assertInstanceOf($this->headerType, $result);

--- a/tests/Block/BlockHeaderTest.php
+++ b/tests/Block/BlockHeaderTest.php
@@ -67,26 +67,30 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetVersionDefault()
     {
-        $header = new BlockHeader(null, null, null, null, null, null);
+        $header = new BlockHeader(null, null, null, null, new Buffer(), null);
         $this->assertEquals(BlockHeaderInterface::CURRENT_VERSION, $header->getVersion());
     }
-
+/*
     public function testSetNonce()
     {
         $header = new BlockHeader();
         $header->setNonce('20229302');
         $this->assertEquals('20229302', $header->getNonce());
     }
-
+*/
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Next block not known
+     */
     public function testGetNextBlock()
     {
-        $header = new BlockHeader();
+        $header = new BlockHeader(null, null, null, null, new Buffer(), null);
         $this->assertNull($header->getNextBlock());
     }
 
     public function testSetNextBlock()
     {
-        $header = new BlockHeader();
+        $header = new BlockHeader(null, null, null, null, new Buffer(), null);
         $header->setNextBlock('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048');
         $this->assertEquals('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048', $header->getNextBlock());
     }

--- a/tests/Block/BlockHeaderTest.php
+++ b/tests/Block/BlockHeaderTest.php
@@ -67,13 +67,13 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
 
     public function testGetVersionDefault()
     {
-        $header = new BlockHeader(null, null, null, null, new Buffer(), null);
+        $header = new BlockHeader(BlockHeaderInterface::CURRENT_VERSION, null, null, null, new Buffer(), null);
         $this->assertEquals(BlockHeaderInterface::CURRENT_VERSION, $header->getVersion());
     }
 
     public function testSetNonce()
     {
-        $header = new BlockHeader(null, null, null, null, new Buffer(), '20229302');
+        $header = new BlockHeader(1, null, null, null, new Buffer(), '20229302');
         $this->assertEquals('20229302', $header->getNonce());
         $this->assertEquals('20229304', $header->setNonce('20229304')->getNonce());
     }
@@ -84,13 +84,13 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
      */
     public function testGetNextBlock()
     {
-        $header = new BlockHeader(null, null, null, null, new Buffer(), null);
+        $header = new BlockHeader(1, null, null, null, new Buffer(), null);
         $this->assertNull($header->getNextBlock());
     }
 
     public function testSetNextBlock()
     {
-        $header = new BlockHeader(null, null, null, null, new Buffer(), null);
+        $header = new BlockHeader(1, null, null, null, new Buffer(), null);
         $header->setNextBlock('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048');
         $this->assertEquals('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048', $header->getNextBlock());
     }

--- a/tests/Block/BlockHeaderTest.php
+++ b/tests/Block/BlockHeaderTest.php
@@ -70,14 +70,13 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
         $header = new BlockHeader(null, null, null, null, new Buffer(), null);
         $this->assertEquals(BlockHeaderInterface::CURRENT_VERSION, $header->getVersion());
     }
-/*
+
     public function testSetNonce()
     {
-        $header = new BlockHeader();
-        $header->setNonce('20229302');
+        $header = new BlockHeader(null, null, null, null, new Buffer(), '20229302');
         $this->assertEquals('20229302', $header->getNonce());
     }
-*/
+
     /**
      * @expectedException \RuntimeException
      * @expectedExceptionMessage Next block not known
@@ -102,11 +101,11 @@ class BlockHeaderTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf($this->headerType, $result);
         $this->assertSame('1', $result->getVersion());
 
-        $this->assertInstanceOf($this->bufferType, $result->getPrevBlock());
-        $this->assertSame('0000000000000000000000000000000000000000000000000000000000000000', $result->getPrevBlock()->getHex());
+        $this->assertInternalType('string', $result->getPrevBlock());
+        $this->assertSame('0000000000000000000000000000000000000000000000000000000000000000', $result->getPrevBlock());
 
-        $this->assertInstanceOf($this->bufferType, $result->getMerkleRoot());
-        $this->assertSame('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b', $result->getMerkleRoot()->getHex());
+        $this->assertInternalType('string', $result->getMerkleRoot());
+        $this->assertSame('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b', $result->getMerkleRoot());
 
         $this->assertInstanceOf($this->bufferType, $result->getBits());
         $this->assertSame('1d00ffff', $result->getBits()->getHex());

--- a/tests/Block/MerkleRootTest.php
+++ b/tests/Block/MerkleRootTest.php
@@ -3,60 +3,32 @@
 namespace BitWasp\Bitcoin\Tests\Block;
 
 use BitWasp\Bitcoin\Bitcoin;
-use BitWasp\Bitcoin\Block\BlockHeader;
 use BitWasp\Bitcoin\Block\MerkleRoot;
-use BitWasp\Bitcoin\Block\Block;
+use BitWasp\Bitcoin\Math\Math;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
 use BitWasp\Bitcoin\Transaction\TransactionCollection;
 use BitWasp\Bitcoin\Transaction\TransactionFactory;
-use BitWasp\Buffertools\Buffer;
 
-class MerkleRootTest extends \PHPUnit_Framework_TestCase
+class MerkleRootTest extends AbstractTestCase
 {
     /**
      * @var string
      */
-    protected $rootType;
-
-    public function __construct()
-    {
-        $this->rootType = 'BitWasp\Bitcoin\Block\MerkleRoot';
-    }
-
-    public function testCreateNew()
-    {
-        $hex = '010000000462442ea8de9ee6cc2dd7d76dfc4523910eb2e3bd4b202d376910de700f63bf4b000000008b48304502207db5ea602fe2e9f8e70bfc68b7f468d68910d2ff4ac50294fc80109e254f317f022100a68a66f23406fdfd93025c28ffef4e79260283335ce39a4e8d0b52c5ee41913b014104f8de51f3b278225c0fe74a856ea2481e9ad4c9385fc10cefadaa4357ecd2c4d29904902d10e376546500c127f65d0de35b6215d49dd1ef6c67e6cdd5e781ef22ffffffff10aa2a8f9211ab71ffc9df03d52450d89a9de648fdfd75c0d20e4dcb1be29cfd020000008b483045022100d088af937bd457903391023c468bdbb9dc46681c3c83ab7b101c26a41524a0e20220369597fa4737aa4408469fec831b5ce53caee8e9fec81282376c6f592be354fb01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff067b1e03bd8edc0496b41af958fead9d57489fa12d23f4b341ded9b78d8cb114000000008b483045022009538bca3258eb4175faa7121dca68b51d95f2ed7d24278f03e2d88077d92815022100b8706672c585e8607e18d235e69548cd28736adfa9ce4f8f5f3baffc5aad091b01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff7f6d4bbb8f0d9b8bcad2e431c270aac63aa9caaa880dbd1688e39b6ac0d45ff4020000008b48304502203da091fed8fc71b3c859ee1dfe9c3d0e64915502af057357effa1ae4d1e0dbbf02210090fd964dfe7286b1ab0af3e8d6686c7826039eb0b46bac9803af367f080f38e401410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff0200b79ba7000000001976a914b5ac94f60f833b1e2dab9bc5f7895687bd750e8688acb0720200000000001976a9141b16cf7372a97b42533605e14616b6338caba8e888ac00000000';
-        $tx = TransactionFactory::fromHex($hex);
-
-        $math = Bitcoin::getMath();
-
-        $root = new MerkleRoot($math, new TransactionCollection(array($tx)));
-        $this->assertInstanceOf($this->rootType, $root);
-    }
+    public $rootType= 'BitWasp\Bitcoin\Block\MerkleRoot';
 
     /**
      * @expectedException \BitWasp\Bitcoin\Exceptions\MerkleTreeEmpty
-     * @expectedExceptionMessage
      */
-    public function testCannotUseEmptyBlock()
+    public function testCannotUseEmptyCollection()
     {
         $math = Bitcoin::getMath();
         $root = new MerkleRoot($math, new TransactionCollection());
         $root->calculateHash();
     }
 
-    public function testWithOnlyOneTransaction()
-    {
-        $hex = '010000000462442ea8de9ee6cc2dd7d76dfc4523910eb2e3bd4b202d376910de700f63bf4b000000008b48304502207db5ea602fe2e9f8e70bfc68b7f468d68910d2ff4ac50294fc80109e254f317f022100a68a66f23406fdfd93025c28ffef4e79260283335ce39a4e8d0b52c5ee41913b014104f8de51f3b278225c0fe74a856ea2481e9ad4c9385fc10cefadaa4357ecd2c4d29904902d10e376546500c127f65d0de35b6215d49dd1ef6c67e6cdd5e781ef22ffffffff10aa2a8f9211ab71ffc9df03d52450d89a9de648fdfd75c0d20e4dcb1be29cfd020000008b483045022100d088af937bd457903391023c468bdbb9dc46681c3c83ab7b101c26a41524a0e20220369597fa4737aa4408469fec831b5ce53caee8e9fec81282376c6f592be354fb01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff067b1e03bd8edc0496b41af958fead9d57489fa12d23f4b341ded9b78d8cb114000000008b483045022009538bca3258eb4175faa7121dca68b51d95f2ed7d24278f03e2d88077d92815022100b8706672c585e8607e18d235e69548cd28736adfa9ce4f8f5f3baffc5aad091b01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff7f6d4bbb8f0d9b8bcad2e431c270aac63aa9caaa880dbd1688e39b6ac0d45ff4020000008b48304502203da091fed8fc71b3c859ee1dfe9c3d0e64915502af057357effa1ae4d1e0dbbf02210090fd964dfe7286b1ab0af3e8d6686c7826039eb0b46bac9803af367f080f38e401410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff0200b79ba7000000001976a914b5ac94f60f833b1e2dab9bc5f7895687bd750e8688acb0720200000000001976a9141b16cf7372a97b42533605e14616b6338caba8e888ac00000000';
-        $tx = TransactionFactory::fromHex($hex);
-        $math = Bitcoin::getMath();
-
-        $merkle = new MerkleRoot($math, new TransactionCollection(array($tx)));
-        $this->assertSame($tx->getTransactionId(), $merkle->calculateHash());
-    }
-
     /**
      * @param array $hexes - a list of transaction hex strings
-     * @return array
+     * @return TransactionCollection
      */
     private function getTransactionCollection(array $hexes)
     {
@@ -69,34 +41,54 @@ class MerkleRootTest extends \PHPUnit_Framework_TestCase
         return $transactions;
     }
 
-    public function testWithOnlyEvenNumberOfTransactions()
+    /**
+     * @return array
+     */
+    public function getMerkleVectors()
     {
-        $math = Bitcoin::getMath();
+        $math = new Math();
+        $vectors = [];
 
-        $transactions = $this->getTransactionCollection([
-            '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff070456720e1b017bffffffff0100f2052a010000004341048cb16dcb7db3dd9ebee9f677d487c6272a93841e73a96589ba214a0324798048794a9fafe9e8d761e77f3eba3d45b1618f25493eee1ac598bdef3951aaca0a63ac00000000',
-            '01000000015132aa73be95888c4ceefd27c2be87df5c03e463afa0be4161e6740e85c9b154010000008b48304502202b69c4847d96f9d6fcdfeb3c277ab16471f45577236eafd15baa504a5655d1ae022100a40c1fcd609e360b98e5d48b58c1afcf7c308b799868b0c47e6b55c726e67125014104d4dfd5815e61e2496856326ea23443b1e6b2067ddb1e14f22c6b700e27043976a73f5d0312a332fc4c6a87513d296e54b12dedb635aa5f7cecfd3a891acdf0acffffffff0280509b1b050000001976a914669b317ee66d134446517794c81cd304e115609088ac00e40b54020000001976a9141a1487913d49504f3e7672868b35caf85b68940888ac00000000'
-        ]);
+        // Only one transaction - will equal the transaction txid
+        $txHex1 = '010000000462442ea8de9ee6cc2dd7d76dfc4523910eb2e3bd4b202d376910de700f63bf4b000000008b48304502207db5ea602fe2e9f8e70bfc68b7f468d68910d2ff4ac50294fc80109e254f317f022100a68a66f23406fdfd93025c28ffef4e79260283335ce39a4e8d0b52c5ee41913b014104f8de51f3b278225c0fe74a856ea2481e9ad4c9385fc10cefadaa4357ecd2c4d29904902d10e376546500c127f65d0de35b6215d49dd1ef6c67e6cdd5e781ef22ffffffff10aa2a8f9211ab71ffc9df03d52450d89a9de648fdfd75c0d20e4dcb1be29cfd020000008b483045022100d088af937bd457903391023c468bdbb9dc46681c3c83ab7b101c26a41524a0e20220369597fa4737aa4408469fec831b5ce53caee8e9fec81282376c6f592be354fb01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff067b1e03bd8edc0496b41af958fead9d57489fa12d23f4b341ded9b78d8cb114000000008b483045022009538bca3258eb4175faa7121dca68b51d95f2ed7d24278f03e2d88077d92815022100b8706672c585e8607e18d235e69548cd28736adfa9ce4f8f5f3baffc5aad091b01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff7f6d4bbb8f0d9b8bcad2e431c270aac63aa9caaa880dbd1688e39b6ac0d45ff4020000008b48304502203da091fed8fc71b3c859ee1dfe9c3d0e64915502af057357effa1ae4d1e0dbbf02210090fd964dfe7286b1ab0af3e8d6686c7826039eb0b46bac9803af367f080f38e401410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff0200b79ba7000000001976a914b5ac94f60f833b1e2dab9bc5f7895687bd750e8688acb0720200000000001976a9141b16cf7372a97b42533605e14616b6338caba8e888ac00000000';
+        $tx = TransactionFactory::fromHex($txHex1);
+        $vectors[] = [
+            $math,
+            [$txHex1],
+            $tx->getTransactionId()
+        ];
 
-        $block = new Block($math,
-            new BlockHeader(null, null, null, null, new Buffer(), null),
-            $transactions
-        );
-        
-        $this->assertSame('e22e7f473e3c50e2a5eab4ee1bc1bd8bb6d21a5485542ccebbda9282bb75491f', $block->getMerkleRoot());
+        // Only an even number of transactions
+        $vectors[] = [
+            $math,
+            [
+                '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff070456720e1b017bffffffff0100f2052a010000004341048cb16dcb7db3dd9ebee9f677d487c6272a93841e73a96589ba214a0324798048794a9fafe9e8d761e77f3eba3d45b1618f25493eee1ac598bdef3951aaca0a63ac00000000',
+                '01000000015132aa73be95888c4ceefd27c2be87df5c03e463afa0be4161e6740e85c9b154010000008b48304502202b69c4847d96f9d6fcdfeb3c277ab16471f45577236eafd15baa504a5655d1ae022100a40c1fcd609e360b98e5d48b58c1afcf7c308b799868b0c47e6b55c726e67125014104d4dfd5815e61e2496856326ea23443b1e6b2067ddb1e14f22c6b700e27043976a73f5d0312a332fc4c6a87513d296e54b12dedb635aa5f7cecfd3a891acdf0acffffffff0280509b1b050000001976a914669b317ee66d134446517794c81cd304e115609088ac00e40b54020000001976a9141a1487913d49504f3e7672868b35caf85b68940888ac00000000'
+            ],
+            'e22e7f473e3c50e2a5eab4ee1bc1bd8bb6d21a5485542ccebbda9282bb75491f'
+        ];
 
+        // An odd number of transactions
+        $vectors[] = [
+            $math,
+            ['01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff070456720e1b014dffffffff0100f2052a01000000434104e42b336370edbe2ba4c82a4239cecb5584416b5d844c25c58644700fa37512f300294fc802ed0a8525e83c583986ef58bd0fd259318506e600accd9ea39c8a7aac00000000','01000000016d00d07023106a1f15d8e0bebd2340945fe14f48525764952f7698e25dee8f6c000000008b483045022070145ad92706c5525c304e40d307bfe919ea13fb13b3f1d1449cba8cfc97018d022100ecf96a9a3d9b840c2fc944150200e0ba3c79d725b15dece47fd3529bb83e88040141040dc92273d787c973be5649047ef7241c0faa77f5968056630e46fc4e7bdf7d06886c23bf67d42c62ee8274758cfc1906313cb324e1b1b12aabe0b6785a17138affffffff02c05961240b0000001976a9140dcee4bebdccd55fbcc7bdd63a11215667ce868088ac404b4c00000000001976a9141d5cf706fe85aecfdb2b0536fe2682b2e93f8ecf88ac00000000','0100000001e5d7950689c9376d387b280bf1b0145a2dbdd2708f8c40e9e74ee1e65b389855000000004948304502205ef4bfb3e3551f0477c8ad5609690220c58a7de8b9cbd1d0f5730929e366d548022100dc968d62db776912ec3ab1a64640a31559cfdddb9eed4706224be9bfe058d46401ffffffff0100f2052a010000001976a914f74a2698d94e41a97a8ad2e96fd858f9db05559f88ac00000000'],
+            'cb59c3f584d7fd3d391b56674c00830d0c33c164a44ab25df88ba8547c6355cb'
+        ];
+
+        return $vectors;
     }
 
-    public function testWithOnlyOddNumberOfTransactions()
+    /**
+     * @dataProvider getMerkleVectors
+     * @param Math $math
+     * @param array $txArray
+     * @param string $eMerkleRoot
+     * @throws \BitWasp\Bitcoin\Exceptions\MerkleTreeEmpty
+     */
+    public function testWholeSet(Math $math, array $txArray, $eMerkleRoot)
     {
-        $math = Bitcoin::getMath();
-        $transactions = $this->getTransactionCollection(['01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff070456720e1b014dffffffff0100f2052a01000000434104e42b336370edbe2ba4c82a4239cecb5584416b5d844c25c58644700fa37512f300294fc802ed0a8525e83c583986ef58bd0fd259318506e600accd9ea39c8a7aac00000000','01000000016d00d07023106a1f15d8e0bebd2340945fe14f48525764952f7698e25dee8f6c000000008b483045022070145ad92706c5525c304e40d307bfe919ea13fb13b3f1d1449cba8cfc97018d022100ecf96a9a3d9b840c2fc944150200e0ba3c79d725b15dece47fd3529bb83e88040141040dc92273d787c973be5649047ef7241c0faa77f5968056630e46fc4e7bdf7d06886c23bf67d42c62ee8274758cfc1906313cb324e1b1b12aabe0b6785a17138affffffff02c05961240b0000001976a9140dcee4bebdccd55fbcc7bdd63a11215667ce868088ac404b4c00000000001976a9141d5cf706fe85aecfdb2b0536fe2682b2e93f8ecf88ac00000000','0100000001e5d7950689c9376d387b280bf1b0145a2dbdd2708f8c40e9e74ee1e65b389855000000004948304502205ef4bfb3e3551f0477c8ad5609690220c58a7de8b9cbd1d0f5730929e366d548022100dc968d62db776912ec3ab1a64640a31559cfdddb9eed4706224be9bfe058d46401ffffffff0100f2052a010000001976a914f74a2698d94e41a97a8ad2e96fd858f9db05559f88ac00000000']);
-
-        $block = new Block($math,
-            new BlockHeader(null, null, null, null, new Buffer(), null),
-            $transactions
-        );
-        $this->assertSame('cb59c3f584d7fd3d391b56674c00830d0c33c164a44ab25df88ba8547c6355cb', $block->getMerkleRoot());
-
+        $transactions = $this->getTransactionCollection($txArray);
+        $merkle = new MerkleRoot($math, $transactions);
+        $this->assertSame($eMerkleRoot, $merkle->calculateHash());
     }
 }

--- a/tests/Block/MerkleRootTest.php
+++ b/tests/Block/MerkleRootTest.php
@@ -11,10 +11,6 @@ use BitWasp\Bitcoin\Transaction\TransactionFactory;
 
 class MerkleRootTest extends AbstractTestCase
 {
-    /**
-     * @var string
-     */
-    public $rootType= 'BitWasp\Bitcoin\Block\MerkleRoot';
 
     /**
      * @expectedException \BitWasp\Bitcoin\Exceptions\MerkleTreeEmpty

--- a/tests/Block/MerkleRootTest.php
+++ b/tests/Block/MerkleRootTest.php
@@ -3,11 +3,8 @@
 namespace BitWasp\Bitcoin\Tests\Block;
 
 use BitWasp\Bitcoin\Bitcoin;
-use BitWasp\Bitcoin\Block\BlockFactory;
-use BitWasp\Bitcoin\Exceptions\MerkleTreeEmpty;
 use BitWasp\Bitcoin\Block\MerkleRoot;
 use BitWasp\Bitcoin\Block\Block;
-use BitWasp\Bitcoin\Transaction\Transaction;
 use BitWasp\Bitcoin\Transaction\TransactionCollection;
 use BitWasp\Bitcoin\Transaction\TransactionFactory;
 
@@ -23,21 +20,14 @@ class MerkleRootTest extends \PHPUnit_Framework_TestCase
         $this->rootType = 'BitWasp\Bitcoin\Block\MerkleRoot';
     }
 
-    public function setUp()
-    {
-
-    }
-
     public function testCreateNew()
     {
         $hex = '010000000462442ea8de9ee6cc2dd7d76dfc4523910eb2e3bd4b202d376910de700f63bf4b000000008b48304502207db5ea602fe2e9f8e70bfc68b7f468d68910d2ff4ac50294fc80109e254f317f022100a68a66f23406fdfd93025c28ffef4e79260283335ce39a4e8d0b52c5ee41913b014104f8de51f3b278225c0fe74a856ea2481e9ad4c9385fc10cefadaa4357ecd2c4d29904902d10e376546500c127f65d0de35b6215d49dd1ef6c67e6cdd5e781ef22ffffffff10aa2a8f9211ab71ffc9df03d52450d89a9de648fdfd75c0d20e4dcb1be29cfd020000008b483045022100d088af937bd457903391023c468bdbb9dc46681c3c83ab7b101c26a41524a0e20220369597fa4737aa4408469fec831b5ce53caee8e9fec81282376c6f592be354fb01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff067b1e03bd8edc0496b41af958fead9d57489fa12d23f4b341ded9b78d8cb114000000008b483045022009538bca3258eb4175faa7121dca68b51d95f2ed7d24278f03e2d88077d92815022100b8706672c585e8607e18d235e69548cd28736adfa9ce4f8f5f3baffc5aad091b01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff7f6d4bbb8f0d9b8bcad2e431c270aac63aa9caaa880dbd1688e39b6ac0d45ff4020000008b48304502203da091fed8fc71b3c859ee1dfe9c3d0e64915502af057357effa1ae4d1e0dbbf02210090fd964dfe7286b1ab0af3e8d6686c7826039eb0b46bac9803af367f080f38e401410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff0200b79ba7000000001976a914b5ac94f60f833b1e2dab9bc5f7895687bd750e8688acb0720200000000001976a9141b16cf7372a97b42533605e14616b6338caba8e888ac00000000';
         $tx = TransactionFactory::fromHex($hex);
 
         $math = Bitcoin::getMath();
-        $block = new Block($math);
-        $block->setTransactions(new TransactionCollection(array($tx)));
 
-        $root = new MerkleRoot($math, $block);
+        $root = new MerkleRoot($math, new TransactionCollection(array($tx)));
         $this->assertInstanceOf($this->rootType, $root);
     }
 
@@ -48,9 +38,7 @@ class MerkleRootTest extends \PHPUnit_Framework_TestCase
     public function testCannotUseEmptyBlock()
     {
         $math = Bitcoin::getMath();
-        $block = new Block($math);
-
-        $root = new MerkleRoot($math, $block);
+        $root = new MerkleRoot($math, new TransactionCollection());
         $root->calculateHash();
     }
 
@@ -59,12 +47,9 @@ class MerkleRootTest extends \PHPUnit_Framework_TestCase
         $hex = '010000000462442ea8de9ee6cc2dd7d76dfc4523910eb2e3bd4b202d376910de700f63bf4b000000008b48304502207db5ea602fe2e9f8e70bfc68b7f468d68910d2ff4ac50294fc80109e254f317f022100a68a66f23406fdfd93025c28ffef4e79260283335ce39a4e8d0b52c5ee41913b014104f8de51f3b278225c0fe74a856ea2481e9ad4c9385fc10cefadaa4357ecd2c4d29904902d10e376546500c127f65d0de35b6215d49dd1ef6c67e6cdd5e781ef22ffffffff10aa2a8f9211ab71ffc9df03d52450d89a9de648fdfd75c0d20e4dcb1be29cfd020000008b483045022100d088af937bd457903391023c468bdbb9dc46681c3c83ab7b101c26a41524a0e20220369597fa4737aa4408469fec831b5ce53caee8e9fec81282376c6f592be354fb01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff067b1e03bd8edc0496b41af958fead9d57489fa12d23f4b341ded9b78d8cb114000000008b483045022009538bca3258eb4175faa7121dca68b51d95f2ed7d24278f03e2d88077d92815022100b8706672c585e8607e18d235e69548cd28736adfa9ce4f8f5f3baffc5aad091b01410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff7f6d4bbb8f0d9b8bcad2e431c270aac63aa9caaa880dbd1688e39b6ac0d45ff4020000008b48304502203da091fed8fc71b3c859ee1dfe9c3d0e64915502af057357effa1ae4d1e0dbbf02210090fd964dfe7286b1ab0af3e8d6686c7826039eb0b46bac9803af367f080f38e401410445e476b3ea4559019c9f44dc41c103090473ce448f421f0000f2d630a62bb96af64f0fde21c84e4c5a679c43cb7b74e520dad662abfbedc86cc27cc03036c2b0ffffffff0200b79ba7000000001976a914b5ac94f60f833b1e2dab9bc5f7895687bd750e8688acb0720200000000001976a9141b16cf7372a97b42533605e14616b6338caba8e888ac00000000';
         $tx = TransactionFactory::fromHex($hex);
         $math = Bitcoin::getMath();
-        $block = new Block($math);
-        $block->setTransactions(new TransactionCollection(array($tx)));
 
-        $root = $block->getMerkleRoot();
-
-        $this->assertSame($tx->getTransactionId(), $root);
+        $merkle = new MerkleRoot($math, new TransactionCollection(array($tx)));
+        $this->assertSame($tx->getTransactionId(), $merkle->calculateHash());
     }
 
     public function testWithOnlyEvenNumberOfTransactions()
@@ -96,7 +81,6 @@ class MerkleRootTest extends \PHPUnit_Framework_TestCase
 
         $block = new Block($math);
         $block->setTransactions($transactions);
-
         $this->assertSame('cb59c3f584d7fd3d391b56674c00830d0c33c164a44ab25df88ba8547c6355cb', $block->getMerkleRoot());
 
     }

--- a/tests/Rpc/Client/BitcoindTest.php
+++ b/tests/Rpc/Client/BitcoindTest.php
@@ -179,7 +179,7 @@ class BitcoindTest extends AbstractTestCase
 
         $txHex = '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000';
 
-        $json = $this->getMock($this->jsonRpcType, ['execute', 'send'], ['127.0.0.1', 19332]);
+        $json = $this->getMock($this->jsonRpcType, ['execute', 'send'], ['127.0.0.1', 8332]);
         $json->expects($this->atLeastOnce())
             ->method('execute')
             ->willReturnCallback(

--- a/tests/Rpc/Client/BitcoindTest.php
+++ b/tests/Rpc/Client/BitcoindTest.php
@@ -110,7 +110,6 @@ class BitcoindTest extends AbstractTestCase
         $results = $bitcoind->getblockhash($height);
 
         $this->assertEquals($hash, $results);
-        //
     }
 
     /**
@@ -132,6 +131,31 @@ class BitcoindTest extends AbstractTestCase
         $this->assertEquals($tx, $results);
     }
 
+    /**
+     * Get raw transaction with details - wrapper instantiates tx.
+     */
+    public function testMockGetRawTransactionVerbose()
+    {
+        $tx = '0100000001d307610c0d7ba6972bc1ba213ba766814213e63f99d443f93a87025de3649ae42f0200006b483045022100cfa227c903c88df20c2798ff48d53fed4b2a9c5e25f24a0dc63aba39a778773302206fb057829c7ecb62150a306c6c08c43cbbe58591ab2dd7430afd5d7591e25687012103ef3f4f6ba23280a262aa8ffb8743df57c97c21f38de09c76fa6fa1851a2c6540ffffffff01ef240000000000001976a9145eacfaa836d1806b13e9e42730d99c6b0914dcae88ac00000000';
+        $hash = '75bf3c64b181f92f0a5262e7c4ea315baa48b7dd3cf64c028a259a2c91064371';
+        $json = $this->getMock($this->jsonRpcType, ['execute'], ['127.0.0.1', 8332]);
+        $json
+            ->expects($this->once())
+            ->method('execute')
+            ->willReturn($tx);
+
+        $bitcoind = new Bitcoind($json);
+        $results = $bitcoind->getrawtransaction($hash, true);
+
+        $this->assertInstanceof('BitWasp\Bitcoin\Transaction\Transaction', $results);
+        $this->assertEquals($tx, $results->getHex());
+        $this->assertEquals($hash, $results->getTransactionId());
+    }
+
+    /**
+     * Mock a successful block request, which should return a Block object with
+     * all the necessary Transaction instances
+     */
     public function testMockGetBlock()
     {
         $rpc = json_decode('{
@@ -179,28 +203,6 @@ class BitcoindTest extends AbstractTestCase
         $this->assertEquals($hash, $block->getHeader()->getBlockHash());
         $this->assertEquals($txHex, $block->getTransactions()->getTransaction(0)->getHex());
     }
-
-    /**
-     * Get raw transaction with details - wrapper instantiates tx.
-     */
-    public function testMockGetRawTransactionVerbose()
-    {
-        $tx = '0100000001d307610c0d7ba6972bc1ba213ba766814213e63f99d443f93a87025de3649ae42f0200006b483045022100cfa227c903c88df20c2798ff48d53fed4b2a9c5e25f24a0dc63aba39a778773302206fb057829c7ecb62150a306c6c08c43cbbe58591ab2dd7430afd5d7591e25687012103ef3f4f6ba23280a262aa8ffb8743df57c97c21f38de09c76fa6fa1851a2c6540ffffffff01ef240000000000001976a9145eacfaa836d1806b13e9e42730d99c6b0914dcae88ac00000000';
-        $hash = '75bf3c64b181f92f0a5262e7c4ea315baa48b7dd3cf64c028a259a2c91064371';
-        $json = $this->getMock($this->jsonRpcType, ['execute'], ['127.0.0.1', 8332]);
-        $json
-            ->expects($this->once())
-            ->method('execute')
-            ->willReturn($tx);
-
-        $bitcoind = new Bitcoind($json);
-        $results = $bitcoind->getrawtransaction($hash, true);
-
-        $this->assertInstanceof('BitWasp\Bitcoin\Transaction\Transaction', $results);
-        $this->assertEquals($tx, $results->getHex());
-        $this->assertEquals($hash, $results->getTransactionId());
-    }
-
 
     /**
      * Should take a TransactionInterface, return a hash.

--- a/tests/Rpc/Client/BitcoindTest.php
+++ b/tests/Rpc/Client/BitcoindTest.php
@@ -11,6 +11,8 @@ class BitcoindTest extends AbstractTestCase
 {
     private $jsonRpcType = 'BitWasp\Bitcoin\JsonRpc\JsonRpcClient';
 
+    public $mockGetBlockCount = 0;
+
     /**
      * Test totally invalid details so the JsonRpcClient returns null.
      * @expectedException \Exception
@@ -128,6 +130,54 @@ class BitcoindTest extends AbstractTestCase
         $results = $bitcoind->getrawtransaction($hash, false);
 
         $this->assertEquals($tx, $results);
+    }
+
+    public function testMockGetBlock()
+    {
+        $rpc = json_decode('{
+    "hash" : "00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048",
+    "confirmations" : 355538,
+    "size" : 215,
+    "height" : 1,
+    "version" : 1,
+    "merkleroot" : "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098",
+    "tx" : [
+        "0e3e2357e806b6cdb1f70b54c3a3a17b6714ee1f0e68bebb44a74b1efd512098"
+    ],
+    "time" : 1231469665,
+    "nonce" : 2573394689,
+    "bits" : "1d00ffff",
+    "difficulty" : 1.00000000,
+    "chainwork" : "0000000000000000000000000000000000000000000000000000000200020002",
+    "previousblockhash" : "000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f",
+    "nextblockhash" : "000000006a625f06636b8bb6ac7b960a8d03705d1ace08b1a19da3fdcc99ddbd"
+}', true);
+
+        $txHex = '01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a0100000043410496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858eeac00000000';
+
+        $json = $this->getMock($this->jsonRpcType, ['execute', 'send'], ['127.0.0.1', 19332]);
+        $json->expects($this->atLeastOnce())
+            ->method('execute')
+            ->willReturnCallback(
+                function () use ($rpc, $txHex) {
+                    $re = ($this->mockGetBlockCount++ == 0)
+                        ? $rpc
+                        : array($txHex);
+
+                    return $re;
+                }
+            );
+
+        $json->expects($this->atLeastOnce())
+            ->method('send')
+            ->willReturn(array($txHex));
+
+        $bitcoind = new Bitcoind($json);
+        $hash = '00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048';
+        $block = $bitcoind->getblock('00000000839a8e6886ab5951d76f411475428afc90947ee320161bbf18eb6048');
+
+        $this->assertEquals($hash, $block->getHeader()->getBlockHash());
+        $this->assertEquals($txHex, $block->getTransactions()->getTransaction(0)->getHex());
     }
 
     /**


### PR DESCRIPTION
Require that BlockHeader is provided with all the arguments you'd expect. Removed all setter functions apart from setNextBlock(), which is only available sometimes. 

Change signature for MerkleRoot constructor, should take a TransactionCollection instead of a Block.

Add tests to Bitcoind::getblock(), mocking a successful response. 