### PR TITLE
Change scrutinizer tests

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -17,7 +17,7 @@ tools:
     php_pdepend:
         excluded_dirs: [vendor, build, tests]
     external_code_coverage:
-        timeout: 2100
+        timeout: 4100
         runs: 6
 
 changetracking:

--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -18,7 +18,7 @@ tools:
         excluded_dirs: [vendor, build, tests]
     external_code_coverage:
         timeout: 2100
-        runs: 1
+        runs: 6
 
 changetracking:
     bug_patterns: ["\bfix(?:es|ed)?\b"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ script:
 
 after_script:
    - wget https://scrutinizer-ci.com/ocular.phar
-   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
+   - sh -c 'if [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then php ocular.phar code-coverage:upload --format=php-clover build/logs/clover.xml; fi;'
 
 matrix:
     fast_finish: true


### PR DESCRIPTION
The tests fail on scrutinizer when no coverage is produced but ocular is run anyway (hhvm/nightly). This finally fixes this and has scrutinizer accept 6 lots of code coverage from php5.4/5.5/5.6 with and without the extension.

It never reported failures because it was only set to 1 run, and typically php5.4 w/ the extension submitted coverage before the nightly/hhvm tests even started.