### PR TITLE
ScriptParser::next() should always take an instance

### DIFF
--- a/src/Script/Interpreter/Interpreter.php
+++ b/src/Script/Interpreter/Interpreter.php
@@ -401,6 +401,8 @@ class Interpreter implements InterpreterInterface
             return (bool)$c;
         };
 
+        $pushData = new Buffer();
+
         try {
             while ($parser->next($opCode, $pushData) === true) {
                 $fExec = !$checkFExec();
@@ -424,7 +426,7 @@ class Interpreter implements InterpreterInterface
                 if ($fExec && $opCode >= 0 && $opcodes->cmp($opCode, 'OP_PUSHDATA4') <= 0) {
                     // In range of a pushdata opcode
                     if ($flags->checkFlags(InterpreterInterface::VERIFY_MINIMALDATA) && !$this->checkMinimalPush($opCode, $pushData)) {
-                        throw  new ScriptRuntimeException(InterpreterInterface::VERIFY_MINIMALDATA, 'Minimal pushdata required');
+                        throw new ScriptRuntimeException(InterpreterInterface::VERIFY_MINIMALDATA, 'Minimal pushdata required');
                     }
                     $mainStack->push($pushData);
                     //echo " - [pushed '" . $pushData->getHex() . "']\n";

--- a/src/Script/ScriptParser.php
+++ b/src/Script/ScriptParser.php
@@ -98,7 +98,7 @@ class ScriptParser
      * @param Buffer $pushData
      * @return bool
      */
-    public function next(&$opCode, &$pushData)
+    public function next(&$opCode, Buffer &$pushData)
     {
         $opcodes = $this->script->getOpcodes();
         $opCode = $opcodes->getOpByName('OP_INVALIDOPCODE');
@@ -148,7 +148,7 @@ class ScriptParser
     public function parse()
     {
         $data = array();
-
+        $pushData = new Buffer();
         while ($this->next($opCode, $pushData)) {
             if ($opCode < 1) {
                 $push = Buffer::hex('00');

--- a/tests/Script/ScriptParserTest.php
+++ b/tests/Script/ScriptParserTest.php
@@ -68,10 +68,10 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
     public function testPush($script, $expectedOp, $expectedPushData, $result)
     {
         $parser = ScriptFactory::fromHex($script)->getScriptParser();
-
+        $pushdata = new Buffer();
         $this->assertEquals($result, $parser->next($opCode, $pushdata));
         $this->assertSame($expectedOp, $opCode);
-        if ($pushdata instanceof Buffer) {
+        if ($pushdata->getSize() > 0) {
             $this->assertSame($expectedPushData, $pushdata->getBinary());
         }
     }


### PR DESCRIPTION
of Buffer as it's second argument. This requires changing
checks of $pushData instanceof Buffer