### PR TITLE
Add BlockLocator

### DIFF
--- a/src/Chain/BlockLocator.php
+++ b/src/Chain/BlockLocator.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace BitWasp\Bitcoin\Chain;
+
+use BitWasp\Buffertools\Buffer;
+
+class BlockLocator
+{
+    /**
+     * @var Buffer[]
+     */
+    private $hashes;
+
+    /**
+     * @var Buffer
+     */
+    private $hashStop;
+
+    /**
+     * @param Buffer[] $hashes
+     * @param Buffer $hashStop
+     */
+    public function __construct(array $hashes, Buffer $hashStop)
+    {
+        foreach ($hashes as $hash) {
+            $this->addHash($hash);
+        }
+
+        $this->hashStop = $hashStop;
+    }
+
+    /**
+     * @param Buffer $hash
+     */
+    private function addHash(Buffer $hash)
+    {
+        $this->hashes[] = $hash;
+    }
+
+    /**
+     * @return \BitWasp\Buffertools\Buffer[]
+     */
+    public function getHashes()
+    {
+        return $this->hashes;
+    }
+
+    /**
+     * @return Buffer
+     */
+    public function getHashStop()
+    {
+        return $this->hashStop;
+    }
+
+    /**
+     * @param int $height
+     * @param BlockIndex $index
+     * @param bool $all
+     * @return BlockLocator
+     */
+    public static function create($height, BlockIndex $index, $all = false)
+    {
+        $step = 1;
+        $hashes = [];
+        $pIndex = $index->hash()->fetch($height);
+
+        while (true) {
+            array_push($hashes, Buffer::hex($pIndex, 32));
+            if ($height == 0) {
+                break;
+            }
+
+            $height = max($height - $step, 0);
+            $pIndex = $index->hash()->fetch($height);
+            if (count($hashes) >= 10) {
+                $step *= 2;
+            }
+        }
+
+        $hashStop = ($all || count($hashes) == 1)
+            ? Buffer::hex('00', 32)
+            : array_pop($hashes);
+
+        return new self(
+            $hashes,
+            $hashStop
+        );
+    }
+}

--- a/tests/Bloom/BloomFilterTest.php
+++ b/tests/Bloom/BloomFilterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace BitWasp\Bitcoin\Tests\Networking;
+namespace BitWasp\Bitcoin\Tests\Bloom;
 
 use BitWasp\Bitcoin\Flags;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;

--- a/tests/Chain/BlockLocatorTest.php
+++ b/tests/Chain/BlockLocatorTest.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Chain;
+
+use BitWasp\Bitcoin\Chain\BlockHashIndex;
+use BitWasp\Bitcoin\Chain\BlockHeightIndex;
+use BitWasp\Bitcoin\Chain\BlockIndex;
+use BitWasp\Bitcoin\Chain\BlockLocator;
+use Doctrine\Common\Cache\ArrayCache;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+
+class BlockLocatorTest extends AbstractTestCase
+{
+    public function testGenesis()
+    {
+        $index = new BlockIndex(new BlockHashIndex(new ArrayCache()), new BlockHeightIndex(new ArrayCache()));
+
+        $genesis = $this->getBlock(0)->getHeader();
+        $index->saveGenesis($this->getBlock(0)->getHeader());
+        $index->save($this->getBlock(1)->getHeader());
+
+        $locator = BlockLocator::create($index->height()->height(), $index, true);
+        $this->assertEquals(2, count($locator->getHashes()));
+        $this->assertEquals($genesis->getBlockHash(), $locator->getHashes()[1]->getHex());
+    }
+
+    public function test20Blocks()
+    {
+        $index = new BlockIndex(new BlockHashIndex(new ArrayCache()), new BlockHeightIndex(new ArrayCache()));
+
+        $genesis = $this->getBlock(0)->getHeader();
+        $index->saveGenesis($this->getBlock(0)->getHeader());
+        for ($i = 1; $i < 20; $i++) {
+            $index->save($this->getBlock($i)->getHeader());
+        }
+
+        // Locator should be smaller than 20, since step function kicks in after the latest ten blocks.
+        $locator = BlockLocator::create($index->height()->height(), $index, true);
+        $this->assertTrue(20 > count($locator->getHashes()));
+        $hashes = $locator->getHashes();
+
+        $this->assertEquals($genesis->getBlockHash(), end($hashes)->getHex());
+    }
+
+    public function testGenesisNoHashStop()
+    {
+
+        $index = new BlockIndex(new BlockHashIndex(new ArrayCache()), new BlockHeightIndex(new ArrayCache()));
+
+        $genesis = $this->getBlock(0)->getHeader();
+        $index->saveGenesis($this->getBlock(0)->getHeader());
+        $index->save($this->getBlock(1)->getHeader());
+
+        $locator = BlockLocator::create($index->height()->height(), $index, false);
+        $this->assertEquals(1, count($locator->getHashes()));
+        $this->assertEquals($genesis->getBlockHash(), $locator->getHashStop()->getHex());
+    }
+}


### PR DESCRIPTION
to Chain namespace. 

Presently it requires a BlockIndex and a chain height. However, I believe the handling of hashStop, etc, may not be 100% correct.