### PR TITLE
Scrutinizer nits

### DIFF
--- a/src/Block/MerkleRoot.php
+++ b/src/Block/MerkleRoot.php
@@ -5,7 +5,6 @@ namespace BitWasp\Bitcoin\Block;
 use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Transaction\TransactionCollection;
 use BitWasp\Buffertools\Buffertools;
-use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\Exceptions\MerkleTreeEmpty;
 use Pleo\Merkle\FixedSizeTree;
 

--- a/src/Block/PartialMerkleTree.php
+++ b/src/Block/PartialMerkleTree.php
@@ -130,8 +130,7 @@ class PartialMerkleTree extends Serializable
                 $right = $left;
             }
 
-            $hash = Hash::sha256d(Buffertools::concat($left, $right));
-            return $hash;
+            return Hash::sha256d(Buffertools::concat($left, $right));
         }
     }
 

--- a/src/Chain/BlockHashIndex.php
+++ b/src/Chain/BlockHashIndex.php
@@ -13,11 +13,6 @@ class BlockHashIndex
     private $index;
 
     /**
-     * @var int
-     */
-    private $height;
-
-    /**
      * @param Cache $cache
      */
     public function __construct(Cache $cache)

--- a/src/Chain/Blockchain.php
+++ b/src/Chain/Blockchain.php
@@ -76,7 +76,7 @@ class Blockchain
         }
 
         $this->chainDiff = $this->difficulty->getDifficulty($this->chainTip()->getHeader()->getBits());
-        $this->pow = new ProofOfWork($this->math, $this->difficulty, $this->chainDiff);
+        $this->pow = new ProofOfWork($this->math, $this->difficulty);
     }
 
     /**
@@ -166,7 +166,7 @@ class Blockchain
     {
         if ($this->math->cmp(0, $this->math->mod($this->currentHeight(), 2016)) == 0) {
             $this->chainDiff = $this->difficulty->getDifficulty($this->chainTip()->getHeader()->getBits());
-            $this->pow = new ProofOfWork($this->math, $this->difficulty, $this->chainDiff);
+            $this->pow = new ProofOfWork($this->math, $this->difficulty);
         }
         return $this;
     }

--- a/src/Chain/Headerchain.php
+++ b/src/Chain/Headerchain.php
@@ -67,7 +67,7 @@ class Headerchain
         $initBlock = $this->chainTip();
         $this->difficulty = new Difficulty($math, $initBlock->getBits());
         $this->chainDiff = $this->difficulty->getDifficulty($initBlock->getBits());
-        $this->pow = new ProofOfWork($this->math, $this->difficulty, $this->chainDiff);
+        $this->pow = new ProofOfWork($this->math, $this->difficulty);
     }
 
     /**
@@ -144,7 +144,7 @@ class Headerchain
     {
         if ($this->math->cmp(0, $this->math->mod($this->currentHeight(), 2016)) == 0) {
             $this->chainDiff = $this->difficulty->getDifficulty($this->chainTip()->getBits());
-            $this->pow = new ProofOfWork($this->math, $this->difficulty, $this->chainDiff);
+            $this->pow = new ProofOfWork($this->math, $this->difficulty);
         }
         return $this;
     }

--- a/src/Chain/ProofOfWork.php
+++ b/src/Chain/ProofOfWork.php
@@ -21,13 +21,11 @@ class ProofOfWork
     /**
      * @param Math $math
      * @param Difficulty $difficulty
-     * @param int|string $networkDifficulty
      */
-    public function __construct(Math $math, Difficulty $difficulty, $networkDifficulty)
+    public function __construct(Math $math, Difficulty $difficulty)
     {
         $this->math = $math;
         $this->difficulty = $difficulty;
-        $this->networkDifficulty = $networkDifficulty;
     }
 
     /**

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Adapter/EcAdapter.php
@@ -149,8 +149,8 @@ class EcAdapter implements EcAdapterInterface
      */
     public function verify(Buffer $messageHash, PublicKeyInterface $publicKey, SignatureInterface $signature)
     {
-        /** @var $publicKey PublicKey */
-        /** @var $signature Signature */
+        /** @var PublicKey $publicKey */
+        /** @var Signature $signature */
         return $this->doVerify($messageHash, $publicKey, $signature);
     }
 
@@ -214,7 +214,7 @@ class EcAdapter implements EcAdapterInterface
      */
     public function sign(Buffer $messageHash, PrivateKeyInterface $privateKey, RbgInterface $rbg = null)
     {
-        /** @var $privateKey PrivateKey */
+        /** @var PrivateKey $privateKey */
         return $this->doSign($messageHash, $privateKey, $rbg);
     }
 

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Adapter/EcAdapter.php
@@ -57,7 +57,7 @@ class EcAdapter implements EcAdapterInterface
     }
 
     /**
-     * @param $scalar
+     * @param int|string $scalar
      * @param bool|false $compressed
      * @return PrivateKey
      */

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PrivateKey.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PrivateKey.php
@@ -7,7 +7,6 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Adapter\EcAdapter;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Serializer\Key\PrivateKeySerializer;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\Key;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Crypto\Random\RbgInterface;
 use BitWasp\Bitcoin\Exceptions\InvalidPrivateKey;
 use BitWasp\Bitcoin\Network\NetworkInterface;
@@ -32,7 +31,7 @@ class PrivateKey extends Key implements PrivateKeyInterface
     private $publicKey;
 
     /**
-     * @var EcAdapterInterface
+     * @var EcAdapter
      */
     private $ecAdapter;
 
@@ -80,7 +79,7 @@ class PrivateKey extends Key implements PrivateKeyInterface
     }
 
     /**
-     * @param int $tweak
+     * @param int|string $tweak
      * @return PrivateKeyInterface
      */
     public function tweakAdd($tweak)
@@ -103,7 +102,7 @@ class PrivateKey extends Key implements PrivateKeyInterface
     }
 
     /**
-     * @param int $tweak
+     * @param int|string $tweak
      * @return PrivateKeyInterface
      */
     public function tweakMul($tweak)
@@ -123,16 +122,6 @@ class PrivateKey extends Key implements PrivateKeyInterface
             ),
             $this->compressed
         );
-    }
-
-    /**
-     * Always returns true when private key.
-     *
-     * @return bool
-     */
-    public function isPrivate()
-    {
-        return true;
     }
 
     /**
@@ -161,16 +150,6 @@ class PrivateKey extends Key implements PrivateKeyInterface
         }
 
         return $this->publicKey;
-    }
-
-    /**
-     * Return the hash of the associated public key
-     *
-     * @return Buffer
-     */
-    public function getPubKeyHash()
-    {
-        return $this->getPublicKey()->getPubKeyHash();
     }
 
     /**

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PublicKey.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PublicKey.php
@@ -7,7 +7,6 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Serializer\Key\PublicKeySeriali
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\Key;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Signature\SignatureInterface;
-use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Buffertools\Buffer;
 use Mdanter\Ecc\Primitives\PointInterface;
 
@@ -55,14 +54,6 @@ class PublicKey extends Key implements PublicKeyInterface
     }
 
     /**
-     * @return Buffer
-     */
-    public function getPubKeyHash()
-    {
-        return Hash::sha256ripe160($this->getBuffer());
-    }
-
-    /**
      * @param Buffer $msg32
      * @param SignatureInterface $signature
      * @return bool
@@ -79,9 +70,9 @@ class PublicKey extends Key implements PublicKeyInterface
     public function tweakAdd($tweak)
     {
         $adapter = $this->ecAdapter;
-        $G = $adapter->getGenerator();
-        $point = $this->point->add($G->mul($tweak));
-        return $adapter->getPublicKey($point, $this->compressed);
+        $offset = $adapter->getGenerator()->mul($tweak);
+        $newPoint = $this->point->add($offset);
+        return $adapter->getPublicKey($newPoint, $this->compressed);
     }
 
     /**
@@ -124,36 +115,11 @@ class PublicKey extends Key implements PublicKeyInterface
     }
 
     /**
-     * Sets a public key to be compressed
-     *
-     * @param $compressed
-     * @return $this
-     * @throws \Exception
-     */
-    public function setCompressed($compressed)
-    {
-        if (!is_bool($compressed)) {
-            throw new \Exception('Compressed flag must be a boolean');
-        }
-
-        $this->compressed = $compressed;
-        return $this;
-    }
-
-    /**
      * @return bool
      */
     public function isCompressed()
     {
         return $this->compressed;
-    }
-
-    /**
-     * @inheritdoc
-     */
-    public function isPrivate()
-    {
-        return false;
     }
 
     /**

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PublicKey.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PublicKey.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key;
 
-use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Adapter\EcAdapter;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Serializer\Key\PublicKeySerializer;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\Key;
@@ -15,7 +14,7 @@ use Mdanter\Ecc\Primitives\PointInterface;
 class PublicKey extends Key implements PublicKeyInterface
 {
     /**
-     * @var EcAdapterInterface
+     * @var EcAdapter
      */
     private $ecAdapter;
 

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Signature/CompactSignatureSerializer.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Signature/CompactSignatureSerializer.php
@@ -16,7 +16,7 @@ class CompactSignatureSerializer implements CompactSignatureSerializerInterface
 {
 
     /**
-     * @var Math
+     * @var EcAdapter
      */
     private $ecAdapter;
 

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
@@ -116,7 +116,7 @@ class EcAdapter implements EcAdapterInterface
     }
 
     /**
-     * @param $int
+     * @param int|string $int
      * @param bool|false $compressed
      * @return PrivateKey
      */

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
@@ -244,10 +244,9 @@ class EcAdapter implements EcAdapterInterface
     /**
      * @param Buffer $msg32
      * @param PrivateKey $privateKey
-     * @param RbgInterface|null $rbg
      * @return CompactSignature
      */
-    private function doSignCompact(Buffer $msg32, PrivateKey $privateKey, RbgInterface $rbg = null)
+    private function doSignCompact(Buffer $msg32, PrivateKey $privateKey)
     {
         $sig_t = $this->doSignRecoverable($msg32, $privateKey);
         $recid = '';
@@ -274,6 +273,6 @@ class EcAdapter implements EcAdapterInterface
     public function signCompact(Buffer $msg32, PrivateKeyInterface $privateKey, RbgInterface $rbg = null)
     {
         /** @var PrivateKey $privateKey */
-        return $this->doSignCompact($msg32, $privateKey, $rbg);
+        return $this->doSignCompact($msg32, $privateKey);
     }
 }

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
@@ -220,13 +220,13 @@ class EcAdapter implements EcAdapterInterface
     private function doRecover(Buffer $msg32, CompactSignature $compactSig)
     {
         $publicKey = '';
+        /** @var resource $publicKey */
         $context = $this->context;
         $sig = $compactSig->getResource();
         if (1 != secp256k1_ecdsa_recover($context, $msg32->getBinary(), $sig, $publicKey)) {
             throw new \RuntimeException('Unable to recover Public Key');
         }
 
-        /** @var resource $publicKey */
         return new PublicKey($this, $publicKey, $compactSig->isCompressed());
     }
 

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
@@ -87,14 +87,6 @@ class PrivateKey extends Key implements PrivateKeyInterface
     }
 
     /**
-     * @return bool
-     */
-    public function isPrivate()
-    {
-        return true;
-    }
-
-    /**
      * @return int|string
      */
     public function getSecretMultiplier()
@@ -127,16 +119,6 @@ class PrivateKey extends Key implements PrivateKeyInterface
         }
 
         return $this->publicKey;
-    }
-
-    /**
-     * Return the hash of the associated public key
-     *
-     * @return Buffer
-     */
-    public function getPubKeyHash()
-    {
-        return $this->getPublicKey()->getPubKeyHash();
     }
 
     /**

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PublicKey.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PublicKey.php
@@ -59,14 +59,6 @@ class PublicKey extends Key implements PublicKeyInterface
     }
 
     /**
-     * @return bool
-     */
-    public function isPrivate()
-    {
-        return false;
-    }
-
-    /**
      * @return bool|false
      */
     public function isCompressed()
@@ -80,14 +72,6 @@ class PublicKey extends Key implements PublicKeyInterface
     public function getResource()
     {
         return $this->pubkey_t;
-    }
-
-    /**
-     * @return Buffer
-     */
-    public function getPubKeyHash()
-    {
-        return Hash::sha256ripe160($this->getBuffer());
     }
 
     /**

--- a/src/Crypto/EcAdapter/Key/Key.php
+++ b/src/Crypto/EcAdapter/Key/Key.php
@@ -3,11 +3,33 @@
 namespace BitWasp\Bitcoin\Crypto\EcAdapter\Key;
 
 use BitWasp\Bitcoin\Address\AddressFactory;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
+use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Serializable;
 
 abstract class Key extends Serializable implements KeyInterface
 {
+    /**
+     * @return bool
+     */
+    public function isPrivate()
+    {
+        return $this instanceof PrivateKeyInterface;
+    }
+
+    /**
+     * @return \BitWasp\Buffertools\Buffer
+     */
+    public function getPubKeyHash()
+    {
+        if ($this instanceof PrivateKeyInterface) {
+            $publicKey = $this->getPublicKey();
+        } else {
+            $publicKey = $this;
+        }
+
+        return Hash::sha256ripe160($publicKey->getBuffer());
+    }
+
     /**
      * @return \BitWasp\Bitcoin\Address\PayToPubKeyHashAddress
      */

--- a/src/Crypto/EcAdapter/Key/PrivateKeyInterface.php
+++ b/src/Crypto/EcAdapter/Key/PrivateKeyInterface.php
@@ -5,7 +5,7 @@ namespace BitWasp\Bitcoin\Crypto\EcAdapter\Key;
 use BitWasp\Bitcoin\Crypto\Random\RbgInterface;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Buffertools\Buffer;
-use Mdanter\Ecc\Crypto\Signature\SignatureInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Signature\SignatureInterface;
 
 interface PrivateKeyInterface extends KeyInterface
 {

--- a/src/Key/PublicKeyFactory.php
+++ b/src/Key/PublicKeyFactory.php
@@ -18,9 +18,10 @@ class PublicKeyFactory
      */
     public static function getSerializer(EcAdapterInterface $ecAdapter = null)
     {
-        $ecAdapter = $ecAdapter ?: Bitcoin::getEcAdapter();
-        $hexSerializer = EcSerializer::getSerializer($ecAdapter, 'BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface');
-        return $hexSerializer;
+        return EcSerializer::getSerializer(
+            $ecAdapter ?: Bitcoin::getEcAdapter(),
+            'BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface'
+        );
     }
 
     /**
@@ -34,15 +35,18 @@ class PublicKeyFactory
         return self::getSerializer($ecAdapter)->parse($hex);
     }
 
+    /**
+     * @param $hex
+     * @param EcAdapterInterface|null $ecAdapter
+     * @return bool
+     */
     public static function validateHex($hex, EcAdapterInterface $ecAdapter = null)
     {
         try {
             self::fromHex($hex, $ecAdapter);
-            $valid = true;
+            return true;
         } catch (\Exception $e) {
-            $valid = false;
+            return false;
         }
-
-        return $valid;
     }
 }

--- a/src/Miner/Miner.php
+++ b/src/Miner/Miner.php
@@ -57,7 +57,7 @@ class Miner
     private $timestamp;
 
     /**
-     * @var int
+     * @var int|string
      */
     private $version;
 
@@ -71,8 +71,8 @@ class Miner
      * @param BlockHeaderInterface $lastBlockHeader
      * @param ScriptInterface $script
      * @param Buffer $personalString
-     * @param mixed $timestamp
-     * @param int $version
+     * @param int|string $timestamp
+     * @param int|string $version
      * @param bool $report
      */
     public function __construct(

--- a/src/Script/Interpreter/Operation/ScriptNum.php
+++ b/src/Script/Interpreter/Operation/ScriptNum.php
@@ -14,12 +14,12 @@ class ScriptNum extends Buffer
     /**
      * @var Math
      */
-    private $math;
+    protected $math;
 
     /**
      * @var
      */
-    private $buffer;
+    protected $buffer;
 
     /**
      * @param Math $math
@@ -49,7 +49,6 @@ class ScriptNum extends Buffer
             }
         }
 
-        $this->originalSize = $bufferSize;
         $this->math = $math;
         parent::__construct($str, $size, $math);
     }
@@ -59,6 +58,6 @@ class ScriptNum extends Buffer
      */
     public function getBuffer()
     {
-        return new Buffer($this->buffer, $this->originalSize, $this->math);
+        return new Buffer($this->buffer, null, $this->math);
     }
 }

--- a/src/Serializer/Block/BlockHeaderSerializer.php
+++ b/src/Serializer/Block/BlockHeaderSerializer.php
@@ -47,7 +47,9 @@ class BlockHeaderSerializer
 
         try {
             list ($version, $prevHash, $merkleHash, $time, $nBits, $nonce) = $this->getTemplate()->parse($parser);
-
+            /** @var int|string $version */
+            /** @var Buffer $prevHash */
+            /** @var Buffer $merkleHash */
             return new BlockHeader(
                 $version,
                 $prevHash->getHex(),

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -5,8 +5,6 @@ namespace BitWasp\Bitcoin\Tests;
 use BitWasp\Bitcoin\Block\BlockFactory;
 use BitWasp\Bitcoin\Crypto\EcAdapter\EcAdapterFactory;
 use BitWasp\Bitcoin\Math\Math;
-use BitWasp\Bitcoin\Crypto\EcAdapter\PhpEcc;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Secp256k1;
 use Mdanter\Ecc\EccFactory;
 
 abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
@@ -83,7 +81,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
                 ? EcAdapterFactory::getSecp256k1($math, $generator)
                 : EcAdapterFactory::getPhpEcc($math, $generator))];
         }
-        
+
         return $adapters;
     }
 

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -11,6 +11,16 @@ use Mdanter\Ecc\EccFactory;
 
 abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 {
+    private static $context;
+
+    public static function getContext()
+    {
+        if (self::$context == null) {
+            self::$context = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
+        }
+
+        return self::$context;
+    }
 
     /**
      * @param $filename
@@ -29,7 +39,6 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
         $blocks = $this->dataFile('180blocks');
         $a = explode("\n", $blocks);
         return array_filter($a, 'strlen');
-        return $a;
     }
 
     /**
@@ -39,9 +48,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
     public function getBlock($i)
     {
         $blocks = $this->getBlocks();
-        $hex = $blocks[$i];
-        $b = BlockFactory::fromHex($hex);
-        return $b;
+        return BlockFactory::fromHex($blocks[$i]);
     }
 
     /**
@@ -49,8 +56,7 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      */
     public function getGenesisBlock()
     {
-        $b = $this->getBlock(0);
-        return $b;
+        return $this->getBlock(0);
     }
 
     /**
@@ -77,19 +83,8 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
                 ? EcAdapterFactory::getSecp256k1($math, $generator)
                 : EcAdapterFactory::getPhpEcc($math, $generator))];
         }
-
+        
         return $adapters;
-    }
-
-    private static $context;
-
-    public static function getContext()
-    {
-        if (self::$context == null) {
-            self::$context = secp256k1_context_create(SECP256K1_CONTEXT_VERIFY | SECP256K1_CONTEXT_SIGN);
-        }
-
-        return self::$context;
     }
 
     public function safeMath()

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -407,20 +407,20 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
             [81, Buffer::hex('01')],
             [79, Buffer::hex('81')],
             [5, Buffer::hex('0102030405')],
-            [0x4c, Buffer::hex('', 76)],
-            [0x4c, Buffer::hex('', 78)],
-            [0x4c, Buffer::hex('', 255)],
-            [0x4d, Buffer::hex('', 256)],
-            [0x4d, Buffer::hex('', 65535)],
-            [0x4e, Buffer::hex('', 65536)],
+            [0x4c, new Buffer('', 76)],
+            [0x4c, new Buffer('', 78)],
+            [0x4c, new Buffer('', 255)],
+            [0x4d, new Buffer('', 256)],
+            [0x4d, new Buffer('', 65535)],
+            [0x4e, new Buffer('', 65536)],
         ];
 
         $invalid = [
-            [0x81, Buffer::hex('')],
+            [0x81, new Buffer('')],
             [01, Buffer::hex('0102030405')],
-            [0x4d, Buffer::hex('', 74)],
-            [0x4e, Buffer::hex('', 255)],
-            [0x4d, Buffer::hex('', 255)]
+            [0x4d, new Buffer('', 74)],
+            [0x4e, new Buffer('', 255)],
+            [0x4d, new Buffer('', 255)]
         ];
 
         $i = new \BitWasp\Bitcoin\Script\Interpreter\Interpreter(Bitcoin::getEcAdapter(), new Transaction, new Flags(InterpreterInterface::VERIFY_P2SH));


### PR DESCRIPTION
After the EcAdapter overhaul I've been meaning to do a clean-up. 

There are some errors I can't seem to shake - PrivateKey, BlockHeader, and Transaction all complain about integers sometimes being passed as doubles - I'd love to axe that..