### PR TITLE
Don't use recoverable signatures during normal sign operation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "react/socket-client": "~0.4",
     "bitwasp/buffertools": "~0.1",
     "bitwasp/stratum": "~0.1",
-    "bitwasp/secp256k1-php": "0.0.5"
+    "bitwasp/secp256k1-php": "~0.0.5"
   },
   "require-dev": {
     "bitwasp/testing-php": "~0.0",


### PR DESCRIPTION
Previously I was trying to leverage secp256k1's recoverable signatures during regular signing, since they can be serialized in compact form. Ultimately this was to obtain r and s, to fulfill `SignatureInterface`. 

However, it seems recoverable signatures, once converted to regular types do not yield the same serialized DER signature as when the signature is produced directly 

Since libsecp256k1's DER signatures are have a strict form, we can extract r and s from the DER form without much issue, without having to rely on recoverable signatures. Probably should have done it this way first.