### PR TITLE
Add ScriptCreator - making Script immutable

### DIFF
--- a/src/PaymentProtocol/PaymentRequestBuilder.php
+++ b/src/PaymentProtocol/PaymentRequestBuilder.php
@@ -3,6 +3,7 @@
 namespace BitWasp\Bitcoin\PaymentProtocol;
 
 use BitWasp\Bitcoin\Address\AddressInterface;
+use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\PaymentProtocol\Protobufs\Output as OutputBuf;
 use BitWasp\Bitcoin\PaymentProtocol\Protobufs\PaymentRequest as PaymentRequestBuf;
@@ -108,7 +109,7 @@ class PaymentRequestBuilder
     {
         return new TransactionOutput(
             $outBuf->getAmount(),
-            ScriptFactory::create(new Buffer($outBuf->getScript()))
+            new Script(new Buffer($outBuf->getScript()))
         );
     }
 

--- a/src/Script/Factory/InputScriptFactory.php
+++ b/src/Script/Factory/InputScriptFactory.php
@@ -30,7 +30,8 @@ class InputScriptFactory
     {
         return ScriptFactory::create()
             ->push($signature->getBuffer())
-            ->push($publicKey->getBuffer());
+            ->push($publicKey->getBuffer())
+            ->getScript();
     }
 
     /**
@@ -41,14 +42,12 @@ class InputScriptFactory
     public function multisigP2sh(RedeemScript $redeemScript, $signatures)
     {
         $script = ScriptFactory::create()->op('OP_0');
-
         foreach ($signatures as $signature) {
             $script->push($signature->getBuffer());
         }
-
         $script->push($redeemScript->getBuffer());
 
-        return $script;
+        return $script->getScript();
     }
 
     /**
@@ -57,6 +56,8 @@ class InputScriptFactory
      */
     public function payToPubKey(TransactionSignatureInterface $signature)
     {
-        return ScriptFactory::create()->push($signature->getBuffer());
+        return ScriptFactory::create()
+            ->push($signature->getBuffer())
+            ->getScript();
     }
 }

--- a/src/Script/Factory/OutputScriptFactory.php
+++ b/src/Script/Factory/OutputScriptFactory.php
@@ -29,7 +29,7 @@ class OutputScriptFactory
      */
     public function payToAddress(AddressInterface $address)
     {
-        return ($address instanceof ScriptHashAddress
+        $script = ($address instanceof ScriptHashAddress
             ? ScriptFactory::create()
                 ->op('OP_HASH160')
                 ->push(Buffer::hex($address->getHash(), 20))
@@ -40,6 +40,8 @@ class OutputScriptFactory
                 ->push(Buffer::hex($address->getHash(), 20))
                 ->op('OP_EQUALVERIFY')
                 ->op('OP_CHECKSIG'));
+
+        return $script->getScript();
     }
 
     /**
@@ -52,7 +54,8 @@ class OutputScriptFactory
     {
         return ScriptFactory::create()
             ->push($public_key->getBuffer())
-            ->op('OP_CHECKSIG');
+            ->op('OP_CHECKSIG')
+            ->getScript();
     }
 
     /**
@@ -68,7 +71,8 @@ class OutputScriptFactory
             ->op('OP_HASH160')
             ->push($public_key->getPubKeyHash())
             ->op('OP_EQUALVERIFY')
-            ->op('OP_CHECKSIG');
+            ->op('OP_CHECKSIG')
+            ->getScript();
     }
 
     /**
@@ -82,7 +86,8 @@ class OutputScriptFactory
         return ScriptFactory::create()
             ->op('OP_HASH160')
             ->push($script->getScriptHash())
-            ->op('OP_EQUAL');
+            ->op('OP_EQUAL')
+            ->getScript();
     }
 
     /**
@@ -111,6 +116,7 @@ class OutputScriptFactory
                 ->concat(ScriptFactory::multisig(2, [$a1, $b1]))
             ->op('OP_ELSE')
                 ->concat(ScriptFactory::multisig(2, [$a2, $b2]))
-            ->op('OP_ENDIF');
+            ->op('OP_ENDIF')
+            ->getScript();
     }
 }

--- a/src/Script/RedeemScript.php
+++ b/src/Script/RedeemScript.php
@@ -14,6 +14,11 @@ class RedeemScript extends Script
     private $m;
 
     /**
+     * @var string
+     */
+    protected $script;
+
+    /**
      * @var array
      */
     private $keys = [];
@@ -38,18 +43,21 @@ class RedeemScript extends Script
         $opM = $ops->getOp($ops->getOpByName('OP_1') - 1 + $m);
         $opN = $ops->getOp($ops->getOpByName('OP_1') - 1 + $n);
 
-        $this->op($opM);
+        $script = ScriptFactory::create();
+        $script->op($opM);
         foreach ($keys as $key) {
             if (!$key instanceof PublicKeyInterface) {
                 throw new \LogicException('Values in $keys[] must be a PublicKey');
             }
 
             $this->keys[] = $key;
-            $this->push($key->getBuffer());
+            $script->push($key->getBuffer());
         }
-        $this
+        $script
             ->op($opN)
             ->op('OP_CHECKMULTISIG');
+
+        $this->script = $script->getScript()->getBinary();
 
         $this->m = $m;
     }

--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -4,7 +4,6 @@ namespace BitWasp\Bitcoin\Script;
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Buffertools\Buffer;
-use BitWasp\Buffertools\Parser;
 use BitWasp\Bitcoin\Address\AddressFactory;
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Serializable;
@@ -20,7 +19,7 @@ class Script extends Serializable implements ScriptInterface
     /**
      * @var null|string
      */
-    private $script;
+    protected $script;
 
     /**
      * Initialize container
@@ -33,6 +32,10 @@ class Script extends Serializable implements ScriptInterface
         $this->opcodes = new Opcodes;
     }
 
+    /**
+     * @param ScriptInterface $script
+     * @return $this
+     */
     public function concat(ScriptInterface $script)
     {
         $this->script .= $script->getBinary();
@@ -83,55 +86,6 @@ class Script extends Serializable implements ScriptInterface
         return Hash::sha256ripe160($this->getBuffer());
     }
 
-    /**
-     * Add an opcode to the script
-     *
-     * @param string $name
-     * @return $this
-     */
-    public function op($name)
-    {
-        $code = $this->opcodes->getOpByName($name);
-        $this->script .= pack("H*", (Bitcoin::getMath()->decHex($code)));
-        return $this;
-    }
-
-    /**
-     * Push data into the stack.
-     *
-     * @param $data
-     * @return $this
-     * @throws \Exception
-     */
-    public function push(Buffer $data)
-    {
-        $length = $data->getSize();
-        $parsed = new Parser('', Bitcoin::getMath());
-
-        /** Note that larger integers are serialized without flipping bits - Big endian */
-
-        if ($length < $this->opcodes->getOpByName('OP_PUSHDATA1')) {
-            $parsed = $parsed->writeWithLength($data);
-
-        } elseif ($length <= 0xff) {
-            $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA1'))
-                ->writeInt(1, $length, false)
-                ->writeBytes($length, $data);
-
-        } elseif ($length <= 0xffff) {
-            $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA2'))
-                ->writeInt(2, $length, true)
-                ->writeBytes($length, $data);
-
-        } else {
-            $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA4'))
-                ->writeInt(4, $length, true)
-                ->writeBytes($length, $data);
-        }
-
-        $this->script .= $parsed->getBuffer()->getBinary();
-        return $this;
-    }
 
     /**
      * @return bool

--- a/src/Script/ScriptCreator.php
+++ b/src/Script/ScriptCreator.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace BitWasp\Bitcoin\Script;
+
+use BitWasp\Bitcoin\Math\Math;
+use BitWasp\Buffertools\Buffer;
+use BitWasp\Buffertools\Parser;
+
+class ScriptCreator
+{
+    /**
+     * @var string
+     */
+    private $script = '';
+
+    /**
+     * @var Opcodes
+     */
+    private $opcodes;
+
+    /**
+     * @var Math
+     */
+    private $math;
+
+    /**
+     * @param Math $math
+     * @param Opcodes $opcodes
+     * @param Buffer|null $buffer
+     */
+    public function __construct(Math $math, Opcodes $opcodes, Buffer $buffer = null)
+    {
+        if ($buffer != null) {
+            $this->script = $buffer->getBinary();
+        }
+
+        $this->math = $math;
+        $this->opcodes = $opcodes;
+    }
+
+    /**
+     * Add an opcode to the script
+     *
+     * @param string $name
+     * @return $this
+     */
+    public function op($name)
+    {
+        $code = $this->opcodes->getOpByName($name);
+        $this->script .= pack("H*", dechex($code));
+        return $this;
+    }
+
+    /**
+     * Push data into the stack.
+     *
+     * @param $data
+     * @return $this
+     * @throws \Exception
+     */
+    public function push(Buffer $data)
+    {
+        $length = $data->getSize();
+        $parsed = new Parser('', $this->math);
+
+        /** Note that larger integers are serialized without flipping bits - Big endian */
+
+        if ($length < $this->opcodes->getOpByName('OP_PUSHDATA1')) {
+            $parsed = $parsed->writeWithLength($data);
+
+        } elseif ($length <= 0xff) {
+            $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA1'))
+                ->writeInt(1, $length, false)
+                ->writeBytes($length, $data);
+
+        } elseif ($length <= 0xffff) {
+            $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA2'))
+                ->writeInt(2, $length, true)
+                ->writeBytes($length, $data);
+
+        } else {
+            $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA4'))
+                ->writeInt(4, $length, true)
+                ->writeBytes($length, $data);
+        }
+
+        $this->script .= $parsed->getBuffer()->getBinary();
+        return $this;
+    }
+
+    /**
+     * @param ScriptInterface $script
+     * @return $this
+     */
+    public function concat(ScriptInterface $script)
+    {
+        $this->script .= $script->getBinary();
+        return $this;
+    }
+
+    /**
+     * @return Script
+     */
+    public function getScript()
+    {
+        return new Script(new Buffer($this->script, null, $this->math));
+    }
+}

--- a/src/Script/ScriptFactory.php
+++ b/src/Script/ScriptFactory.php
@@ -2,6 +2,8 @@
 
 namespace BitWasp\Bitcoin\Script;
 
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Script\Factory\InputScriptFactory;
 use BitWasp\Bitcoin\Script\Factory\OutputScriptFactory;
 use BitWasp\Buffertools\Buffer;
@@ -10,10 +12,20 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
 class ScriptFactory
 {
     /**
+     * @param Opcodes $opcodes
+     * @param Math|null $math
+     * @return ScriptCreator
+     */
+    public static function create(Buffer $buffer = null, Opcodes $opcodes = null, Math $math = null)
+    {
+        return new ScriptCreator($math ?: Bitcoin::getMath(), $opcodes ?: new Opcodes(), $buffer);
+    }
+
+    /**
      * @param Buffer $script
      * @return Script
      */
-    public static function create(Buffer $script = null)
+    public static function createOld(Buffer $script = null)
     {
         return new Script($script ?: new Buffer());
     }
@@ -55,6 +67,6 @@ class ScriptFactory
      */
     public static function fromHex($string)
     {
-        return self::create(Buffer::hex($string));
+        return new Script(Buffer::hex($string));
     }
 }

--- a/src/Script/ScriptInterface.php
+++ b/src/Script/ScriptInterface.php
@@ -8,7 +8,7 @@ use BitWasp\Bitcoin\Address\Address;
 interface ScriptInterface extends SerializableInterface
 {
     /**
-     * @return mixed
+     * @return \BitWasp\Buffertools\Buffer
      */
     public function getScriptHash();
 
@@ -28,7 +28,7 @@ interface ScriptInterface extends SerializableInterface
     public function getOpcodes();
 
     /**
-     * @return mixed
+     * @return bool
      */
     public function isPushOnly();
 }

--- a/src/Transaction/SignatureHash.php
+++ b/src/Transaction/SignatureHash.php
@@ -74,7 +74,7 @@ class SignatureHash implements SignatureHashInterface
             $nOutput = $inputToSign;
 
             if ($math->cmp($nOutput, count($outputs)) >= 0) {
-                return Buffer::hex('0100000000000000000000000000000000000000000000000000000000000000');
+                return Buffer::hex('0100000000000000000000000000000000000000000000000000000000000000', 32, $math);
             }
 
             // Resize..

--- a/src/Transaction/TransactionBuilderInputState.php
+++ b/src/Transaction/TransactionBuilderInputState.php
@@ -7,6 +7,7 @@ use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
 use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
 use BitWasp\Bitcoin\Script\RedeemScript;
+use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Signature\TransactionSignatureInterface;
@@ -292,17 +293,17 @@ class TransactionBuilderInputState
             function () use (&$signatures) {
                 return count($signatures) == 1
                     ? ScriptFactory::scriptSig()->payToPubKeyHash($signatures[0], $this->publicKeys[0])
-                    : ScriptFactory::create();
+                    : new Script();
             },
             function () use (&$signatures) {
                 return count($signatures) == 1
                     ? ScriptFactory::scriptSig()->payToPubKey($signatures[0])
-                    : ScriptFactory::create();
+                    : new Script;
             },
             function () use (&$signatures) {
                 return count($signatures) > 0
                     ? ScriptFactory::scriptSig()->multisigP2sh($this->getRedeemScript(), array_filter($this->signatures))
-                    : ScriptFactory::create();
+                    : new Script();
             }
         );
 

--- a/src/Transaction/TransactionInput.php
+++ b/src/Transaction/TransactionInput.php
@@ -32,8 +32,8 @@ class TransactionInput extends Serializable implements TransactionInputInterface
     private $script;
 
     /**
-     * @param string|null $txid
-     * @param string|null $vout
+     * @param string $txid
+     * @param string $vout
      * @param ScriptInterface|Buffer $script
      * @param int $sequence
      */
@@ -56,7 +56,7 @@ class TransactionInput extends Serializable implements TransactionInputInterface
     /**
      * Return the transaction ID buffer
      *
-     * @return mixed
+     * @return string
      */
     public function getTransactionId()
     {
@@ -64,7 +64,7 @@ class TransactionInput extends Serializable implements TransactionInputInterface
     }
 
     /**
-     * @return mixed
+     * @return int
      */
     public function getVout()
     {

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -97,7 +97,7 @@ class AddressTest extends AbstractTestCase
         $scriptAddress = AddressFactory::fromOutputScript($scriptHash);
         $this->assertInstanceOf('BitWasp\Bitcoin\Address\ScriptHashAddress', $scriptAddress);
 
-        $unknownScript = ScriptFactory::create()->op('OP_0')->op('OP_1');
+        $unknownScript = ScriptFactory::create()->op('OP_0')->op('OP_1')->getScript();
         AddressFactory::fromOutputScript($unknownScript);
     }
 

--- a/tests/Script/Classifier/InputClassifierTest.php
+++ b/tests/Script/Classifier/InputClassifierTest.php
@@ -21,8 +21,7 @@ class InputClassifierTest extends AbstractTestCase
     {
         $privateKey = PrivateKeyFactory::create();
         $p2sh = ScriptFactory::scriptPubKey()->payToPubKeyHash($privateKey->getPublicKey());
-        $scriptSig = new Script();
-        $scriptSig->op('OP_0')->push($p2sh->getBuffer());
+        $scriptSig = ScriptFactory::create()->op('OP_0')->push($p2sh->getBuffer())->getScript();
 
         $classifier = new InputClassifier($scriptSig);
         $this->assertTrue($classifier->isPayToScriptHash());

--- a/tests/Script/Factory/InputScriptFactoryTest.php
+++ b/tests/Script/Factory/InputScriptFactoryTest.php
@@ -4,6 +4,7 @@ namespace BitWasp\Bitcoin\Tests\Script\Factory;
 
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
+use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\Classifier\InputClassifier;
 use BitWasp\Bitcoin\Signature\TransactionSignatureFactory;
@@ -13,7 +14,7 @@ class InputScriptFactoryTest extends AbstractTestCase
 {
     public function testClassify()
     {
-        $script = ScriptFactory::create();
+        $script = new Script();
         $classifier = ScriptFactory::scriptSig()->classify($script);
         $this->assertInstanceOf('BitWasp\Bitcoin\Script\Classifier\InputClassifier', $classifier);
     }

--- a/tests/Script/Factory/OutputScriptFactoryTest.php
+++ b/tests/Script/Factory/OutputScriptFactoryTest.php
@@ -6,6 +6,7 @@ use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Crypto\Random\Random;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
+use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
@@ -92,11 +93,12 @@ class OutputScriptFactoryTest extends AbstractTestCase
 
     public function testPayToPubKeyInvalid()
     {
-        $script = ScriptFactory::create();
+        $script = new Script();
         $this->assertFalse(ScriptFactory::scriptPubKey()->classify($script)->isPayToPublicKey());
 
         $script = ScriptFactory::create()
-            ->push(new Buffer());
+            ->push(new Buffer())
+            ->getScript();
         $this->assertFalse(ScriptFactory::scriptPubKey()->classify($script)->isPayToPublicKey());
     }
 
@@ -120,7 +122,8 @@ class OutputScriptFactoryTest extends AbstractTestCase
             ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
             ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
             ->op('OP_3')
-            ->op('OP_CHECKMULTISIG');
+            ->op('OP_CHECKMULTISIG')
+            ->getScript();
 
         $this->assertEquals(OutputClassifier::MULTISIG, ScriptFactory::scriptPubKey()->classify($script)->classify());
     }
@@ -134,7 +137,8 @@ class OutputScriptFactoryTest extends AbstractTestCase
             ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
             ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
             ->op('OP_3')
-            ->op('OP_CHECKMULTISIG');
+            ->op('OP_CHECKMULTISIG')
+            ->getScript();
 
         $scriptHash = ScriptFactory::scriptPubKey()->payToScriptHash($script);
         $parsed = $scriptHash->getScriptParser()->parse();

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -237,7 +237,7 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
         ];
 
         // Pay to pubkey that succeeds
-        $s1 = ScriptFactory::create()->push($privateKey->getPublicKey()->getBuffer())->op('OP_CHECKSIG');
+        $s1 = ScriptFactory::create()->push($privateKey->getPublicKey()->getBuffer())->op('OP_CHECKSIG')->getScript();
         $vectors[] = [
             true,
             $ec,
@@ -300,7 +300,7 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
         $vectors[] = [
             $flags,
             new Script(new Buffer()),
-            ScriptFactory::create()->push(Buffer::hex(file_get_contents(__DIR__ . "/../../Data/10010bytes.hex"))),
+            ScriptFactory::create()->push(Buffer::hex(file_get_contents(__DIR__ . "/../../Data/10010bytes.hex")))->getScript(),
             false,
             'fails with >10000 bytes',
             new Transaction
@@ -330,8 +330,7 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
     public function testVerifyOnScriptSigFail()
     {
         $i = new \BitWasp\Bitcoin\Script\Interpreter\Interpreter(Bitcoin::getEcAdapter(), new Transaction, new Flags(0));
-        $script = new Script();
-        $script->op('OP_RETURN');
+        $script = ScriptFactory::create()->op('OP_RETURN')->getScript();
 
         $this->assertFalse($i->verify($script, new Script, 0));
     }
@@ -340,8 +339,7 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
     {
         $i = new \BitWasp\Bitcoin\Script\Interpreter\Interpreter(Bitcoin::getEcAdapter(), new Transaction, new Flags(0));
         $true = new Script(Buffer::hex('0101'));
-        $false = new Script();
-        $false->op('OP_RETURN');
+        $false = ScriptFactory::create()->op('OP_RETURN')->getScript();
         $this->assertFalse($i->verify($true, $false, 0));
     }
 
@@ -373,13 +371,11 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
 
     public function testInvalidPayToScriptHash()
     {
-        $p2sh = new Script();
-        $p2sh->op('OP_RETURN');
+        $p2sh = ScriptFactory::create()->op('OP_RETURN')->getScript();
 
         $scriptPubKey = ScriptFactory::scriptPubKey()->payToScriptHash($p2sh);
 
-        $scriptSig = new Script();
-        $scriptSig->op('OP_0')->push($p2sh->getBuffer());
+        $scriptSig = ScriptFactory::create()->op('OP_0')->push($p2sh->getBuffer())->getScript();
 
         $i = new \BitWasp\Bitcoin\Script\Interpreter\Interpreter(Bitcoin::getEcAdapter(), new Transaction, new Flags(InterpreterInterface::VERIFY_P2SH));
         $this->assertFalse($i->verify($scriptSig, $scriptPubKey, 0));
@@ -388,11 +384,9 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
 
     public function testVerifyScriptsigMustBePushOnly()
     {
-        $p2sh = new Script();
-        $p2sh->op('OP_1')->push(Buffer::hex('41414141'))->op('OP_DEPTH');
+        $p2sh = ScriptFactory::create()->op('OP_1')->push(Buffer::hex('41414141'))->op('OP_DEPTH')->getScript();
 
-        $scriptSig = new Script();
-        $scriptSig->op('OP_DEPTH')->push($p2sh->getBuffer());
+        $scriptSig = ScriptFactory::create()->op('OP_DEPTH')->push($p2sh->getBuffer())->getScript();
 
         $scriptPubKey = ScriptFactory::scriptPubKey()->payToScriptHash($p2sh);
 

--- a/tests/Script/RedeemScriptTest.php
+++ b/tests/Script/RedeemScriptTest.php
@@ -95,7 +95,8 @@ class RedeemScriptTest extends AbstractTestCase
             ->push(Buffer::hex($pkHex))
             ->push(Buffer::hex($pkHex))
             ->op('OP_3')
-            ->op('OP_CHECKMULTISIG');
+            ->op('OP_CHECKMULTISIG')
+            ->getScript();
 
         $rs = RedeemSCript::fromScript($script);
         $this->assertEquals(2, $rs->getRequiredSigCount());
@@ -112,7 +113,8 @@ class RedeemScriptTest extends AbstractTestCase
         $script = ScriptFactory::create()
             ->op('OP_2')
             ->op('OP_3')
-            ->op('OP_CHECKMULTISIG');
+            ->op('OP_CHECKMULTISIG')
+            ->getScript();
 
         RedeemSCript::fromScript($script);
     }
@@ -127,7 +129,8 @@ class RedeemScriptTest extends AbstractTestCase
             ->op('OP_2')
             ->op('OP_3')
             ->op('OP_3')
-            ->op('OP_CHECKMULTISIG');
+            ->op('OP_CHECKMULTISIG')
+            ->getScript();
 
         RedeemSCript::fromScript($script);
     }
@@ -142,7 +145,8 @@ class RedeemScriptTest extends AbstractTestCase
             ->push(Buffer::hex($pkHex))
             ->push(Buffer::hex($pkHex))
             ->op('OP_3')
-            ->op('OP_CHECKMULTISIG');
+            ->op('OP_CHECKMULTISIG')
+            ->getScript();
 
         $hash = hash('ripemd160', hash('sha256', $script->getBinary(), true), true);
         $this->assertEquals($hash, $script->getScriptHash()->getBinary());

--- a/tests/Script/ScriptFactoryTest.php
+++ b/tests/Script/ScriptFactoryTest.php
@@ -39,7 +39,7 @@ class ScriptFactoryTest extends AbstractTestCase
     public function testCreate()
     {
         $script = ScriptFactory::create(null);
-        $this->assertInstanceOf('BitWasp\Bitcoin\Script\Script', $script);
-        $this->assertEmpty($script->getBinary());
+        $this->assertInstanceOf('BitWasp\Bitcoin\Script\ScriptCreator', $script);
+        $this->assertEmpty($script->getScript()->getBinary());
     }
 }

--- a/tests/Script/ScriptParserTest.php
+++ b/tests/Script/ScriptParserTest.php
@@ -78,7 +78,7 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
 
     public function testDefaultParse()
     {
-        $parse = ScriptFactory::create()->getScriptParser()->parse();
+        $parse = ScriptFactory::create()->getScript()->getScriptParser()->parse();
         $this->assertInternalType('array', $parse);
         $this->assertEmpty($parse);
     }
@@ -86,7 +86,7 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
     public function testParse()
     {
         $buf = Buffer::hex('0f9947c2b0fdd82ef3153232ee23d5c0bed84a02');
-        $script = ScriptFactory::create()->op('OP_HASH160')->push($buf)->op('OP_EQUAL');
+        $script = ScriptFactory::create()->op('OP_HASH160')->push($buf)->op('OP_EQUAL')->getScript();
         $parse = $script->getScriptParser()->parse();
 
         $this->assertSame($parse[0], 'OP_HASH160');
@@ -103,15 +103,14 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
      */
     public function testParseInvalidOp()
     {
-        $script = ScriptFactory::create(Buffer::hex('fa'));
+        $script = ScriptFactory::create(Buffer::hex('fa'))->getScript();
         $script->getScriptParser()->parse();
     }
 
     public function testParseNullByte()
     {
         $null = chr(0x00);
-        $script = ScriptFactory::create();
-        $script->op('OP_0');
+        $script = ScriptFactory::create()->op('OP_0')->getScript();
         $parse = $script->getScriptParser()->parse();
         $this->assertSame($parse[0]->getBinary(), $null);
     }
@@ -122,7 +121,7 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
         $json = json_decode($f);
 
         // Pay to pubkey hash
-        $s0 = ScriptFactory::create(Buffer::hex($json->test[0]->script));
+        $s0 = ScriptFactory::create(Buffer::hex($json->test[0]->script))->getScript();
 
         $script0 = $s0->getScriptParser()->parse();
         $this->assertSame($script0[0], 'OP_DUP');
@@ -133,7 +132,7 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($s0->getScriptParser()->getHumanReadable(), $json->test[0]->asm);
 
         // <65 bytes> OP_CHECKSIG - uncompressed paytopubkey
-        $s1 = ScriptFactory::create(Buffer::hex($json->test[1]->script));
+        $s1 = ScriptFactory::create(Buffer::hex($json->test[1]->script))->getScript();
 
         $script1 = $s1->getScriptParser()->parse();
         $this->assertSame($script1[0]->getSize(), 65);
@@ -141,7 +140,7 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($s1->getScriptParser()->getHumanReadable(), $json->test[1]->asm);
 
         // pay to script hash output
-        $s2 = ScriptFactory::create(Buffer::hex($json->test[2]->script));
+        $s2 = ScriptFactory::create(Buffer::hex($json->test[2]->script))->getScript();
 
         $script2 = $s2->getScriptParser()->parse();
         $this->assertSame($script2[0], 'OP_HASH160');
@@ -149,13 +148,13 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($script2[2], 'OP_EQUAL');
 
         // <33 bytes> OP_CHECKSIG - compressed paytopubkey
-        $s3 = ScriptFactory::create(Buffer::hex($json->test[3]->script));
+        $s3 = ScriptFactory::create(Buffer::hex($json->test[3]->script))->getScript();
         $script3 = $s3->getScriptParser()->parse();
         $this->assertSame($script3[0]->getSize(), 33);
         $this->assertSame($script3[1], 'OP_CHECKSIG');
 
         // 1 <pubkey> <pubkey> OP_CHECKMULTISIG
-        $s4 = ScriptFactory::create(Buffer::hex($json->test[4]->script));
+        $s4 = ScriptFactory::create(Buffer::hex($json->test[4]->script))->getScript();
 
         $script4 = $s4->getScriptParser()->parse();
         $this->assertSame($script4[0], 'OP_1');
@@ -165,14 +164,14 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($script4[4], 'OP_CHECKMULTISIG');
 
         // OP_RETURN <40 bytes>
-        $s5 = ScriptFactory::create(Buffer::hex($json->test[5]->script));
+        $s5 = ScriptFactory::create(Buffer::hex($json->test[5]->script))->getScript();
 
         $script5 = $s5->getScriptParser()->parse();
         $this->assertSame($script5[0], 'OP_RETURN');
         $this->assertSame($script5[1]->getSize(), 38);
 
         // MtGox fuckup.
-        $s6 = ScriptFactory::create(Buffer::hex($json->test[6]->script));
+        $s6 = ScriptFactory::create(Buffer::hex($json->test[6]->script))->getScript();
         $script6 = $s6->getScriptParser()->parse();
         $this->assertSame($script6[0], 'OP_DUP');
         $this->assertSame($script6[1], 'OP_HASH160');
@@ -181,13 +180,13 @@ class ScriptParserTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($script6[4], 'OP_CHECKSIG');
 
         // OP_RETURN <38 bytes>
-        $s7 = ScriptFactory::create(Buffer::hex($json->test[7]->script));
+        $s7 = ScriptFactory::create(Buffer::hex($json->test[7]->script))->getScript();
         $script7 = $s7->getScriptParser()->parse();
         $this->assertSame($script7[0], 'OP_RETURN');
         $this->assertSame($script7[1]->getSize(), 40);
 
         //
-        $s8 = ScriptFactory::create(Buffer::hex($json->test[8]->script));
+        $s8 = ScriptFactory::create(Buffer::hex($json->test[8]->script))->getScript();
         $script8 = $s8->getScriptParser()->parse();
         $this->assertSame($script8[0], 'OP_IFDUP');
         $this->assertSame($script8[1], 'OP_IF');

--- a/tests/Script/ScriptTest.php
+++ b/tests/Script/ScriptTest.php
@@ -30,8 +30,7 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
         $eLen = 65536;
         $buffer = new Buffer('', $eLen);
 
-        $script = new Script();
-        $script->push($buffer);
+        $script = ScriptFactory::create()->push($buffer)->getScript();
 
         $parse = new Parser($script->getBuffer());
         $op = $parse->readBytes(1)->getInt();
@@ -72,10 +71,10 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
     {
         $hex = '00483045022057e65d83fb50768f310953300cdf09e8c551a716de81eb9e9bea2b055cffce53022100830c1636104d5ba704ef92849db0415182c364278b7f2a53097b65beb1c755c001483045022100b16c0cf3d6e16a9f9a2559c0043c083e46a8557df1f22755e396b94b08e8624202203b6a9927ceb70eda3e71f584dffe108ef0fcc5040538de45f85c1645b115168601473044022006135422817bd9f8cd24004c9797114838944a7594b6d9d7da043c93700c58bf0220009c226d944fc1d2c4a29d9b687aab04f2f65f9688c468594a0747067fa717800149304602210093f6c1402fdefd71e890168f8a2eb34ff18b50a9babdfd1b4a69c8895b10a9bb022100b7fea02dbc6391ac6403f628afe576c2e8b42f7d31c7c38d959766b45e114f6e01483045022100f6d4fa96d2d221cc0368b0da1fafc889c5212e1a65a5d7b5937d374993568bb002206fc78de031d1cd34b203abedac0ef628ad6c863a0c505533da12cf34bf74fdba01483045022100b52f4d6f1e69554f15b9e02be1a3f03d96943c2aa21544047d9156b91a2eace5022023b41bef3725b1a6cab9c509b95e3a2f839536325597a2359ea0c14786adf2a8014ccf5621025d951ab5a9c3656aa25b4facf7b9824ca3cca7f9eaf3b84551d3aef8b0803a5721027b7eb1910184738f54b00ee7c5f695598d0f21b8ea87bface1e9d901fa5193802102e8537cc8081358b9bbcbd221da7f10ec167fbadcb03b8ff2980c8a78aca076712102f2d0f1996cf932b766032ea1da0051d8e7688516eb005b9ffd6acfbf032627c321030bd27f6a978bc03748b301e20531dd76f27ddcc25e51c09e65a6e4dafa8abbaf21037bd4c27021916bd09f7af32433a0eb542087cf0ae51cd4289c1c6d35ebfab79856ae';
 
-        $script = ScriptFactory::create();
+        $script = ScriptFactory::create()->getScript();
         $this->assertEmpty($script->getBuffer()->getBinary());
 
-        $script = ScriptFactory::create(Buffer::hex($hex));
+        $script = ScriptFactory::create(Buffer::hex($hex))->getScript();
         $this->assertSame($script->getBuffer()->getHex(), $hex);
     }
 
@@ -85,8 +84,10 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
         $expected = '01' . $hex;
         $data = Buffer::hex($hex);
 
-        $script = new Script();
-        $script->push($data);
+        $script = ScriptFactory::create()
+            ->push($data)
+            ->getScript();
+
         $out = $script->getBuffer()->getHex();
         $this->assertSame($expected, $out);
     }
@@ -104,8 +105,7 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
     {
         $hash = '0f9947c2b0fdd82ef3153232ee23d5c0bed84a02';
         $buf  = Buffer::hex($hash);
-        $script = new Script();
-        $script->push($buf);
+        $script = ScriptFactory::create()->push($buf)->getScript();
 
         $this->assertSame('14' . $hash, $script->getBuffer()->getHex());
     }
@@ -113,8 +113,7 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
     public function testOp()
     {
         $op = 'OP_HASH160';
-        $script = new Script();
-        $script->op($op);
+        $script = ScriptFactory::create()->op($op)->getScript();
 
         $rOp = $script->getOpCodes()->getOpByName($op);
         $expected = chr($rOp);
@@ -127,9 +126,7 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
      */
     public function testOpFailure()
     {
-        $op = 'OP_HASH666';
-        $script = new Script();
-        $script->op($op);
+        ScriptFactory::create()->op('OP_HASH666');
     }
 
     public function testPushdata1()
@@ -138,8 +135,9 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
             '41414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141' .
             '4141414141414141414141414141414141414141414141414141414141414141'
         );
-        $script = new Script();
-        $script->push($data);
+        $script = ScriptFactory::create()
+            ->push($data)
+            ->getScript();
         $scriptBin = $script->getBuffer()->getBinary();
         $firstOpCode = ord($scriptBin[0]);
         $this->assertSame($firstOpCode, $script->getOpCodes()->getOpByName('OP_PUSHDATA1'));
@@ -156,9 +154,10 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
             '41414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141' .
             '41414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141414141'
         );
+        $script = ScriptFactory::create()
+            ->push($data)
+            ->getScript();
 
-        $script = new Script();
-        $script->push($data);
         $scriptBin = $script->getBuffer()->getBinary();
         $firstOpCode = ord($scriptBin[0]);
         $this->assertSame($firstOpCode, $script->getOpCodes()->getOpByName('OP_PUSHDATA2'));
@@ -167,19 +166,19 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
 
     public function testGetScriptHash()
     {
-        $script = new Script();
-        $script
+        $script = $script = ScriptFactory::create()
             ->op('OP_2')
             ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
             ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
             ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
             ->op('OP_3')
-            ->op('OP_CHECKMULTISIG');
+            ->op('OP_CHECKMULTISIG')
+            ->getScript();
 
         $rs = new Script(Buffer::hex('522102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb53ae'));
 
         // Ensure scripthash is being reproduced
-        $this->assertSame($script->getBuffer()->getHex(), '522102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb53ae');
+        $this->assertSame($script->getHex(), '522102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb53ae');
         $this->assertSame($script->getScriptHash()->getHex(), $rs->getScriptHash()->getHex());
 
         // Validate it's correct
@@ -202,8 +201,8 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
     public function getPushOnlyVectors()
     {
         return [
-            [ScriptFactory::create()->push(new Buffer()), true],
-            [ScriptFactory::create()->op('OP_1'), false]
+            [ScriptFactory::create()->push(new Buffer())->getScript(), true],
+            [ScriptFactory::create()->op('OP_1')->getScript(), false]
         ];
     }
 

--- a/tests/Transaction/TransactionBuilderInputStateTest.php
+++ b/tests/Transaction/TransactionBuilderInputStateTest.php
@@ -3,7 +3,6 @@
 
 namespace BitWasp\Bitcoin\Tests\Transaction;
 
-use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\EcAdapterFactory;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Script\RedeemScript;
@@ -126,7 +125,7 @@ class TransactionBuilderInputStateTest extends AbstractTestCase
      */
     public function testNonStandardScriptFails()
     {
-        $script = ScriptFactory::create()->push(new Buffer('abab'));
+        $script = ScriptFactory::create()->push(new Buffer('abab'))->getScript();
         $this->createState($script);
     }
 }

--- a/tests/Transaction/TransactionInputTest.php
+++ b/tests/Transaction/TransactionInputTest.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Tests\Transaction;
 
+use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionInputSerializer;
 use BitWasp\Bitcoin\Transaction\TransactionInput;
 use BitWasp\Bitcoin\Script\Script;
@@ -35,8 +36,7 @@ class TransactionInputTest extends \PHPUnit_Framework_TestCase
         $txid = '7f8e94bdf85de933d5417145e4b76926777fa2a2d8fe15b684cfd835f43b8b33';
         $vout = '0';
         $scriptBuf = new Buffer('03010203');
-        $script = new Script();
-        $script->push($scriptBuf);
+        $script = ScriptFactory::create()->push($scriptBuf)->getScript();
         $sequence = '0';
         $t = new TransactionInput($txid, $vout, $script, $sequence);
         $this->assertSame($txid, $t->getTransactionId());
@@ -78,7 +78,7 @@ class TransactionInputTest extends \PHPUnit_Framework_TestCase
 
     public function testSerialize()
     {
-        $hex    = '62442ea8de9ee6cc2dd7d76dfc4523910eb2e3bd4b202d376910de700f63bf4b000000008b48304502207db5ea602fe2e9f8e70bfc68b7f468d68910d2ff4ac50294fc80109e254f317f022100a68a66f23406fdfd93025c28ffef4e79260283335ce39a4e8d0b52c5ee41913b014104f8de51f3b278225c0fe74a856ea2481e9ad4c9385fc10cefadaa4357ecd2c4d29904902d10e376546500c127f65d0de35b6215d49dd1ef6c67e6cdd5e781ef22ffffffff';
+        $hex = '62442ea8de9ee6cc2dd7d76dfc4523910eb2e3bd4b202d376910de700f63bf4b000000008b48304502207db5ea602fe2e9f8e70bfc68b7f468d68910d2ff4ac50294fc80109e254f317f022100a68a66f23406fdfd93025c28ffef4e79260283335ce39a4e8d0b52c5ee41913b014104f8de51f3b278225c0fe74a856ea2481e9ad4c9385fc10cefadaa4357ecd2c4d29904902d10e376546500c127f65d0de35b6215d49dd1ef6c67e6cdd5e781ef22ffffffff';
         $s = new TransactionInputSerializer();
         $in = $s->parse($hex);
         $this->assertEquals($hex, $in->getBuffer()->getHex());

--- a/tests/Transaction/TransactionOutputTest.php
+++ b/tests/Transaction/TransactionOutputTest.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Tests\Transaction;
 
+use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionOutputSerializer;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Bitcoin\Script\Script;
@@ -49,8 +50,7 @@ class TransactionOutputTest extends \PHPUnit_Framework_TestCase
 
     public function testSetScript()
     {
-        $script = new Script();
-        $script = $script->op('OP_2')->op('OP_3');
+        $script = ScriptFactory::create()->op('OP_2')->op('OP_3')->getScript();
 
         $out = new TransactionOutput(1, new Script());
         $this->assertEquals(new Script(), $out->getScript());


### PR DESCRIPTION
ScriptCreator exposes three methods - op(), push(), and concat(), taken as-is from Script. Its constructor may be provided a Buffer containing a script to initialize the class with. 

This shouldn't be too much of a break, as ScriptFactory::create() now returns a ScriptCreator, instead of the previously mutable Script. Code which already uses ScriptFactory::create() just needs a call to getScript() to produce the immutable class. Anyone relying on these methods in Script will have to make the change. 