### PR TITLE
Add correct network magic bytes for litecoin/viacoin, fix tests

### DIFF
--- a/src/Network/NetworkFactory.php
+++ b/src/Network/NetworkFactory.php
@@ -54,7 +54,21 @@ class NetworkFactory
         $network = self::create('30', '05', 'b0')
             ->setHDPubByte('019da462')
             ->setHDPrivByte('019d9cfe')
-            ->setNetMagicBytes('d9b4bef9');
+            ->setNetMagicBytes('dbb6c0fb');
+
+        return $network;
+    }
+
+    /**
+     * @return NetworkInterface
+     * @throws \Exception
+     */
+    public static function litecoinTestnet()
+    {
+        $network = self::create('6f', 'c4', 'ef', true)
+            ->setHDPubByte('019da462')
+            ->setHDPrivByte('019d9cfe')
+            ->setNetMagicBytes('dcb7c1fc');
 
         return $network;
     }
@@ -83,7 +97,7 @@ class NetworkFactory
         $network = self::create('7f', 'c4', 'ff', true)
             ->setHDPubByte('043587cf')
             ->setHDPrivByte('04358394')
-            ->setNetMagicBytes('cbc6680f')
+            ->setNetMagicBytes('92efc5a9')
         ;
 
         return $network;

--- a/tests/Network/NetworkTest.php
+++ b/tests/Network/NetworkTest.php
@@ -151,7 +151,7 @@ class NetworkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(NetworkFactory::litecoin()->isTestnet(), false);
         $this->assertEquals(NetworkFactory::litecoin()->getHDPrivByte(), '019d9cfe');
         $this->assertEquals(NetworkFactory::litecoin()->getHDPubByte(), '019da462');
-        $this->assertEquals(NetworkFactory::litecoin()->getNetMagicBytes(), 'd9b4bef9');
+        $this->assertEquals(NetworkFactory::litecoin()->getNetMagicBytes(), 'dbb6c0fb');
 
         $this->assertEquals("36PrZ1KHYMpqSyAQXSG8VwbUiq2EogxLo2", $p2sh->getAddress(NetworkFactory::litecoin()));
         $this->assertEquals("LKrfsrS4SE1tajYRQCPuRcY1sMkoFf1BN3", $p2pk->getAddress(NetworkFactory::litecoin()));
@@ -172,7 +172,7 @@ class NetworkTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(NetworkFactory::viacoinTestnet()->isTestnet(), true);
         $this->assertEquals(NetworkFactory::viacoinTestnet()->getHDPrivByte(), '04358394');
         $this->assertEquals(NetworkFactory::viacoinTestnet()->getHDPubByte(), '043587cf');
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->getNetMagicBytes(), 'cbc6680f');
+        $this->assertEquals(NetworkFactory::viacoinTestnet()->getNetMagicBytes(), '92efc5a9');
         $this->assertEquals("2Mwx4ckFK9pLBeknxCZt17tajwBEQXxNaWV", $p2sh->getAddress(NetworkFactory::viacoinTestnet()));
         $this->assertEquals("t7ZKfRypXUd7ByZGLLi5jX3AbD7KQvDj4a", $p2pk->getAddress(NetworkFactory::viacoinTestnet()));
     }


### PR DESCRIPTION
As taken from the following files, I have updated the Network Magic bytes for litecoin/viacoin. 

https://github.com/litecoin-project/litecoin/blob/master-0.10/src/chainparams.cpp
https://github.com/viacoin/viacoin/blob/master/src/chainparams.cpp
https://github.com/bitcoin/bitcoin/blob/master/src/chainparams.cpp

It appears the library is taking these values in byte-reversed order, which is maybe only a serialization concern. I'll raise a separate issue for this because it will affect Bit-Wasp/bitcoin-p2p if that's the case. 