### PR TITLE
Add script sigops

### DIFF
--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -26,10 +26,10 @@ class Script extends Serializable implements ScriptInterface
      *
      * @param Buffer $script
      */
-    public function __construct(Buffer $script = null)
+    public function __construct(Buffer $script = null, Opcodes $opcodes = null)
     {
         $this->script = $script instanceof Buffer ? $script->getBinary() : '';
-        $this->opcodes = new Opcodes;
+        $this->opcodes = $opcodes ?: new Opcodes();
     }
 
     /**

--- a/src/Script/ScriptCreator.php
+++ b/src/Script/ScriptCreator.php
@@ -103,6 +103,6 @@ class ScriptCreator
      */
     public function getScript()
     {
-        return new Script(new Buffer($this->script, null, $this->math));
+        return new Script(new Buffer($this->script, null, $this->math), $this->opcodes);
     }
 }

--- a/src/Script/ScriptInterface.php
+++ b/src/Script/ScriptInterface.php
@@ -36,4 +36,10 @@ interface ScriptInterface extends SerializableInterface
      * @return int
      */
     public function countSigOps();
+
+    /**
+     * @param ScriptInterface $scriptSig
+     * @return int
+     */
+    public function countP2shSigOps(ScriptInterface $scriptSig);
 }

--- a/src/Script/ScriptInterface.php
+++ b/src/Script/ScriptInterface.php
@@ -31,4 +31,9 @@ interface ScriptInterface extends SerializableInterface
      * @return bool
      */
     public function isPushOnly();
+
+    /**
+     * @return int
+     */
+    public function countSigOps();
 }

--- a/tests/Script/ScriptCountSigOpsTest.php
+++ b/tests/Script/ScriptCountSigOpsTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Script;
+
+use BitWasp\Bitcoin\Script\Script;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Buffertools\Buffer;
+
+class ScriptCountSigOpsTest extends AbstractTestCase
+{
+    public function getCountTestVectors()
+    {
+        $s1 = ScriptFactory::create()->op('OP_1')->push(new Buffer())->push(new Buffer())->op('OP_2')->op('OP_CHECKMULTISIG')->getScript();
+        $s2 = ScriptFactory::create($s1->getBuffer())->op('OP_IF')->op('OP_CHECKSIG')->op('OP_ENDIF')->getScript();
+        return [
+            [
+                new Script(),
+                0
+            ],
+            [
+                $s1,
+                2
+            ],
+            [
+                $s2,
+                3
+            ]
+        ];
+    }
+
+    /**
+     * @param Script $script
+     * @param $eSigOpCount
+     * @dataProvider getCountTestVectors
+     */
+    public function testEmptyScriptHashZero(Script $script, $eSigOpCount)
+    {
+        $this->assertEquals($eSigOpCount, $script->countSigOps());
+    }
+}

--- a/tests/Script/ScriptCountSigOpsTest.php
+++ b/tests/Script/ScriptCountSigOpsTest.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Tests\Script;
 
+use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
@@ -13,20 +14,80 @@ class ScriptCountSigOpsTest extends AbstractTestCase
     {
         $s1 = ScriptFactory::create()->op('OP_1')->push(new Buffer())->push(new Buffer())->op('OP_2')->op('OP_CHECKMULTISIG')->getScript();
         $s2 = ScriptFactory::create($s1->getBuffer())->op('OP_IF')->op('OP_CHECKSIG')->op('OP_ENDIF')->getScript();
+
         return [
             [
                 new Script(),
+                false,
+                0
+            ],
+            [
+                new Script(),
+                true,
                 0
             ],
             [
                 $s1,
+                true,
                 2
             ],
             [
                 $s2,
+                true,
                 3
+            ],
+            [
+                $s2,
+                false,
+                21
             ]
         ];
+    }
+
+    public function testP2sh()
+    {
+        $innerScript = ScriptFactory::create()
+            ->op('OP_1')
+            ->push(new Buffer())
+            ->push(new Buffer())
+            ->op('OP_2')
+            ->op('OP_CHECKMULTISIG')
+            ->op('OP_IF')->op('OP_CHECKSIG')->op('OP_ENDIF')
+            ->getScript();
+
+        $innerBuf = $innerScript->getBuffer();
+
+        $p2sh = ScriptFactory::scriptPubKey()->payToScriptHash($innerScript);
+        $scriptSig = ScriptFactory::create()->op('OP_0')->push($innerBuf)->getScript();
+        $count = $p2sh->countP2shSigOps($scriptSig);
+
+        $this->assertEquals(3, $count);
+
+    }
+
+    public function testMultisig()
+    {
+        $pk = [];
+        for($i = 0; $i < 3; $i++) {
+            $pk[] = PrivateKeyFactory::create()->getPublicKey();
+        }
+
+        $p2shScript = ScriptFactory::multisig(1, $pk);
+        $this->assertEquals(3, $p2shScript->countSigOps(true));
+        $this->assertEquals(20, $p2shScript->countSigOps(false));
+
+        $scriptPubKey = ScriptFactory::scriptPubKey()->payToScriptHash($p2shScript);
+        $this->assertEquals(0, $scriptPubKey->countSigOps(true));
+        $this->assertEquals(0, $scriptPubKey->countSigOps(false));
+
+        $scriptSig = ScriptFactory::create()
+            ->op('OP_1')
+            ->push(new Buffer())
+            ->push(new Buffer())
+            ->push($p2shScript->getBuffer())
+            ->getScript();
+
+        $this->assertEquals(3, $scriptPubKey->countP2shSigOps($scriptSig));
     }
 
     /**
@@ -34,8 +95,22 @@ class ScriptCountSigOpsTest extends AbstractTestCase
      * @param $eSigOpCount
      * @dataProvider getCountTestVectors
      */
-    public function testEmptyScriptHashZero(Script $script, $eSigOpCount)
+    public function testSigOpCount(Script $script, $fAccurate, $eSigOpCount)
     {
-        $this->assertEquals($eSigOpCount, $script->countSigOps());
+        $this->assertEquals($eSigOpCount, $script->countSigOps($fAccurate));
+    }
+
+    public function testWhenNotP2sh()
+    {
+        $p2pkh = ScriptFactory::create()->op('OP_DUP')->op('OP_HASH160')->push(new Buffer())->op('OP_EQUALVERIFY')->op('OP_CHECKSIG')->getScript();
+        $empty = new Script();
+        $this->assertEquals(1, $p2pkh->countP2shSigOps($empty));
+
+        $p2shPubKey = ScriptFactory::scriptPubKey()->payToScriptHash($empty);
+        $this->assertEquals(0, $p2shPubKey->countP2shSigOps($empty));
+
+        $p2shScript = ScriptFactory::create()->op('OP_HASH160')->getScript();
+        $p2shPubKey1 = ScriptFactory::scriptPubKey()->payToScriptHash($p2shScript);
+        $this->assertEquals(0, $p2shPubKey1->countP2shSigOps($p2shScript));
     }
 }

--- a/tests/Script/ScriptTest.php
+++ b/tests/Script/ScriptTest.php
@@ -92,15 +92,6 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($expected, $out);
     }
 
-    public function testConcat()
-    {
-        $s1 = new Script(Buffer::hex('00'));
-        $s2 = new Script(Buffer::hex('01'));
-        $s1->concat($s2);
-
-        $this->assertEquals('0001', $s1->getHex());
-    }
-
     public function testPushBuffer()
     {
         $hash = '0f9947c2b0fdd82ef3153232ee23d5c0bed84a02';


### PR DESCRIPTION
This adds two functions to ScriptInterface: `countSigOps`, and `countP2shSigOps`. It also removes Script::concat(), which wasn't defined in ScriptInterface and should already have been removed. 