### PR TITLE
Cache some method results in Transaction / BlockHeader

### DIFF
--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -40,6 +40,11 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     private $nonce;
 
     /**
+     * @var null|Buffer
+     */
+    private $cacheHash;
+
+    /**
      * @param int|string $version
      * @param string $prevBlock
      * @param string $merkleRoot
@@ -59,6 +64,18 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
         $this->timestamp = $timestamp;
         $this->bits = $bits;
         $this->nonce = $nonce;
+    }
+
+    /**
+     * @return Buffer
+     */
+    public function getHash()
+    {
+        if (is_null($this->cacheHash)) {
+            $this->cacheHash = Hash::sha256d($this->getBuffer())->flip();
+        }
+
+        return $this->cacheHash;
     }
 
     /**
@@ -96,14 +113,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     public function getBits()
     {
         return $this->bits;
-    }
-
-    /**
-     * @return Buffer
-     */
-    public function getHash()
-    {
-        return Hash::sha256d($this->getBuffer())->flip();
     }
 
     /**

--- a/src/Chain/Params.php
+++ b/src/Chain/Params.php
@@ -3,12 +3,14 @@
 namespace BitWasp\Bitcoin\Chain;
 
 use BitWasp\Bitcoin\Block\Block;
+use BitWasp\Bitcoin\Block\BlockFactory;
 use BitWasp\Bitcoin\Block\BlockHeader;
 use BitWasp\Bitcoin\Collection\Transaction\TransactionCollection;
 use BitWasp\Bitcoin\Collection\Transaction\TransactionInputCollection;
 use BitWasp\Bitcoin\Collection\Transaction\TransactionOutputCollection;
 use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\Transaction;
 use BitWasp\Bitcoin\Transaction\TransactionInput;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
@@ -102,9 +104,9 @@ class Params implements ParamsInterface
             '1',
             '0000000000000000000000000000000000000000000000000000000000000000',
             '4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b',
-            1231006505,
+            '1231006505',
             Buffer::hex('1d00ffff', 4, $this->math),
-            2083236893
+            '2083236893'
         );
     }
 
@@ -117,7 +119,7 @@ class Params implements ParamsInterface
         $publicKey = Buffer::hex('04678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5f', null, $this->math);
 
         $inputScript = ScriptFactory::create()
-            ->push(Buffer::int('486604799', 4, $this->math))
+            ->push(Buffer::int('486604799', 4, $this->math)->flip())
             ->push(Buffer::int('4', null, $this->math))
             ->push($timestamp)
             ->getScript();
@@ -131,18 +133,12 @@ class Params implements ParamsInterface
             $this->math,
             $this->getGenesisBlockHeader(),
             new TransactionCollection([
-                new Transaction(
-                    '1',
-                    new TransactionInputCollection([new TransactionInput(
-                        '0000000000000000000000000000000000000000000000000000000000000000',
-                        0xffffffff,
-                        $inputScript
-                    )]),
-                    new TransactionOutputCollection([new TransactionOutput(
-                        50,
-                        $outputScript
-                    )])
-                )
+                (new TxBuilder)
+                    ->version('1')
+                    ->input('0000000000000000000000000000000000000000000000000000000000000000', 0xffffffff, $inputScript)
+                    ->output(5000000000, $outputScript)
+                    ->locktime(0)
+                    ->get()
             ])
         );
     }

--- a/src/Serializer/Transaction/TransactionSerializer.php
+++ b/src/Serializer/Transaction/TransactionSerializer.php
@@ -68,7 +68,9 @@ class TransactionSerializer
      */
     public function fromParser(Parser & $parser)
     {
-        list ($version, $inputArray, $outputArray, $locktime) = $this->getTemplate()->parse($parser);
+        $p  = $this->getTemplate()->parse($parser);
+
+        list ($version, $inputArray, $outputArray, $locktime) = $p;
 
         return (new TxBuilder())
             ->version($version)

--- a/src/Transaction/Factory/TxBuilder.php
+++ b/src/Transaction/Factory/TxBuilder.php
@@ -111,6 +111,7 @@ class TxBuilder
             $script ?: new Script(),
             $nSequence
         );
+
         return $this;
     }
 

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -34,6 +34,21 @@ class Transaction extends Serializable implements TransactionInterface
     private $lockTime;
 
     /**
+     * @var null|Buffer
+     */
+    private $cacheHash;
+
+    /**
+     * @var null|Buffer
+     */
+    private $cacheTxid;
+
+    /**
+     * @var null|Buffer
+     */
+    private $cacheBuffer;
+
+    /**
      * @param int|string $version
      * @param TransactionInputCollection $inputs
      * @param TransactionOutputCollection $outputs
@@ -84,7 +99,11 @@ class Transaction extends Serializable implements TransactionInterface
      */
     public function getTxHash()
     {
-        return Hash::sha256d($this->getBuffer());
+        if (is_null($this->cacheHash)) {
+            $this->cacheHash = Hash::sha256d($this->getBuffer());
+        }
+
+        return $this->cacheHash;
     }
 
     /**
@@ -92,7 +111,11 @@ class Transaction extends Serializable implements TransactionInterface
      */
     public function getTxId()
     {
-        return $this->getTxHash()->flip();
+        if (is_null($this->cacheTxid)) {
+            $this->cacheTxid = $this->getTxHash()->flip();
+        }
+
+        return $this->cacheTxid;
     }
 
     /**
@@ -186,6 +209,10 @@ class Transaction extends Serializable implements TransactionInterface
      */
     public function getBuffer()
     {
-        return (new TransactionSerializer())->serialize($this);
+        if (is_null($this->cacheBuffer)) {
+            $this->cacheBuffer = (new TransactionSerializer)->serialize($this);
+        }
+
+        return $this->cacheBuffer;
     }
 }

--- a/tests/Chain/ParamsTest.php
+++ b/tests/Chain/ParamsTest.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Tests\Chain;
 
+use BitWasp\Bitcoin\Block\BlockFactory;
 use BitWasp\Bitcoin\Chain\Params;
 use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
@@ -30,6 +31,12 @@ class ParamsTest extends AbstractTestCase
 
         $this->assertEquals(20000, $params->getMaxBlockSigOps());
         $this->assertEquals(4000, $params->getMaxTxSigOps());
-        $this->assertEquals('000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f', $params->getGenesisBlock()->getHeader()->getHash()->getHex());
+
+        $genesis = $params->getGenesisBlock();
+        $header = $genesis->getHeader();
+        $hash = $header->getHash();
+        $merkle = $genesis->getMerkleRoot();
+        $this->assertEquals('000000000019d6689c085ae165831e934ff763ae46a2a6c172b3f1b60a8ce26f', $hash->getHex());
+        $this->assertEquals('4a5e1e4baab89f3a32518a88c31bc87f618f76673e2cc77ab2127b7afdeda33b', $merkle);
     }
 }


### PR DESCRIPTION
This PR introduces caching for the results of the following methods: 
Transaction::getTxHash(), getTxId(), getBuffer()
BlockHeader::getHash() 