### PR TITLE
Pass value as a string instead of int, probably getting converted to …

### DIFF
--- a/tests/Transaction/TransactionTest.php
+++ b/tests/Transaction/TransactionTest.php
@@ -50,7 +50,7 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
      */
     public function testSetVersionException()
     {
-        new Transaction(4294967999);
+        new Transaction('4294967999');
     }
 
     public function testGetLockTime()


### PR DESCRIPTION
…a double