### PR TITLE
Move ScriptInterface::getAddress() 

### DIFF
--- a/src/Script/RedeemScript.php
+++ b/src/Script/RedeemScript.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Script;
 
+use BitWasp\Bitcoin\Address\AddressFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
 use BitWasp\Buffertools\Buffer;
@@ -79,6 +80,14 @@ class RedeemScript extends Script
         }
 
         return new self($m, $publicKeys);
+    }
+
+    /**
+     * @return \BitWasp\Bitcoin\Address\ScriptHashAddress
+     */
+    public function getAddress()
+    {
+        return AddressFactory::fromScript($this);
     }
 
     /**

--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -4,7 +4,6 @@ namespace BitWasp\Bitcoin\Script;
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Buffertools\Buffer;
-use BitWasp\Bitcoin\Address\AddressFactory;
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Serializable;
 
@@ -37,14 +36,6 @@ class Script extends Serializable implements ScriptInterface
     public function getBuffer()
     {
         return new Buffer($this->script);
-    }
-
-    /**
-     * @return \BitWasp\Bitcoin\Address\ScriptHashAddress
-     */
-    public function getAddress()
-    {
-        return AddressFactory::fromScript($this);
     }
 
     /**

--- a/src/Script/ScriptInterface.php
+++ b/src/Script/ScriptInterface.php
@@ -13,11 +13,6 @@ interface ScriptInterface extends SerializableInterface
     public function getScriptHash();
 
     /**
-     * @return Address
-     */
-    public function getAddress();
-
-    /**
      * @return ScriptParser
      */
     public function getScriptParser();

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -8,9 +8,11 @@ use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Script\RedeemScript;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Buffertools\Buffer;
 use Symfony\Component\Yaml\Yaml;
 
 class AddressTest extends AbstractTestCase
@@ -58,7 +60,7 @@ class AddressTest extends AbstractTestCase
         if ($type == 'pubkeyhash') {
             $obj = PublicKeyFactory::fromHex($data)->getAddress();
         } else if ($type == 'script') {
-            $obj = ScriptFactory::fromHex($data)->getAddress();
+            $obj = RedeemScript::fromScript(new Script(Buffer::hex($data)))->getAddress();
         } else {
             throw new \Exception('Unknown address type');
         }


### PR DESCRIPTION
it's confusing there, as has been highlighted in #169. It's been moved to RedeemScript, meaning only RedeemScript's can produce addresses. ScriptInterface::getScriptHash() is still there, mainly to allow AddressFactory::fromScript() to function, but this can be refactored later. 