### PR TITLE
Disable Tx/Block method caching

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -37,6 +37,7 @@
     "react/react": "~0.4",
     "react/socket-client": "~0.4",
     "bitwasp/buffertools": "~0.1",
+    "bitwasp/trait": "~0.0",
     "bitwasp/stratum": "~0.1",
     "bitwasp/secp256k1-php": "~0.0.6"
   },

--- a/src/Block/Block.php
+++ b/src/Block/Block.php
@@ -9,9 +9,12 @@ use BitWasp\Bitcoin\Serializer\Block\BlockSerializer;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializer;
 use BitWasp\Bitcoin\Collection\Transaction\TransactionCollection;
 use BitWasp\Bitcoin\Bloom\BloomFilter;
+use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
 class Block extends Serializable implements BlockInterface
 {
+    use FunctionAliasArrayAccess;
+
     /**
      * @var Math
      */
@@ -42,6 +45,10 @@ class Block extends Serializable implements BlockInterface
         $this->math = $math;
         $this->header = $header;
         $this->transactions = $transactions;
+        $this
+            ->initFunctionAlias('header', 'getHeader')
+            ->initFunctionAlias('merkleRoot', 'getMerkleRoot')
+            ->initFunctionAlias('tx', 'getTransactions');
     }
 
     /**

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -6,9 +6,12 @@ use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Serializable;
 use BitWasp\Bitcoin\Serializer\Block\BlockHeaderSerializer;
+use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
 class BlockHeader extends Serializable implements BlockHeaderInterface
 {
+    use FunctionAliasArrayAccess;
+
     /**
      * @var int|string
      */
@@ -59,6 +62,14 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
         $this->timestamp = $timestamp;
         $this->bits = $bits;
         $this->nonce = $nonce;
+
+        $this
+            ->initFunctionAlias('version', 'getVersion')
+            ->initFunctionAlias('prevBlock', 'getPrevBlock')
+            ->initFunctionAlias('merkleRoot', 'getMerkleRoot')
+            ->initFunctionAlias('timestamp', 'getTimestamp')
+            ->initFunctionAlias('bits', 'getBits')
+            ->initFunctionAlias('nonce', 'getNonce');
     }
 
     /**

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -40,11 +40,6 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     private $nonce;
 
     /**
-     * @var null|Buffer
-     */
-    private $cacheHash;
-
-    /**
      * @param int|string $version
      * @param string $prevBlock
      * @param string $merkleRoot
@@ -71,11 +66,7 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
      */
     public function getHash()
     {
-        if (null === $this->cacheHash) {
-            $this->cacheHash = Hash::sha256d($this->getBuffer())->flip();
-        }
-
-        return $this->cacheHash;
+        return Hash::sha256d($this->getBuffer())->flip();
     }
 
     /**
@@ -97,6 +88,7 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     {
         return $this->prevBlock;
     }
+    
     /**
      * {@inheritdoc}
      * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getMerkleRoot()

--- a/src/Block/BlockHeader.php
+++ b/src/Block/BlockHeader.php
@@ -88,7 +88,7 @@ class BlockHeader extends Serializable implements BlockHeaderInterface
     {
         return $this->prevBlock;
     }
-    
+
     /**
      * {@inheritdoc}
      * @see \BitWasp\Bitcoin\Block\BlockHeaderInterface::getMerkleRoot()

--- a/src/Block/BlockHeaderInterface.php
+++ b/src/Block/BlockHeaderInterface.php
@@ -5,7 +5,7 @@ namespace BitWasp\Bitcoin\Block;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\SerializableInterface;
 
-interface BlockHeaderInterface extends SerializableInterface
+interface BlockHeaderInterface extends SerializableInterface, \ArrayAccess
 {
     const CURRENT_VERSION = 2;
 

--- a/src/Block/BlockInterface.php
+++ b/src/Block/BlockInterface.php
@@ -7,7 +7,7 @@ use BitWasp\Bitcoin\SerializableInterface;
 use BitWasp\Bitcoin\Collection\Transaction\TransactionCollection;
 use BitWasp\Bitcoin\Transaction\TransactionInterface;
 
-interface BlockInterface extends SerializableInterface
+interface BlockInterface extends SerializableInterface, \ArrayAccess
 {
     const CURRENT_VERSION = 2;
     const MAX_BLOCK_SIZE = 1000000;

--- a/src/Script/Opcodes.php
+++ b/src/Script/Opcodes.php
@@ -2,7 +2,7 @@
 
 namespace BitWasp\Bitcoin\Script;
 
-class Opcodes
+class Opcodes implements \ArrayAccess
 {
 
     const OP_0 = 0;
@@ -328,6 +328,46 @@ class Opcodes
     public function isOp($op, $opCodeStr)
     {
         return $op === $this->getOpByName($opCodeStr);
+    }
+
+    /**
+     * @param int $opcode
+     * @return string
+     */
+    public function offsetGet($opcode)
+    {
+        return $this->getOp($opcode);
+    }
+
+    /**
+     * @param int $opcode
+     * @return bool
+     */
+    public function offsetExists($opcode)
+    {
+        return isset(self::$names[$opcode]);
+    }
+
+    private function errorNoWrite()
+    {
+        throw new \RuntimeException('Cannot write to Opcodes');
+    }
+
+    /**
+     * @param int $opcode
+     */
+    public function offsetUnset($opcode)
+    {
+        $this->errorNoWrite();
+    }
+
+    /**
+     * @param int $opcode
+     * @param mixed $value
+     */
+    public function offsetSet($opcode, $value)
+    {
+        $this->errorNoWrite();
     }
 
     /**

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -10,9 +10,12 @@ use BitWasp\Bitcoin\Serializable;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializer;
 use BitWasp\Bitcoin\Transaction\SignatureHash\Hasher;
 use BitWasp\Buffertools\Buffer;
+use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
-class Transaction extends Serializable implements TransactionInterface
+class Transaction extends Serializable implements TransactionInterface, \ArrayAccess
 {
+    use FunctionAliasArrayAccess;
+
     /**
      * @var int|string
      */
@@ -68,6 +71,12 @@ class Transaction extends Serializable implements TransactionInterface
         $this->inputs = $inputs ?: new TransactionInputCollection();
         $this->outputs = $outputs ?: new TransactionOutputCollection();
         $this->lockTime = $nLockTime;
+
+        $this
+            ->initFunctionAlias('version', 'getVersion')
+            ->initFunctionAlias('inputs', 'getInputs')
+            ->initFunctionAlias('outputs', 'getOutputs')
+            ->initFunctionAlias('locktime', 'getLockTime');
     }
 
     /**

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -34,21 +34,6 @@ class Transaction extends Serializable implements TransactionInterface
     private $lockTime;
 
     /**
-     * @var null|Buffer
-     */
-    private $cacheHash;
-
-    /**
-     * @var null|Buffer
-     */
-    private $cacheTxid;
-
-    /**
-     * @var null|Buffer
-     */
-    private $cacheBuffer;
-
-    /**
      * @param int|string $nVersion
      * @param TransactionInputCollection $inputs
      * @param TransactionOutputCollection $outputs
@@ -99,11 +84,7 @@ class Transaction extends Serializable implements TransactionInterface
      */
     public function getTxHash()
     {
-        if (null === $this->cacheHash) {
-            $this->cacheHash = Hash::sha256d($this->getBuffer());
-        }
-
-        return $this->cacheHash;
+        return Hash::sha256d($this->getBuffer());
     }
 
     /**
@@ -111,11 +92,7 @@ class Transaction extends Serializable implements TransactionInterface
      */
     public function getTxId()
     {
-        if (null === $this->cacheTxid) {
-            $this->cacheTxid = $this->getTxHash()->flip();
-        }
-
-        return $this->cacheTxid;
+        return $this->getTxHash()->flip();
     }
 
     /**
@@ -209,10 +186,6 @@ class Transaction extends Serializable implements TransactionInterface
      */
     public function getBuffer()
     {
-        if (null === $this->cacheBuffer) {
-            $this->cacheBuffer = (new TransactionSerializer)->serialize($this);
-        }
-
-        return $this->cacheBuffer;
+        return (new TransactionSerializer)->serialize($this);
     }
 }

--- a/src/Transaction/Transaction.php
+++ b/src/Transaction/Transaction.php
@@ -12,7 +12,7 @@ use BitWasp\Bitcoin\Transaction\SignatureHash\Hasher;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
-class Transaction extends Serializable implements TransactionInterface, \ArrayAccess
+class Transaction extends Serializable implements TransactionInterface
 {
     use FunctionAliasArrayAccess;
 

--- a/src/Transaction/TransactionInput.php
+++ b/src/Transaction/TransactionInput.php
@@ -10,7 +10,7 @@ use BitWasp\Bitcoin\Serializable;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionInputSerializer;
 use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
-class TransactionInput extends Serializable implements TransactionInputInterface, \ArrayAccess
+class TransactionInput extends Serializable implements TransactionInputInterface
 {
     use FunctionAliasArrayAccess;
 

--- a/src/Transaction/TransactionInput.php
+++ b/src/Transaction/TransactionInput.php
@@ -8,9 +8,12 @@ use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Serializable;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionInputSerializer;
+use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
-class TransactionInput extends Serializable implements TransactionInputInterface
+class TransactionInput extends Serializable implements TransactionInputInterface, \ArrayAccess
 {
+    use FunctionAliasArrayAccess;
+
     /**
      * @var string
      */
@@ -51,6 +54,11 @@ class TransactionInput extends Serializable implements TransactionInputInterface
         $this->nPrevOut = $nPrevOut;
         $this->script = $script ?: new Script();
         $this->sequence = $sequence;
+        $this
+            ->initFunctionAlias('txid', 'getTransactionId')
+            ->initFunctionAlias('vout', 'getVout')
+            ->initFunctionAlias('script', 'getScript')
+            ->initFunctionAlias('sequence', 'getSequence');
     }
 
     /**

--- a/src/Transaction/TransactionInputInterface.php
+++ b/src/Transaction/TransactionInputInterface.php
@@ -4,7 +4,7 @@ namespace BitWasp\Bitcoin\Transaction;
 
 use BitWasp\Bitcoin\Script\ScriptInterface;
 
-interface TransactionInputInterface
+interface TransactionInputInterface extends \ArrayAccess
 {
     /**
      * The default sequence.

--- a/src/Transaction/TransactionInterface.php
+++ b/src/Transaction/TransactionInterface.php
@@ -8,7 +8,7 @@ use BitWasp\Bitcoin\SerializableInterface;
 use BitWasp\Bitcoin\Transaction\SignatureHash\SignatureHashInterface;
 use BitWasp\Buffertools\Buffer;
 
-interface TransactionInterface extends SerializableInterface
+interface TransactionInterface extends SerializableInterface, \ArrayAccess
 {
     const DEFAULT_VERSION = 1;
 

--- a/src/Transaction/TransactionOutput.php
+++ b/src/Transaction/TransactionOutput.php
@@ -5,9 +5,12 @@ namespace BitWasp\Bitcoin\Transaction;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Serializable;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionOutputSerializer;
+use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
-class TransactionOutput extends Serializable implements TransactionOutputInterface
+class TransactionOutput extends Serializable implements TransactionOutputInterface, \ArrayAccess
 {
+    use FunctionAliasArrayAccess;
+
     /**
      * @var string|int
      */
@@ -28,6 +31,9 @@ class TransactionOutput extends Serializable implements TransactionOutputInterfa
     {
         $this->value = $value;
         $this->script = $script;
+        $this
+            ->initFunctionAlias('value', 'getValue')
+            ->initFunctionAlias('script', 'getScript');
     }
 
     /**

--- a/src/Transaction/TransactionOutput.php
+++ b/src/Transaction/TransactionOutput.php
@@ -7,7 +7,7 @@ use BitWasp\Bitcoin\Serializable;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionOutputSerializer;
 use BitWasp\CommonTrait\FunctionAliasArrayAccess;
 
-class TransactionOutput extends Serializable implements TransactionOutputInterface, \ArrayAccess
+class TransactionOutput extends Serializable implements TransactionOutputInterface
 {
     use FunctionAliasArrayAccess;
 

--- a/src/Transaction/TransactionOutputInterface.php
+++ b/src/Transaction/TransactionOutputInterface.php
@@ -5,7 +5,7 @@ namespace BitWasp\Bitcoin\Transaction;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\SerializableInterface;
 
-interface TransactionOutputInterface extends SerializableInterface
+interface TransactionOutputInterface extends SerializableInterface, \ArrayAccess
 {
     /**
      * Get the value of this output

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -15,6 +15,10 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      */
     protected $netInterfaceType = 'BitWasp\Bitcoin\Network\NetworkInterface';
 
+    /**
+     * @var string
+     */
+    protected $scriptType = 'BitWasp\Bitcoin\Script\Script';
     protected $scriptInterfaceType = 'BitWasp\Bitcoin\Script\ScriptInterface';
     protected $outScriptFactoryType = 'BitWasp\Bitcoin\Script\Factory\OutputScriptFactory';
     protected $inScriptFactoryType = 'BitWasp\Bitcoin\Script\Factory\InputScriptFactory';
@@ -23,7 +27,10 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
      * @var string
      */
     protected $txType = 'BitWasp\Bitcoin\Transaction\Transaction';
-
+    /**
+     * @var string
+     */
+    protected $txOutType = 'BitWasp\Bitcoin\Transaction\TransactionOutput';
     /**
      * @var string
      */

--- a/tests/Block/BlockHeaderTest.php
+++ b/tests/Block/BlockHeaderTest.php
@@ -49,6 +49,11 @@ class BlockHeaderTest extends AbstractTestCase
         $this->assertEquals($merkleRoot, $header->getMerkleRoot());
         $this->assertEquals($time, $header->getTimestamp());
         $this->assertEquals($nonce, $header->getNonce());
+        $this->assertEquals($version, $header['version']);
+        $this->assertEquals($prevBlock, $header['prevBlock']);
+        $this->assertEquals($merkleRoot, $header['merkleRoot']);
+        $this->assertEquals($time, $header['timestamp']);
+        $this->assertEquals($nonce, $header['nonce']);
 
     }
 

--- a/tests/Block/BlockTest.php
+++ b/tests/Block/BlockTest.php
@@ -55,8 +55,11 @@ class BlockTest extends AbstractTestCase
     public function testSetHeader()
     {
         $header = $this->getBlockHeader();
-        $block = new Block(new Math(), $header, new TransactionCollection());
+        $txs = new TransactionCollection();
+        $block = new Block(new Math(), $header, $txs);
         $this->assertSame($header, $block->getHeader());
+        $this->assertSame($header, $block['header']);
+        $this->assertSame($txs, $block['tx']);
     }
 
     public function testGetTransactions()
@@ -87,6 +90,7 @@ class BlockTest extends AbstractTestCase
         $block = new Block(new Math(), new BlockHeader(1, 1, 1, 1, new Buffer(), 1), $txCollection);
 
         $this->assertEquals($tx->getTxId()->getHex(), $block->getMerkleRoot());
+        $this->assertEquals($tx->getTxId()->getHex(), $block['merkleRoot']);
     }
 
     public function testFromParser()

--- a/tests/Script/OpcodesTest.php
+++ b/tests/Script/OpcodesTest.php
@@ -10,8 +10,11 @@ class OpcodesTest extends \PHPUnit_Framework_TestCase
     {
         $op = new OpCodes;
         $expected = 0;
+        $lookupOpName = 'OP_0';
         $val = $op->getOpByName('OP_0');
         $this->assertSame($expected, $val);
+        $this->assertTrue(isset($op[Opcodes::OP_0]));
+        $this->assertSame($lookupOpName, $op[Opcodes::OP_0]);
     }
 
     /**

--- a/tests/Transaction/TransactionInputTest.php
+++ b/tests/Transaction/TransactionInputTest.php
@@ -61,6 +61,11 @@ class TransactionInputTest extends \PHPUnit_Framework_TestCase
         $this->assertSame($vout, $t->getVout());
         $this->assertSame($script, $t->getScript());
         $this->assertSame($sequence, $t->getSequence());
+        $this->assertSame($txid, $t['txid']);
+        $this->assertSame($vout, $t['vout']);
+        $this->assertSame($script, $t['script']);
+        $this->assertSame($sequence, $t['sequence']);
+
     }
 
     public function testGetScript()

--- a/tests/Transaction/TransactionOutputTest.php
+++ b/tests/Transaction/TransactionOutputTest.php
@@ -3,32 +3,14 @@
 namespace BitWasp\Bitcoin\Tests\Transaction;
 
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionOutputSerializer;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\Parser;
 
-class TransactionOutputTest extends \PHPUnit_Framework_TestCase
+class TransactionOutputTest extends AbstractTestCase
 {
-    /**
-     * @var string
-     */
-    private $txOutType = 'BitWasp\Bitcoin\Transaction\TransactionOutput';
-    /**
-     * @var string
-     */
-    private $scriptType = 'BitWasp\Bitcoin\Script\Script';
-
-    /**
-     * @var TransactionOutputSerializer
-     */
-    protected $serializer;
-
-    public function setUp()
-    {
-
-        $this->serializer = new TransactionOutputSerializer();
-    }
 
     public function testGetValueDefault()
     {
@@ -37,14 +19,17 @@ class TransactionOutputTest extends \PHPUnit_Framework_TestCase
 
         $out = new TransactionOutput(10901, new Script());
         $this->assertSame(10901, $out->getValue());
+        $this->assertSame(10901, $out['value']);
+
     }
 
     public function testGetScript()
     {
-        $out = new TransactionOutput(1, new Script());
+        $testScript = new Script(Buffer::hex('414141'));
+        $out = new TransactionOutput(1, $testScript);
         $script = $out->getScript();
         $this->assertInstanceOf($this->scriptType, $script);
-        $this->assertEmpty($script->getBuffer()->getBinary());
+        $this->assertSame($testScript, $out['script']);
     }
 
     public function testFromParser()

--- a/tests/Transaction/TransactionTest.php
+++ b/tests/Transaction/TransactionTest.php
@@ -120,6 +120,10 @@ class TransactionTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $tx->getLocktime());
         $this->assertEquals(20, count($tx->getInputs()));
         $this->assertEquals(19, count($tx->getOutputs()));
+        $this->assertEquals(1, $tx['version']);
+        $this->assertEquals(0, $tx['locktime']);
+        $this->assertEquals($tx->getInputs(), $tx['inputs']);
+        $this->assertEquals($tx->getOutputs(), $tx['outputs']);
 
         $serialized = $tx->getBuffer()->getHex();
         $this->assertSame($hex, $serialized);


### PR DESCRIPTION
And expose ArrayAccess on TransactionInterface, TransactionOutputInterface, TransactionInputInterface, BlockHeaderInterface, BlockInterface, with array key aliases to functions with usually much longer names. 