### PR TITLE
Test consensus interface

### DIFF
--- a/examples/script.decode.php
+++ b/examples/script.decode.php
@@ -1,0 +1,9 @@
+<?php
+
+require_once "../vendor/autoload.php";
+
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Transaction\Transaction;
+
+$script = ScriptFactory::fromHex($argv[1]);
+print_r($script->getScriptParser()->getHumanReadable());

--- a/src/Script/Consensus/BitcoinConsensus.php
+++ b/src/Script/Consensus/BitcoinConsensus.php
@@ -6,7 +6,7 @@ use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Flags;
 use BitWasp\Bitcoin\Transaction\TransactionInterface;
 
-class BitcoinConsensus
+class BitcoinConsensus implements ConsensusInterface
 {
     /**
      * @var Flags

--- a/src/Script/Consensus/BitcoinConsensus.php
+++ b/src/Script/Consensus/BitcoinConsensus.php
@@ -30,12 +30,16 @@ class BitcoinConsensus implements ConsensusInterface
     public function verify(TransactionInterface $tx, ScriptInterface $scriptPubKey, $nInputToSign)
     {
         $error = 0;
-        return (bool) bitcoinconsensus_verify_script(
+        $result = (bool) bitcoinconsensus_verify_script(
             $scriptPubKey->getBinary(),
-            $tx->getbinary(),
+            $tx->getBinary(),
             $nInputToSign,
             $this->flags->getFlags(),
             $error
         );
+        if ($error !== 0) {
+            var_dump($error);
+        }
+        return $result;
     }
 }

--- a/src/Script/Consensus/ConsensusInterface.php
+++ b/src/Script/Consensus/ConsensusInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace BitWasp\Bitcoin\Script\Consensus;
+
+
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Transaction\TransactionInterface;
+
+interface ConsensusInterface
+{
+    /**
+     * @param TransactionInterface $tx
+     * @param ScriptInterface $scriptPubKey
+     * @param integer $nInputToSign
+     */
+    public function verify(TransactionInterface $tx, ScriptInterface $scriptPubKey, $nInputToSign);
+}

--- a/src/Script/Consensus/ConsensusInterface.php
+++ b/src/Script/Consensus/ConsensusInterface.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Bitcoin\Script\Consensus;
 
-
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Transaction\TransactionInterface;
 

--- a/src/Script/Consensus/NativeConsensus.php
+++ b/src/Script/Consensus/NativeConsensus.php
@@ -6,7 +6,7 @@ use BitWasp\Bitcoin\Script\Interpreter\InterpreterFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Transaction\TransactionInterface;
 
-class NativeConsensus
+class NativeConsensus implements ConsensusInterface
 {
     /**
      * @var InterpreterFactory

--- a/src/Script/ConsensusFactory.php
+++ b/src/Script/ConsensusFactory.php
@@ -5,6 +5,7 @@ namespace BitWasp\Bitcoin\Script;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Flags;
 use BitWasp\Bitcoin\Script\Consensus\BitcoinConsensus;
+use BitWasp\Bitcoin\Script\Consensus\ConsensusInterface;
 use BitWasp\Bitcoin\Script\Consensus\NativeConsensus;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface;
@@ -74,7 +75,7 @@ class ConsensusFactory
 
     /**
      * @param Flags $flags
-     * @return BitcoinConsensus|NativeConsensus
+     * @return ConsensusInterface
      */
     public function getConsensus(Flags $flags)
     {

--- a/src/Script/Interpreter/Interpreter.php
+++ b/src/Script/Interpreter/Interpreter.php
@@ -452,7 +452,6 @@ class Interpreter implements InterpreterInterface
                 } elseif ($fExec || ($opCode !== Opcodes::OP_IF && $opCode !== Opcodes::OP_ENDIF)) {
                      //echo "OPCODE - " . $this->script->getOpCodes()->getOp($opCode) . "\n";
                     switch ($opCode) {
-
                         case Opcodes::OP_1:
                         case Opcodes::OP_2:
                         case Opcodes::OP_3:

--- a/src/Script/Interpreter/ScriptNum.php
+++ b/src/Script/Interpreter/ScriptNum.php
@@ -27,16 +27,20 @@ class ScriptNum extends Buffer
 
         $bufferSize = $vch->getSize();
         if ($bufferSize > $size) {
-            throw new ScriptStackException(InterpreterInterface::VERIFY_MINIMALDATA, 'Script number overflow');
+            throw new ScriptStackException('a'.InterpreterInterface::VERIFY_MINIMALDATA);//, 'Script number overflow');
         }
 
         $str = $vch->getBinary();
         if ($flags->checkFlags(InterpreterInterface::VERIFY_MINIMALDATA) && $bufferSize > 0) {
             if ((ord($str[0]) & 0x7f) === 0) {
                 if ($bufferSize <= 1 || (ord($str[1]) & 0x7f) === 0) {
-                    throw new ScriptStackException(InterpreterInterface::VERIFY_MINIMALDATA, 'Non-minimally encoded integer');
+                    throw new ScriptStackException('b'.InterpreterInterface::VERIFY_MINIMALDATA);//, 'Non-minimally encoded integer');
                 }
             }
+        }
+
+        if ($bufferSize === 0) {
+            $str = "\x00";
         }
 
         $this->math = $math;

--- a/src/Script/ScriptParser.php
+++ b/src/Script/ScriptParser.php
@@ -107,7 +107,6 @@ class ScriptParser
         if ($opCode == Opcodes::OP_0) {
             $pushData = new Buffer('', 0);
         } elseif ($opCode <= Opcodes::OP_PUSHDATA4) {
-
             if ($opCode < Opcodes::OP_PUSHDATA1) {
                 $size = $opCode;
             } else if ($opCode === Opcodes::OP_PUSHDATA1) {

--- a/src/Script/ScriptParser.php
+++ b/src/Script/ScriptParser.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Script;
 
+use BitWasp\Bitcoin\Script\Interpreter\ScriptNum;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\Math\Math;
 
@@ -103,7 +104,10 @@ class ScriptParser
 
         $opCode = $this->getNextOp();
 
-        if ($opCode <= Opcodes::OP_PUSHDATA4) {
+        if ($opCode == Opcodes::OP_0) {
+            $pushData = new Buffer('', 0);
+        } elseif ($opCode <= Opcodes::OP_PUSHDATA4) {
+
             if ($opCode < Opcodes::OP_PUSHDATA1) {
                 $size = $opCode;
             } else if ($opCode === Opcodes::OP_PUSHDATA1) {
@@ -120,6 +124,7 @@ class ScriptParser
 
             $pushData = new Buffer(substr($this->scriptRaw, $this->ptr, $size), $size, $this->math);
             $this->ptr += $size;
+
         }
 
         return true;

--- a/src/Script/ScriptParser.php
+++ b/src/Script/ScriptParser.php
@@ -144,7 +144,7 @@ class ScriptParser
         $data = array();
         $pushData = new Buffer('', 0, $this->math);
         while ($this->next($opCode, $pushData)) {
-            if ($opCode < 1) {
+            if ($opCode == 0) {
                 $push = Buffer::hex('00', 1, $this->math);
             } elseif ($opCode <= 78) {
                 $push = $pushData;

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -7,6 +7,7 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\EcAdapterFactory;
 use BitWasp\Bitcoin\Math\Math;
 use Mdanter\Ecc\EccFactory;
 use \BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Adapter\EcAdapter as PhpEccAdapter;
+use BitWasp\Bitcoin\Flags;
 
 abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
 {

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -175,6 +175,24 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
         return $adapters;
     }
 
+    /**
+     * @param $flagStr
+     * @return Flags
+     */
+    public function getInterpreterFlags($flagStr)
+    {
+        $array = explode(",", $flagStr);
+        $int = 0;
+        $checkdisabled = false;
+        foreach ($array as $activeFlag) {
+            $f = constant('\BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface::'.$activeFlag);
+            $int |= $f;
+        }
+
+        return new Flags($int, $checkdisabled);
+    }
+
+
     public function safeMath()
     {
         return new Math();

--- a/tests/Data/scriptinterpreter.simple.json
+++ b/tests/Data/scriptinterpreter.simple.json
@@ -2,7 +2,7 @@
   "test":[
     {
       "scriptSig": "",
-      "scriptPubKey": "74010087",
+      "scriptPubKey": "740087",
       "result": true,
       "flags": "VERIFY_P2SH,VERIFY_STRICTENC",
       "desc": "OP_DEPTH 0 OP_EQUAL"
@@ -86,38 +86,38 @@
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "0100aa201406e05881e299367766d313e26c05564ec91bf721d31726bd6e46e60689539a88",
+      "scriptPubKey": "0100aa201406e05881e299367766d313e26c05564ec91bf721d31726bd6e46e60689539a87",
       "result": true,
       "flags": "VERIFY_P2SH,VERIFY_STRICTENC",
-      "desc": "00 OP_HASH256 [32 byte hash] OP_EQUALVERIFY"
+      "desc": "00 OP_HASH256 [32 byte hash] OP_EQUAL"
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "0100a9149f7fd096d37ed2c0e3f7f0cfc924beef4ffceb6888",
+      "scriptPubKey": "0100a9149f7fd096d37ed2c0e3f7f0cfc924beef4ffceb6887",
       "result": true,
       "flags": "VERIFY_P2SH,VERIFY_STRICTENC",
-      "desc": "00 OP_HASH160 [20 byte hash] OP_EQUALVERIFY"
+      "desc": "00 OP_HASH160 [20 byte hash] OP_EQUAL"
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "0100a8206e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d88",
+      "scriptPubKey": "0100a8206e340b9cffb37a989ca544e6bb780a2c78901d3fb33738768511a30617afa01d87",
       "result": true,
       "flags": "VERIFY_P2SH,VERIFY_STRICTENC",
-      "desc": "00 OP_SHA256 [32 byte hash] OP_EQUALVERIFY"
+      "desc": "00 OP_SHA256 [32 byte hash] OP_EQUAL"
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "0100a7145ba93c9db0cff93f52b521d7420e43f6eda2784f88",
+      "scriptPubKey": "0100a7145ba93c9db0cff93f52b521d7420e43f6eda2784f87",
       "result": true,
       "flags": "VERIFY_P2SH,VERIFY_STRICTENC",
-      "desc": "00 OP_SHA1 [20 byte hash] OP_EQUALVERIFY"
+      "desc": "00 OP_SHA1 [20 byte hash] OP_EQUAL"
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "0100a614c81b94933420221a7ac004a90242d8b1d3e5070d88",
+      "scriptPubKey": "0100a614c81b94933420221a7ac004a90242d8b1d3e5070d87",
       "result": true,
       "flags": "VERIFY_P2SH,VERIFY_STRICTENC",
-      "desc": "00 OP_RIPEMD160 [20 byte hash] OP_EQUALVERIFY"
+      "desc": "00 OP_RIPEMD160 [20 byte hash] OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -149,10 +149,10 @@
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "01007676768888",
+      "scriptPubKey": "01007676768887",
       "result": true,
       "flags": "VERIFY_P2SH,VERIFY_STRICTENC",
-      "desc": "00 OP_DUP OP_DUP OP_EQUALVERIFY OP_EQUALVERIFY"
+      "desc": "00 OP_DUP OP_DUP OP_EQUALVERIFY OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -184,13 +184,6 @@
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "b0",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "upgradable nop without discourage flag"
-    },
-    {
-      "scriptSig": "",
       "scriptPubKey": "6a",
       "result": false,
       "flags": "VERIFY_STRICTENC",
@@ -198,10 +191,10 @@
     },
     {
       "scriptSig": "010001006d",
-      "scriptPubKey": "74010088",
+      "scriptPubKey": "740087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 00 OP_2DROP - OP_DEPTH 00 OP_EQUALVERIFY"
+      "desc": "00 00 OP_2DROP - OP_DEPTH 0 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -212,17 +205,17 @@
     },
     {
       "scriptSig": "010001006e",
-      "scriptPubKey": "74010488",
+      "scriptPubKey": "745487",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 00 OP_2DUP OP_DEPTH 04 OP_EQUALVERIFY"
+      "desc": "00 00 OP_2DUP OP_DEPTH OP_4 OP_EQUAL"
     },
     {
       "scriptSig": "010101026e",
-      "scriptPubKey": "010288010188010288010188",
+      "scriptPubKey": "010288010188010288010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_2DUP 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY"
+      "desc": "01 02 OP_2DUP 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -233,17 +226,17 @@
     },
     {
       "scriptSig": "0100010001006f",
-      "scriptPubKey": "74010688",
+      "scriptPubKey": "74010687",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 00 00 OP_3DUP OP_DEPTH 06 OP_EQUALVERIFY"
+      "desc": "00 00 00 OP_3DUP OP_DEPTH 06 OP_EQUAL"
     },
     {
       "scriptSig": "0101010201036f",
-      "scriptPubKey": "010388010288010188010388010288010188",
+      "scriptPubKey": "010388010288010188010388010288010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 03 OP_3DUP 03 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 03 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY"
+      "desc": "01 02 03 OP_3DUP 03 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 03 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -261,10 +254,10 @@
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "010169",
+      "scriptPubKey": "0101010169",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_VERIFY"
+      "desc": "01 01 OP_VERIFY"
     },
     {
       "scriptSig": "",
@@ -289,13 +282,6 @@
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "010075",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "00 OP_DROP"
-    },
-    {
-      "scriptSig": "",
       "scriptPubKey": "75",
       "result": false,
       "flags": "VERIFY_STRICTENC",
@@ -310,17 +296,17 @@
     },
     {
       "scriptSig": "01010102",
-      "scriptPubKey": "7774010188",
+      "scriptPubKey": "7774010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_NIP OP_DEPTH 01 OP_EQUALVERIFY"
+      "desc": "01 02 OP_NIP OP_DEPTH 01 OP_EQUAL"
     },
     {
       "scriptSig": "01010102",
-      "scriptPubKey": "77010288",
+      "scriptPubKey": "77010287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_NIP 02 OP_EQUALVERIFY"
+      "desc": "01 02 OP_NIP 02 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -331,17 +317,17 @@
     },
     {
       "scriptSig": "01010102",
-      "scriptPubKey": "780101880288010188",
+      "scriptPubKey": "780101880288010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_OVER 01 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY"
+      "desc": "01 02 OP_OVER 01 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUAL"
     },
     {
       "scriptSig": "01010102",
-      "scriptPubKey": "7874010388",
+      "scriptPubKey": "7874010387",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_OVER OP_DEPTH 03 OP_EQUALVERIFY"
+      "desc": "01 02 OP_OVER OP_DEPTH 03 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -352,10 +338,10 @@
     },
     {
       "scriptSig": "0101010201030104",
-      "scriptPubKey": "7001028801018804880103880288010188",
+      "scriptPubKey": "7001028801018804880103880288010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 03 04 OP_2OVER 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 04 OP_EQUALVERIFY 03 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY"
+      "desc": "01 02 03 04 OP_2OVER 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 04 OP_EQUALVERIFY 03 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUAL"
     },
     {
       "scriptSig": "0101010201030104",
@@ -387,17 +373,17 @@
     },
     {
       "scriptSig": "01010102",
-      "scriptPubKey": "7c010188010288",
+      "scriptPubKey": "7c010188010287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_SWAP 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY"
+      "desc": "01 02 OP_SWAP 02 OP_EQUALVERIFY 01 OP_EQUAL"
     },
     {
       "scriptSig": "0101010201030104",
-      "scriptPubKey": "72010288010188010488010388",
+      "scriptPubKey": "72010288010188010488010387",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 03 04 OP_2SWAP 03 OP_EQUALVERIFY 04 OP_EQUALVERIFY 01 OP_EQUALVERIFY 02 OP_EQUALVERIFY"
+      "desc": "01 02 03 04 OP_2SWAP 03 OP_EQUALVERIFY 04 OP_EQUALVERIFY 01 OP_EQUALVERIFY 02 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -415,7 +401,7 @@
     },
     {
       "scriptSig": "010101020103",
-      "scriptPubKey": "7b010188010388010288",
+      "scriptPubKey": "7b010188010388010287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "01 02 03 OP_ROT"
@@ -436,17 +422,17 @@
     },
     {
       "scriptSig": "010001010102",
-      "scriptPubKey": "010279010088010288010188010088",
+      "scriptPubKey": "010279010088010288010188010087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 01 02 <2> OP_PICK 00 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 00 OP_EQUALVERIFY"
+      "desc": "00 01 02 <2> OP_PICK 00 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 00 OP_EQUAL"
     },
     {
       "scriptSig": "010001010102",
-      "scriptPubKey": "01017a010188010288010088",
+      "scriptPubKey": "01017a010188010288010087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 01 02 <0> OP_ROLL 02 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY OP_DEPTH 00 OP_EQUALVERIFY"
+      "desc": "00 01 02 <0> OP_ROLL 02 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY OP_DEPTH 00 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -457,10 +443,10 @@
     },
     {
       "scriptSig": "",
-      "scriptPubKey": "03010203820103880301020388",
+      "scriptPubKey": "03010203820103880301020387",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "010203 OP_SIZE 03 OP_EQUALVERIFY 010203 OP_EQUALVERIFY"
+      "desc": "010203 OP_SIZE 03 OP_EQUALVERIFY 010203 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -471,10 +457,10 @@
     },
     {
       "scriptSig": "0101",
-      "scriptPubKey": "7374010288010188010188",
+      "scriptPubKey": "7374010288010188010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_IFDUP OP_DEPTH 02 OP_EQUALVERIFY "
+      "desc": "01 OP_IFDUP OP_DEPTH 02 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -485,10 +471,10 @@
     },
     {
       "scriptSig": "010101020103010401050106",
-      "scriptPubKey": "71010288010188010688010588010488010388",
+      "scriptPubKey": "71010288010188010688010588010488010387",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 03 04 05 06 OP_2ROT 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 06 OP_EQUALVERIFY 05  OP_EQUALVERIFY 04  OP_EQUALVERIFY 03 OP_EQUALVERIFY"
+      "desc": "01 02 03 04 05 06 OP_2ROT 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 06 OP_EQUALVERIFY 05  OP_EQUALVERIFY 04  OP_EQUALVERIFY 03 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -505,18 +491,18 @@
       "desc": "OP_TOALTSTACK"
     },
     {
-      "scriptSig": "0100",
-      "scriptPubKey": "6b74010088",
+      "scriptSig": "00",
+      "scriptPubKey": "6b740087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 OP_TOALTSTACK OP_DEPTH 00 OP_EQUALVERIFY"
+      "desc": "OP_0 OP_TOALTSTACK OP_DEPTH OP_0 OP_EQUAL"
     },
     {
-      "scriptSig": "0100",
-      "scriptPubKey": "6b740100886c74010188010088",
+      "scriptSig": "00",
+      "scriptPubKey": "6b7400886c7451880087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 OP_TOALTSTACK OP_DEPTH 00 OP_EQUALVERIFY OP_FROMALTSTACK OP_DEPTH 01 OP_EQUALVERIFY 00 OP_EQUALVERIFY"
+      "desc": "OP_0 OP_TOALTSTACK OP_DEPTH 0 OP_EQUALVERIFY OP_FROMALTSTACK OP_DEPTH OP_1 OP_EQUALVERIFY OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -527,24 +513,24 @@
     },
     {
       "scriptSig": "0101",
-      "scriptPubKey": "8b010288",
+      "scriptPubKey": "8b010287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_1ADD 02 OP_EQUALVERIFY"
+      "desc": "01 OP_1ADD 02 OP_EQUAL"
     },
     {
       "scriptSig": "0102",
-      "scriptPubKey": "8c010188",
+      "scriptPubKey": "8c010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_1SUB 00 OP_EQUALVERIFY"
+      "desc": "01 OP_1SUB 00 OP_EQUAL"
     },
     {
       "scriptSig": "0101",
-      "scriptPubKey": "8d010288",
+      "scriptPubKey": "8d010287",
       "result": false,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_2MUL 02 OP_EQUALVERIFY"
+      "desc": "01 OP_2MUL 02 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -555,10 +541,10 @@
     },
     {
       "scriptSig": "01010101",
-      "scriptPubKey": "9374010188010288",
+      "scriptPubKey": "9374010188010287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 1 OP_ADD OP_DEPTH 01 OP_EQUALVERIFY 02 OP_EQUALVERIFY"
+      "desc": "1 1 OP_ADD OP_DEPTH 01 OP_EQUALVERIFY 02 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -568,11 +554,11 @@
       "desc": "OP_SUB"
     },
     {
-      "scriptSig": "01010101",
-      "scriptPubKey": "9474010188010088",
+      "scriptSig": "5151",
+      "scriptPubKey": "947451880087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 1 OP_SUB OP_DEPTH 01 OP_EQUALVERIFY 00 OP_EQUALVERIFY"
+      "desc": "OP_1 OP_1 OP_SUB OP_DEPTH OP_1 OP_EQUALVERIFY OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -583,10 +569,10 @@
     },
     {
       "scriptSig": "01010101",
-      "scriptPubKey": "9c010188",
+      "scriptPubKey": "9c010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 1 OP_NUMEQUAL 00 OP_EQUALVERIFY"
+      "desc": "1 1 OP_NUMEQUAL 00 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -597,164 +583,157 @@
     },
     {
       "scriptSig": "01010101",
-      "scriptPubKey": "9d",
+      "scriptPubKey": "9c",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 1 OP_NUMEQUAL 00 OP_EQUALVERIFY"
+      "desc": "1 1 OP_NUMEQUAL 00 OP_NUMEQUAL"
     },
     {
       "scriptSig": "01010100",
-      "scriptPubKey": "9d",
-      "result": false,
+      "scriptPubKey": "a4010187",
+      "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 0 OP_NUMEQUAL 00 OP_EQUALVERIFY"
+      "desc": "1 0 OP_MAX 01 OP_EQUAL"
+    },
+    {
+      "scriptSig": "5100",
+      "scriptPubKey": "a30087",
+      "result": true,
+      "flags": "VERIFY_STRICTENC",
+      "desc": "OP_1 OP_0 OP_MIN OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "01010100",
-      "scriptPubKey": "a4010188",
+      "scriptPubKey": "9e010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 0 OP_MAX 01 OP_EQUALVERIFY"
-    },
-    {
-      "scriptSig": "01010100",
-      "scriptPubKey": "a3010088",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "1 0 OP_MIN 00 OP_EQUALVERIFY"
-    },
-    {
-      "scriptSig": "01010100",
-      "scriptPubKey": "9e010188",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "1 0 OP_NUMNOTEQUAL 01 OP_EQUALVERIFY"
+      "desc": "1 0 OP_NUMNOTEQUAL 01 OP_EQUAL"
     },
     {
       "scriptSig": "012e0111",
-      "scriptPubKey": "9f010088",
+      "scriptPubKey": "9f0087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_LESSTHAN 00 OP_EQUALVERIFY"
+      "desc": "46 17 OP_LESSTHAN OP_0 OP_EQUAL"
+    },
+    {
+      "scriptSig": "5100",
+      "scriptPubKey": "a05187",
+      "result": true,
+      "flags": "VERIFY_STRICTENC",
+      "desc": "OP_0 OP_1 OP_GREATERTHAN OP_1 OP_EQUAL"
+    },
+    {
+      "scriptSig": "0111012e",
+      "scriptPubKey": "9f5187",
+      "result": true,
+      "flags": "VERIFY_STRICTENC",
+      "desc": "46 17 OP_LESSTHAN OP_1 OP_EQUAL"
+    },
+    {
+      "scriptSig": "0111012e",
+      "scriptPubKey": "a00087",
+      "result": true,
+      "flags": "VERIFY_STRICTENC",
+      "desc": "46 17 OP_GREATERTHAN OP_0 OP_EQUAL"
+    },
+    {
+      "scriptSig": "0111012e",
+      "scriptPubKey": "a1010187",
+      "result": true,
+      "flags": "VERIFY_STRICTENC",
+      "desc": "46 17 OP_LESSTHANEQUALTO 01 OP_EQUAL"
     },
     {
       "scriptSig": "012e0111",
-      "scriptPubKey": "a0010188",
+      "scriptPubKey": "a2010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_GREATERTHAN 01 OP_EQUALVERIFY"
-    },
-    {
-      "scriptSig": "0111012e",
-      "scriptPubKey": "9f010188",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_LESSTHAN 01 OP_EQUALVERIFY"
-    },
-    {
-      "scriptSig": "0111012e",
-      "scriptPubKey": "a0010088",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_GREATERTHAN 00 OP_EQUALVERIFY"
-    },
-    {
-      "scriptSig": "0111012e",
-      "scriptPubKey": "a1010188",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_LESSTHANEQUALTO 01 OP_EQUALVERIFY"
-    },
-    {
-      "scriptSig": "012e0111",
-      "scriptPubKey": "a2010188",
-      "result": true,
-      "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_GREATERTHANEQUALTO 01 OP_EQUALVERIFY"
+      "desc": "46 17 OP_GREATERTHANEQUALTO 01 OP_EQUAL"
     },
     {
       "scriptSig": "012e012e",
-      "scriptPubKey": "a2010188",
+      "scriptPubKey": "a2010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 46 OP_GREATERTHANEQUALTO 01 OP_EQUALVERIFY"
+      "desc": "46 46 OP_GREATERTHANEQUALTO 01 OP_EQUAL"
     },
     {
       "scriptSig": "012e012e",
-      "scriptPubKey": "a1010188",
+      "scriptPubKey": "a1010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 46 OP_LESSTHANEQUALTO 01 OP_EQUALVERIFY"
+      "desc": "46 46 OP_LESSTHANEQUALTO 01 OP_EQUAL"
     },
     {
       "scriptSig": "012e",
-      "scriptPubKey": "91010088",
+      "scriptPubKey": "910087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 OP_NOT 00 OP_EQUALVERIFY"
+      "desc": "46 OP_NOT OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "0100",
-      "scriptPubKey": "91010188",
+      "scriptPubKey": "91010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 OP_NOT 01 OP_EQUALVERIFY"
+      "desc": "00 OP_NOT 01 OP_EQUAL"
     },
     {
-      "scriptSig": "0101",
-      "scriptPubKey": "91010088",
+      "scriptSig": "51",
+      "scriptPubKey": "910087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_NOT 00 OP_EQUALVERIFY"
+      "desc": "OP_1 OP_NOT OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "012e",
-      "scriptPubKey": "92010188",
+      "scriptPubKey": "92010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 OP_0NOTEQUAL 01 OP_EQUALVERIFY"
+      "desc": "46 OP_0NOTEQUAL 01 OP_EQUAL"
     },
     {
-      "scriptSig": "0100",
-      "scriptPubKey": "92010088",
+      "scriptSig": "00",
+      "scriptPubKey": "920087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 OP_0NOTEQUAL 00 OP_EQUALVERIFY"
+      "desc": "OP_0 OP_0NOTEQUAL OP_0 OP_EQUAL"
     },
     {
-      "scriptSig": "01000101",
-      "scriptPubKey": "9a010088",
+      "scriptSig": "0051",
+      "scriptPubKey": "9a0087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 01 OP_BOOLAND 00 OP_EQUALVERIFY"
+      "desc": "00 01 OP_BOOLAND 00 OP_EQUAL"
     },
     {
       "scriptSig": "01010101",
-      "scriptPubKey": "9a010188",
+      "scriptPubKey": "9a010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 01 OP_BOOLAND 01 OP_EQUALVERIFY"
+      "desc": "01 01 OP_BOOLAND 01 OP_EQUAL"
     },
     {
-      "scriptSig": "01000100",
-      "scriptPubKey": "9b010088",
+      "scriptSig": "0000",
+      "scriptPubKey": "9b0087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 00 OP_BOOLOR 00 OP_EQUALVERIFY"
+      "desc": "OP_0 OP_0 OP_BOOLOR OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "01000101",
-      "scriptPubKey": "9b010188",
+      "scriptPubKey": "9b010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 01 OP_BOOLOR 01 OP_EQUALVERIFY"
+      "desc": "00 01 OP_BOOLOR 01 OP_EQUAL"
     },
     {
       "scriptSig": "01010100",
-      "scriptPubKey": "9b010188",
+      "scriptPubKey": "9b010187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 00 OP_BOOLOR 01 OP_EQUALVERIFY"
+      "desc": "01 00 OP_BOOLOR 01 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -764,11 +743,11 @@
       "desc": "OP_WITHIN"
     },
     {
-      "scriptSig": "010101040106",
-      "scriptPubKey": "a5010088",
+      "scriptSig": "515456",
+      "scriptPubKey": "a50087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 04 06 OP_WITHIN 00 OP_EQUALVERIFY"
+      "desc": "01 04 06 OP_WITHIN 00 OP_EQUAL"
     },
     {
       "scriptSig": "",

--- a/tests/Data/scriptinterpreter.simple.json
+++ b/tests/Data/scriptinterpreter.simple.json
@@ -226,7 +226,7 @@
     },
     {
       "scriptSig": "0100010001006f",
-      "scriptPubKey": "74010687",
+      "scriptPubKey": "745687",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "00 00 00 OP_3DUP OP_DEPTH 06 OP_EQUAL"
@@ -296,10 +296,10 @@
     },
     {
       "scriptSig": "01010102",
-      "scriptPubKey": "7774010187",
+      "scriptPubKey": "77745187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_NIP OP_DEPTH 01 OP_EQUAL"
+      "desc": "01 02 OP_NIP OP_DEPTH OP_1 OP_EQUAL"
     },
     {
       "scriptSig": "01010102",
@@ -324,7 +324,7 @@
     },
     {
       "scriptSig": "01010102",
-      "scriptPubKey": "7874010387",
+      "scriptPubKey": "78745387",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "01 02 OP_OVER OP_DEPTH 03 OP_EQUAL"
@@ -344,11 +344,11 @@
       "desc": "01 02 03 04 OP_2OVER 02 OP_EQUALVERIFY 01 OP_EQUALVERIFY 04 OP_EQUALVERIFY 03 OP_EQUALVERIFY 02 OP_EQUALVERIFY 01 OP_EQUAL"
     },
     {
-      "scriptSig": "0101010201030104",
-      "scriptPubKey": "7074010688",
+      "scriptSig": "51525354",
+      "scriptPubKey": "70745687",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 02 OP_OVER OP_DEPTH 03 OP_EQUALVERIFY"
+      "desc": "OP_1 OP_2 OP_3 OP_4 OP_2OVER OP_DEPTH OP_6 OP_EQUAL"
     },
     {
       "scriptSig": "01010102",
@@ -456,11 +456,11 @@
       "desc": "OP_IFDUP"
     },
     {
-      "scriptSig": "0101",
-      "scriptPubKey": "7374010288010188010187",
+      "scriptSig": "51",
+      "scriptPubKey": "73745287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_IFDUP OP_DEPTH 02 OP_EQUAL"
+      "desc": "OP_1 OP_IFDUP OP_DEPTH 02 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -512,18 +512,18 @@
       "desc": "OP_1ADD"
     },
     {
-      "scriptSig": "0101",
-      "scriptPubKey": "8b010287",
+      "scriptSig": "51",
+      "scriptPubKey": "8b5287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_1ADD 02 OP_EQUAL"
+      "desc": "OP_1 OP_1ADD OP_2 OP_EQUAL"
     },
     {
-      "scriptSig": "0102",
-      "scriptPubKey": "8c010187",
+      "scriptSig": "52",
+      "scriptPubKey": "8c5187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "01 OP_1SUB 00 OP_EQUAL"
+      "desc": "OP_2 OP_1SUB OP_1 OP_EQUAL"
     },
     {
       "scriptSig": "0101",
@@ -540,8 +540,8 @@
       "desc": "OP_ADD"
     },
     {
-      "scriptSig": "01010101",
-      "scriptPubKey": "9374010188010287",
+      "scriptSig": "5151",
+      "scriptPubKey": "937451885287",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "1 1 OP_ADD OP_DEPTH 01 OP_EQUALVERIFY 02 OP_EQUAL"
@@ -568,11 +568,19 @@
       "desc": "OP_NUMEQUAL"
     },
     {
-      "scriptSig": "01010101",
-      "scriptPubKey": "9c010187",
+      "scriptSig": "5151",
+      "scriptPubKey": "9c5187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 1 OP_NUMEQUAL 00 OP_EQUAL"
+      "desc": "1 1 OP_NUMEQUAL OP_1 OP_EQUAL"
+    },
+
+    {
+      "scriptSig": "5100",
+      "scriptPubKey": "9c0087",
+      "result": true,
+      "flags": "VERIFY_STRICTENC",
+      "desc": "1 0 OP_NUMEQUAL OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "",
@@ -589,8 +597,8 @@
       "desc": "1 1 OP_NUMEQUAL 00 OP_NUMEQUAL"
     },
     {
-      "scriptSig": "01010100",
-      "scriptPubKey": "a4010187",
+      "scriptSig": "5100",
+      "scriptPubKey": "a45187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "1 0 OP_MAX 01 OP_EQUAL"
@@ -603,18 +611,18 @@
       "desc": "OP_1 OP_0 OP_MIN OP_0 OP_EQUAL"
     },
     {
-      "scriptSig": "01010100",
-      "scriptPubKey": "9e010187",
+      "scriptSig": "5100",
+      "scriptPubKey": "9e5187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "1 0 OP_NUMNOTEQUAL 01 OP_EQUAL"
+      "desc": "OP_1 OP_0 OP_NUMNOTEQUAL 01 OP_EQUAL"
     },
     {
-      "scriptSig": "012e0111",
+      "scriptSig": "5857",
       "scriptPubKey": "9f0087",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_LESSTHAN OP_0 OP_EQUAL"
+      "desc": "OP_8 OP_7 OP_LESSTHAN OP_0 OP_EQUAL"
     },
     {
       "scriptSig": "5100",
@@ -638,32 +646,32 @@
       "desc": "46 17 OP_GREATERTHAN OP_0 OP_EQUAL"
     },
     {
-      "scriptSig": "0111012e",
-      "scriptPubKey": "a1010187",
+      "scriptSig": "5758",
+      "scriptPubKey": "a15187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 17 OP_LESSTHANEQUALTO 01 OP_EQUAL"
+      "desc": "OP_8 OP_7 OP_LESSTHANEQUALTO OP_1 OP_EQUAL"
     },
     {
-      "scriptSig": "012e0111",
-      "scriptPubKey": "a2010187",
+      "scriptSig": "5856",
+      "scriptPubKey": "a25187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "46 17 OP_GREATERTHANEQUALTO 01 OP_EQUAL"
     },
     {
-      "scriptSig": "012e012e",
-      "scriptPubKey": "a2010187",
+      "scriptSig": "5252",
+      "scriptPubKey": "a25187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "46 46 OP_GREATERTHANEQUALTO 01 OP_EQUAL"
     },
     {
-      "scriptSig": "012e012e",
-      "scriptPubKey": "a1010187",
+      "scriptSig": "5858",
+      "scriptPubKey": "a15187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 46 OP_LESSTHANEQUALTO 01 OP_EQUAL"
+      "desc": "OP_8 OP_8 OP_LESSTHANEQUALTO OP_1 OP_EQUAL"
     },
     {
       "scriptSig": "012e",
@@ -673,11 +681,11 @@
       "desc": "46 OP_NOT OP_0 OP_EQUAL"
     },
     {
-      "scriptSig": "0100",
-      "scriptPubKey": "91010187",
+      "scriptSig": "00",
+      "scriptPubKey": "915187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 OP_NOT 01 OP_EQUAL"
+      "desc": "OP_0 OP_NOT OP_1 OP_EQUAL"
     },
     {
       "scriptSig": "51",
@@ -687,11 +695,11 @@
       "desc": "OP_1 OP_NOT OP_0 OP_EQUAL"
     },
     {
-      "scriptSig": "012e",
-      "scriptPubKey": "92010187",
+      "scriptSig": "51",
+      "scriptPubKey": "925187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "46 OP_0NOTEQUAL 01 OP_EQUAL"
+      "desc": "OP_0 OP_0NOTEQUAL OP_1 OP_EQUAL"
     },
     {
       "scriptSig": "00",
@@ -708,8 +716,8 @@
       "desc": "00 01 OP_BOOLAND 00 OP_EQUAL"
     },
     {
-      "scriptSig": "01010101",
-      "scriptPubKey": "9a010187",
+      "scriptSig": "5151",
+      "scriptPubKey": "9a5187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "01 01 OP_BOOLAND 01 OP_EQUAL"
@@ -722,15 +730,15 @@
       "desc": "OP_0 OP_0 OP_BOOLOR OP_0 OP_EQUAL"
     },
     {
-      "scriptSig": "01000101",
-      "scriptPubKey": "9b010187",
+      "scriptSig": "0051",
+      "scriptPubKey": "9b5187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
-      "desc": "00 01 OP_BOOLOR 01 OP_EQUAL"
+      "desc": "OP_0 OP_1 OP_BOOLOR OP_1 OP_EQUAL"
     },
     {
-      "scriptSig": "01010100",
-      "scriptPubKey": "9b010187",
+      "scriptSig": "5151",
+      "scriptPubKey": "9b5187",
       "result": true,
       "flags": "VERIFY_STRICTENC",
       "desc": "01 00 OP_BOOLOR 01 OP_EQUAL"

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -436,5 +436,4 @@ class InterpreterTest extends AbstractTestCase
             $this->assertFalse($i->checkMinimalPush($opcode, $buffer));
         }
     }
-
 }

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -15,6 +15,7 @@ use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Script\Interpreter\Interpreter;
 use BitWasp\Bitcoin\Script\ScriptStack;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
 use BitWasp\Bitcoin\Transaction\Transaction;
 use BitWasp\Bitcoin\Flags;
 use BitWasp\Bitcoin\Transaction\Factory\TxSigner;
@@ -22,7 +23,7 @@ use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Buffertools\Buffer;
 use Mdanter\Ecc\EccFactory;
 
-class InterpreterTest extends \PHPUnit_Framework_TestCase
+class InterpreterTest extends AbstractTestCase
 {
     /**
      * @param $flagStr
@@ -289,12 +290,12 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
 
     public function getScripts()
     {
-        $f = file_get_contents(__DIR__ . '/../../Data/scriptinterpreter.simple.json');
+        $f = $this->dataFile('scriptinterpreter.simple.json');
         $json = json_decode($f);
 
         $vectors = [];
         foreach ($json->test as $c => $test) {
-            $flags = $this->setFlags($test->flags);
+            $flags = $this->getInterpreterFlags($test->flags);
             $scriptSig = ScriptFactory::fromHex($test->scriptSig);
             $scriptPubKey = ScriptFactory::fromHex($test->scriptPubKey);
             $vectors[] = [

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -323,7 +323,7 @@ class InterpreterTest extends AbstractTestCase
      * @param $result
      * @param $tx
      * @dataProvider getScripts
-     */
+     *
     public function testScript(Flags $flags, ScriptInterface $scriptSig, ScriptInterface $scriptPubKey, $result,  $tx)
     {
         $i = new \BitWasp\Bitcoin\Script\Interpreter\Interpreter(Bitcoin::getEcAdapter(), $tx, $flags);
@@ -436,4 +436,5 @@ class InterpreterTest extends AbstractTestCase
             $this->assertFalse($i->checkMinimalPush($opcode, $buffer));
         }
     }
+
 }

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -299,7 +299,7 @@ class InterpreterTest extends AbstractTestCase
             $scriptSig = ScriptFactory::fromHex($test->scriptSig);
             $scriptPubKey = ScriptFactory::fromHex($test->scriptPubKey);
             $vectors[] = [
-                $flags, $scriptSig, $scriptPubKey, $test->result, $test->desc, new Transaction
+                $flags, $scriptSig, $scriptPubKey, $test->result, new Transaction
             ];
         }
 
@@ -309,7 +309,6 @@ class InterpreterTest extends AbstractTestCase
             new Script(new Buffer()),
             ScriptFactory::create()->push(Buffer::hex(file_get_contents(__DIR__ . "/../../Data/10010bytes.hex")))->getScript(),
             false,
-            'fails with >10000 bytes',
             new Transaction
         ];
 
@@ -318,21 +317,21 @@ class InterpreterTest extends AbstractTestCase
 
 
     /**
-     * @dataProvider getScripts
      * @param Flags $flags
      * @param ScriptInterface $scriptSig
      * @param ScriptInterface $scriptPubKey
-     * @param bool $result
-     * @param string $description
+     * @param $result
+     * @param $tx
+     * @dataProvider getScripts
      */
-    public function testScript(Flags $flags, ScriptInterface $scriptSig, ScriptInterface $scriptPubKey, $result, $description, $tx)
+    public function testScript(Flags $flags, ScriptInterface $scriptSig, ScriptInterface $scriptPubKey, $result,  $tx)
     {
         $i = new \BitWasp\Bitcoin\Script\Interpreter\Interpreter(Bitcoin::getEcAdapter(), $tx, $flags);
 
         $i->setScript($scriptSig)->run();
         $testResult = $i->setScript($scriptPubKey)->run();
 
-        $this->assertEquals($result, $testResult, $description);
+        $this->assertEquals($result, $testResult, ScriptFactory::fromHex($scriptSig->getHex() . $scriptPubKey->getHex())->getScriptParser()->getHumanReadable());
     }/**/
 
 

--- a/tests/Script/OpcodesTest.php
+++ b/tests/Script/OpcodesTest.php
@@ -64,5 +64,4 @@ class OpcodesTest extends \PHPUnit_Framework_TestCase
         $op = new Opcodes();
         unset($op[Opcodes::OP_1]);
     }
-
 }


### PR DESCRIPTION
Despite Interpeter having some tests, NativeConsensus doesn't have any. This PR adds `ConsensusInterface` to tie the two implementations together. 

While testing the `simpleinterpreter` vectors against libbitcoinconsensus, some had to be modified to return the results from the point-of-view of Interpreter::verify() instead of Interpreter::run(). Some bugs were found along the way.