### PR TITLE
Refactor ScriptFactory

### DIFF
--- a/examples/offlinetx.p2shfull.php
+++ b/examples/offlinetx.p2shfull.php
@@ -16,8 +16,8 @@ $pk2 = PrivateKeyFactory::fromHex('f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb8
 
 
 // They exchange public keys, and a multisignature address is made.
-$redeemScript = ScriptFactory::multisig(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
-$outputScript = $redeemScript->getOutputScript();
+$redeemScript = ScriptFactory::scriptPubKey()->multisig(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
+$outputScript = ScriptFactory::scriptPubKey()->payToScriptHash($redeemScript);
 
 
 // The address is funded with a transaction (fake, for the purposes of this script).

--- a/src/Script/Factory/P2shScriptFactory.php
+++ b/src/Script/Factory/P2shScriptFactory.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Bitcoin\Script\Factory;
 
-
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;

--- a/src/Script/Factory/P2shScriptFactory.php
+++ b/src/Script/Factory/P2shScriptFactory.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace BitWasp\Bitcoin\Script\Factory;
+
+
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
+
+class P2shScriptFactory
+{
+    /**
+     * @var OutputScriptFactory
+     */
+    private $scriptPubKey;
+
+    /**
+     * P2shScriptFactory constructor.
+     * @param OutputScriptFactory $scriptPubKey
+     */
+    public function __construct(OutputScriptFactory $scriptPubKey)
+    {
+        $this->scriptPubKey = $scriptPubKey;
+    }
+
+    /**
+     * @param ScriptInterface $script
+     * @return ScriptInterface
+     */
+    private function withOutputScript(ScriptInterface $script)
+    {
+        return [
+            $script,
+            $this->scriptPubKey->payToScriptHash($script)
+        ];
+    }
+
+    /**
+     * Create a multisig redeemScript and outputScript
+     *
+     * @param $m
+     * @param array $keys
+     * @param bool|true $sort
+     * @return ScriptInterface
+     */
+    public function multisig($m, array $keys, $sort = true)
+    {
+        return $this->withOutputScript($this->scriptPubKey->multisig($m, $keys, $sort));
+    }
+
+    /**
+     * Create a Pay to pubkey redeemScript and outputScript
+     * @param PublicKeyInterface  $publicKey
+     * @return ScriptInterface[]
+     */
+    public function payToPubKey(PublicKeyInterface $publicKey)
+    {
+        return $this->withOutputScript($this->scriptPubKey->payToPubKey($publicKey));
+    }
+
+    /**
+     * Create a Pay to pubkey-hash redeemScript and outputScript
+     * @param PublicKeyInterface  $publicKey
+     * @return ScriptInterface[]
+     */
+    public function payToPubKeyHash(PublicKeyInterface $publicKey)
+    {
+        return $this->withOutputScript($this->scriptPubKey->payToPubKeyHash($publicKey));
+    }
+}

--- a/src/Script/ScriptFactory.php
+++ b/src/Script/ScriptFactory.php
@@ -26,36 +26,6 @@ class ScriptFactory
     }
 
     /**
-     * @param int               $m
-     * @param KeyInterface[]    $keys
-     * @param bool              $sort
-     * @return ScriptInterface
-     */
-    public static function multisig($m, array $keys = array(), $sort = true)
-    {
-        if ($sort) {
-            $keys = Buffertools::sort($keys);
-        }
-
-        return self::scriptPubKey()->multisig($m, $keys);
-    }
-
-    /**
-     * @param int               $m
-     * @param KeyInterface[]    $keys
-     * @param bool              $sort
-     * @return ScriptInterface
-     */
-    public static function multisigNew($m, array $keys = array(), $sort = true)
-    {
-        if ($sort) {
-            $keys = Buffertools::sort($keys);
-        }
-
-        return self::scriptPubKey()->multisig($m, $keys);
-    }
-
-    /**
      * @return InputScriptFactory
      */
     public static function scriptSig()

--- a/src/Script/ScriptFactory.php
+++ b/src/Script/ScriptFactory.php
@@ -6,11 +6,10 @@ use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Script\Factory\InputScriptFactory;
 use BitWasp\Bitcoin\Script\Factory\OutputScriptFactory;
+use BitWasp\Bitcoin\Script\Factory\P2shScriptFactory;
 use BitWasp\Bitcoin\Script\Factory\ScriptCreator;
 use BitWasp\Bitcoin\Script\Factory\ScriptInfoFactory;
 use BitWasp\Buffertools\Buffer;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
-use BitWasp\Buffertools\Buffertools;
 
 class ScriptFactory
 {
@@ -39,6 +38,14 @@ class ScriptFactory
     public static function scriptPubKey()
     {
         return new OutputScriptFactory();
+    }
+
+    /**
+     * @return P2shScriptFactory
+     */
+    public static function p2sh()
+    {
+        return new P2shScriptFactory(self::scriptPubKey());
     }
 
     /**

--- a/src/Transaction/Factory/TxBuilder.php
+++ b/src/Transaction/Factory/TxBuilder.php
@@ -220,4 +220,10 @@ class TxBuilder
 
         return $this;
     }
+
+    public function randomizeBip69()
+    {
+        $outputs = $this->outputs;
+
+    }
 }

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -90,7 +90,7 @@ class AddressTest extends AbstractTestCase
         $publicKey = $privateKey->getPublicKey();
 
         $pubkeyHash = $outputScriptFactory->payToPubKeyHash($publicKey);
-        $scriptHash = $outputScriptFactory->payToScriptHash(ScriptFactory::multisig(1, [$publicKey]));
+        $scriptHash = $outputScriptFactory->payToScriptHash($outputScriptFactory->multisig(1, [$publicKey]));
 
         $p2pkhAddress = AddressFactory::fromOutputScript($pubkeyHash);
         $this->assertInstanceOf('BitWasp\Bitcoin\Address\PayToPubKeyHashAddress', $p2pkhAddress);

--- a/tests/Bloom/BloomFilterTest.php
+++ b/tests/Bloom/BloomFilterTest.php
@@ -55,7 +55,7 @@ class BloomFilterTest extends AbstractTestCase
     {
         return TransactionFactory::build()
             ->input('0000000000000000000000000000000000000000000000000000000000000000', 0)
-            ->output(50 * Amount::COIN, ScriptFactory::multisig(1, [$publicKey]))
+            ->output(50 * Amount::COIN, ScriptFactory::scriptPubKey()->multisig(1, [$publicKey]))
             ->get();
     }
     public function testBasics()

--- a/tests/Script/Factory/InputScriptFactoryTest.php
+++ b/tests/Script/Factory/InputScriptFactoryTest.php
@@ -51,7 +51,7 @@ class InputScriptFactoryTest extends AbstractTestCase
     {
         // Script::payToScriptHash should produce a ScriptHash type script, from a different script
         $private = PrivateKeyFactory::create();
-        $script = ScriptFactory::multisig(1, [$private->getPublicKey()]);
+        $script = ScriptFactory::scriptPubKey()->multisig(1, [$private->getPublicKey()]);
 
         $sigHex = '3045022100dbc87baa1b3a0225566728a0e01b8aaeedfc5a94368708bfa221302302f5458a022032df06bc5b894f848e62197d3aab328e5c8ce97ac3119ba5caacac5221d4534901';
         $sig = TransactionSignatureFactory::fromHex($sigHex);

--- a/tests/Script/Factory/OutputScriptFactoryTest.php
+++ b/tests/Script/Factory/OutputScriptFactoryTest.php
@@ -30,7 +30,7 @@ class OutputScriptFactoryTest extends AbstractTestCase
         $this->assertEquals('OP_CHECKSIG', $parsedScript[4]);
         $this->assertEquals(OutputClassifier::PAYTOPUBKEYHASH, ScriptFactory::scriptPubKey()->classify($p2pkhScript)->classify());
 
-        $p2sh = AddressFactory::fromScript(ScriptFactory::multisig(1, [$pk1->getPublicKey()]));
+        $p2sh = AddressFactory::fromScript(ScriptFactory::scriptPubKey()->multisig(1, [$pk1->getPublicKey()]));
         $p2shScript = ScriptFactory::scriptPubKey()->payToAddress($p2sh);
         $parsedScript = $p2shScript->getScriptParser()->parse();
         $this->assertEquals('OP_HASH160', $parsedScript[0]);

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -247,7 +247,7 @@ class InterpreterTest extends AbstractTestCase
             null,               // redeemscript
         ];
 
-        $rs = ScriptFactory::multisig(1, [$privateKey->getPublicKey()]);
+        $rs = ScriptFactory::scriptPubKey()->multisig(1, [$privateKey->getPublicKey()]);
         $vectors[] = [
             true,
             $ec,

--- a/tests/Script/ScriptCountSigOpsTest.php
+++ b/tests/Script/ScriptCountSigOpsTest.php
@@ -72,7 +72,7 @@ class ScriptCountSigOpsTest extends AbstractTestCase
             $pk[] = PrivateKeyFactory::create()->getPublicKey();
         }
 
-        $p2shScript = ScriptFactory::multisig(1, $pk);
+        $p2shScript = ScriptFactory::scriptPubKey()->multisig(1, $pk);
         $this->assertEquals(3, $p2shScript->countSigOps(true));
         $this->assertEquals(20, $p2shScript->countSigOps(false));
 

--- a/tests/Script/ScriptFactoryTest.php
+++ b/tests/Script/ScriptFactoryTest.php
@@ -28,7 +28,7 @@ class ScriptFactoryTest extends AbstractTestCase
         $m = 2;
         $arbitrary = [$pk1->getPublicKey(), $pk2->getPublicKey()];
 
-        $redeemScript = ScriptFactory::multisig($m, $arbitrary, false);
+        $redeemScript = ScriptFactory::scriptPubKey()->multisig($m, $arbitrary, false);
         $outputScript = ScriptFactory::scriptPubKey()->payToScriptHash($redeemScript);
         $info = ScriptFactory::info($outputScript, $redeemScript);
         $keys = $info->getKeys();
@@ -36,7 +36,7 @@ class ScriptFactoryTest extends AbstractTestCase
             $this->assertEquals($arbitrary[$i]->getBinary(), $key->getBinary(), 'verify false flag disables sorting');
         }
 
-        $sorted = ScriptFactory::multisig($m, $arbitrary, true);
+        $sorted = ScriptFactory::scriptPubKey()->multisig($m, $arbitrary, true);
         $this->assertInstanceOf($this->scriptInterfaceType, $sorted);
         $this->assertNotEquals($sorted->getBinary(), $redeemScript->getBinary());
     }

--- a/tests/Transaction/Factory/TxBuilderTest.php
+++ b/tests/Transaction/Factory/TxBuilderTest.php
@@ -135,7 +135,7 @@ class TxBuilderTest extends AbstractTestCase
     public function getAddresses()
     {
         $key = PrivateKeyFactory::create(false);
-        $script = ScriptFactory::multisig(1, [$key->getPublicKey()]);
+        $script = ScriptFactory::scriptPubKey()->multisig(1, [$key->getPublicKey()]);
         $scriptAddress = AddressFactory::fromScript($script);
         return [
             [$key->getAddress()],

--- a/tests/Transaction/Factory/TxSignerTest.php
+++ b/tests/Transaction/Factory/TxSignerTest.php
@@ -130,7 +130,7 @@ class TxSignerTest extends AbstractTestCase
     {
         $pk1 = PrivateKeyFactory::create(false, $ecAdapter);
         $pk2 = PrivateKeyFactory::create(false, $ecAdapter);
-        $redeemScript = ScriptFactory::multisigNew(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
+        $redeemScript = ScriptFactory::scriptPubKey()->multisig(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
         $outputScript = ScriptFactory::scriptPubKey()->payToScriptHash($redeemScript);
         $sampleSpendTx = (new TxBuilder())
             ->output(50, $outputScript)
@@ -229,7 +229,7 @@ class TxSignerTest extends AbstractTestCase
         $pk1 = PrivateKeyFactory::fromHex('421c76d77563afa1914846b010bd164f395bd34c2102e5e99e0cb9cf173c1d87', false, $ecAdapter);
         $pk2 = PrivateKeyFactory::fromHex('f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162', false, $ecAdapter);
 
-        $redeemScript = ScriptFactory::multisig(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
+        $redeemScript = ScriptFactory::scriptPubKey()->multisig(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
         $outputScript = ScriptFactory::scriptPubKey()->payToScriptHash($redeemScript);
 
         $sampleSpendTx = (new TxBuilder())
@@ -324,7 +324,7 @@ class TxSignerTest extends AbstractTestCase
         $pk1 = PrivateKeyFactory::fromHex('421c76d77563afa1914846b010bd164f395bd34c2102e5e99e0cb9cf173c1d87');
         $pk2 = PrivateKeyFactory::fromHex('f7225388c1d69d57e6251c9fda50cbbf9e05131e5adb81e5aa0422402f048162');
 
-        $redeemScript = ScriptFactory::multisig(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
+        $redeemScript = ScriptFactory::scriptPubKey()->multisig(2, [$pk1->getPublicKey(), $pk2->getPublicKey()]);
         $outputScript = ScriptFactory::scriptPubKey()->payToScriptHash($redeemScript);
 
         // this is the transaction we are pretending exists in the blockchain

--- a/tests/Transaction/TransactionBuilderInputStateTest.php
+++ b/tests/Transaction/TransactionBuilderInputStateTest.php
@@ -22,7 +22,7 @@ class TransactionBuilderInputStateTest extends AbstractTestCase
 
     private function getRandomRedeemScript()
     {
-        $script = ScriptFactory::multisigNew(2, [
+        $script = ScriptFactory::scriptPubKey()->multisig(2, [
             PrivateKeyFactory::create()->getPublicKey(),
             PrivateKeyFactory::create()->getPublicKey(),
             PrivateKeyFactory::create()->getPublicKey()


### PR DESCRIPTION
Remove's `ScriptFactory::multisig()` (and the accidentally duplicated multisigNew()) in favor of ScriptFactory::scriptPubKey()->multisig();

Adds P2shScriptFactory, which wraps calls to `OutputScriptFactory::multisig()`, `OutputScriptFactory::payToPubKey()`, `OutputScriptFactory::payToPubkeyHash()`. This class will return _arrays_, the first item being the redeemScript, the second being the output script.