### PR TITLE
Add Uri class

### DIFF
--- a/src/Uri.php
+++ b/src/Uri.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Bitcoin;
 
-
 use BitWasp\Bitcoin\Address\AddressInterface;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace BitWasp\Bitcoin;
+
+
+use BitWasp\Bitcoin\Address\AddressInterface;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+
+class Uri
+{
+    /**
+     * @var AddressInterface
+     */
+    private $address;
+
+    /**
+     * @var null|int
+     */
+    private $amount;
+
+    /**
+     * @var string
+     */
+    private $message;
+
+    /**
+     * @var string
+     */
+    private $request;
+
+    /**
+     * Uri constructor.
+     * @param AddressInterface $address
+     */
+    public function __construct(AddressInterface $address)
+    {
+        $this->address = $address;
+    }
+
+    /**
+     * @param int $value
+     * @return $this
+     */
+    public function setAmountBtc($value)
+    {
+        $this->amount = $value;
+        return $this;
+    }
+
+    /**
+     * @param Amount $amount
+     * @param int $value
+     * @return $this
+     */
+    public function setAmount(Amount $amount, $value)
+    {
+        $this->amount = $amount->toBtc($value);
+        return $this;
+    }
+
+    /**
+     * @param string $message
+     * @return $this
+     */
+    public function setMessage($message)
+    {
+        $this->message = $message;
+        return $this;
+    }
+
+    /**
+     * @param string $url
+     * @return $this
+     */
+    public function setRequestUrl($url)
+    {
+        $this->request = $url;
+        return $this;
+    }
+
+    /**
+     * @param NetworkInterface|null $network
+     * @return string
+     */
+    public function url(NetworkInterface $network = null)
+    {
+        $url = 'bitcoin:' . $this->address->getAddress($network);
+
+        $params = [];
+        if (null !== $this->amount) {
+            $params['amount'] = $this->amount;
+        }
+
+        if (null !== $this->message) {
+            $params['message'] = $this->message;
+        }
+
+        if (null !== $this->request) {
+            $params['r'] = $this->request;
+        }
+
+        if (count($params) > 0) {
+            $url .= '?' . http_build_query($params);
+        }
+
+        return $url;
+    }
+}

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -2,7 +2,6 @@
 
 namespace BitWasp\Bitcoin\Tests;
 
-
 use BitWasp\Bitcoin\Address\AddressFactory;
 use BitWasp\Bitcoin\Amount;
 use BitWasp\Bitcoin\Uri;
@@ -89,5 +88,4 @@ class UriTest extends AbstractTestCase
 
         $this->assertEquals('bitcoin:?r=https%3A%2F%2Fexample.com%2Frequest', $uri->uri());
     }
-
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -1,0 +1,93 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests;
+
+
+use BitWasp\Bitcoin\Address\AddressFactory;
+use BitWasp\Bitcoin\Amount;
+use BitWasp\Bitcoin\Uri;
+
+class UriTest extends AbstractTestCase
+{
+    public function testDefault()
+    {
+        $string = '1FeDtFhARLxjKUPPkQqEBL78tisenc9znS';
+        $address = AddressFactory::fromString($string);
+        $uri = new Uri($address);
+        $this->assertEquals('bitcoin:'.$string, $uri->uri());
+    }
+
+    public function testAmount()
+    {
+        $string = '1FeDtFhARLxjKUPPkQqEBL78tisenc9znS';
+        $address = AddressFactory::fromString($string);
+        $uri = new Uri($address);
+
+        $amount = new Amount();
+        $uri->setAmount($amount, 1);
+
+        $this->assertEquals('bitcoin:'.$string."?amount=0.00000001", $uri->uri());
+    }
+
+    public function testAmountBtc()
+    {
+        $string = '1FeDtFhARLxjKUPPkQqEBL78tisenc9znS';
+        $address = AddressFactory::fromString($string);
+        $uri = new Uri($address);
+
+        $uri->setAmountBtc(1);
+
+        $this->assertEquals('bitcoin:'.$string."?amount=1", $uri->uri());
+    }
+
+
+
+    public function testLabel()
+    {
+        $string = '1FeDtFhARLxjKUPPkQqEBL78tisenc9znS';
+        $address = AddressFactory::fromString($string);
+        $uri = new Uri($address);
+        $uri->setLabel('this is the label');
+
+        $this->assertEquals('bitcoin:'.$string."?label=this+is+the+label", $uri->uri());
+    }
+
+    public function testMessage()
+    {
+        $string = '1FeDtFhARLxjKUPPkQqEBL78tisenc9znS';
+        $address = AddressFactory::fromString($string);
+        $uri = new Uri($address);
+        $uri->setMessage('this is the label');
+
+        $this->assertEquals('bitcoin:'.$string."?message=this+is+the+label", $uri->uri());
+    }
+
+    public function testRequestUrl()
+    {
+        $string = '1FeDtFhARLxjKUPPkQqEBL78tisenc9znS';
+        $address = AddressFactory::fromString($string);
+        $uri = new Uri($address);
+        $uri->setRequestUrl('https://example.com/request');
+
+        $this->assertEquals('bitcoin:'.$string.'?r=https%3A%2F%2Fexample.com%2Frequest', $uri->uri());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testBip21MustProvideAddress()
+    {
+        $address = null;
+        new Uri($address);
+    }
+
+    public function testBip72Incompatible()
+    {
+        $address = null;
+        $uri = new Uri($address, Uri::BIP0072);
+        $uri->setRequestUrl('https://example.com/request');
+
+        $this->assertEquals('bitcoin:?r=https%3A%2F%2Fexample.com%2Frequest', $uri->uri());
+    }
+
+}


### PR DESCRIPTION
Adds a simple class for producing a `bitcoin:` Uri for an address. Supports usual BIP0021 form, plus the BIP0072 form where an address isn't required (pass Uri::BIP0072 constant as second parameter to allow this)