### PR TITLE
Refactor Parser::getHumanReadable() - avoid use of parse()

### DIFF
--- a/src/Address/AddressFactory.php
+++ b/src/Address/AddressFactory.php
@@ -88,7 +88,7 @@ class AddressFactory
         $network = $network ?: Bitcoin::getNetwork();
         try {
             if ($classifier->isPayToPublicKey()) {
-                $address = PublicKeyFactory::fromHex($script->getScriptParser()->parse()[0])->getAddress();
+                $address = PublicKeyFactory::fromHex($script->getScriptParser()->decode()[0]->getData())->getAddress();
             } else {
                 $address = self::fromOutputScript($script);
             }

--- a/src/Address/AddressFactory.php
+++ b/src/Address/AddressFactory.php
@@ -40,15 +40,15 @@ class AddressFactory
     {
         $classifier = new OutputClassifier($outputScript);
         $type = $classifier->classify();
-        $parsed = $outputScript->getScriptParser()->parse();
+        $parsed = $outputScript->getScriptParser()->decode();
 
         if ($type === OutputClassifier::PAYTOPUBKEYHASH) {
             /** @var \BitWasp\Buffertools\Buffer $hash */
-            $hash = $parsed[2];
+            $hash = $parsed[2]->getData();
             return new PayToPubKeyHashAddress($hash);
         } else if ($type === OutputClassifier::PAYTOSCRIPTHASH) {
             /** @var \BitWasp\Buffertools\Buffer $hash */
-            $hash = $parsed[1];
+            $hash = $parsed[1]->getData();
             return new ScriptHashAddress($hash);
         }
 

--- a/src/Script/Interpreter/Interpreter.php
+++ b/src/Script/Interpreter/Interpreter.php
@@ -440,7 +440,6 @@ class Interpreter implements InterpreterInterface
 
         try {
             foreach ($parser as $operation) {
-
                 $opCode = $operation->getOp();
                 $pushData = $operation->getData();
                 $fExec = $this->checkExec();

--- a/src/Script/Parser/Parser.php
+++ b/src/Script/Parser/Parser.php
@@ -234,17 +234,13 @@ class Parser implements \Iterator
      */
     public function getHumanReadable()
     {
-        $parse = $this->parse();
-
-        $array = array_map(
-            function ($value) {
-                return ($value instanceof Buffer)
-                    ? $value->getHex()
-                    : $value;
+        return implode(' ', array_map(
+            function (Operation $operation) {
+                return $operation->isPush()
+                    ? $operation->getData()->getHex()
+                    : $this->script->getOpcodes()->getOp($operation->getOp());
             },
-            $parse
-        );
-
-        return implode(' ', $array);
+            $this->decode()
+        ));
     }
 }

--- a/src/Script/Parser/Parser.php
+++ b/src/Script/Parser/Parser.php
@@ -77,6 +77,7 @@ class Parser implements \Iterator
         if ($this->end - $this->position < $strSize) {
             return false;
         }
+
         $size = unpack($packFormat, substr($this->data, $this->position, $strSize));
         $size = $size[1];
         $this->position += $strSize;
@@ -127,7 +128,7 @@ class Parser implements \Iterator
                 throw new \RuntimeException('Failed to unpack data from Script');
             }
 
-            $pushData = new Buffer(substr($this->data, $this->position, $dataSize), $dataSize, $this->math);
+            $pushData = ($dataSize === 0) ? $this->empty : new Buffer(substr($this->data, $this->position, $dataSize), $dataSize, $this->math);
 
             $this->position += $dataSize;
         }
@@ -187,33 +188,6 @@ class Parser implements \Iterator
     public function valid()
     {
         return isset($this->array[$this->execPtr]) || $this->position < $this->end;
-    }
-
-    /**
-     * returns a mix of Buffer objects and strings
-     *
-     * @return Buffer[]|string[]
-     */
-    public function parse()
-    {
-        $data = array();
-
-        $it = $this;
-        foreach ($it as $exec) {
-            $opCode = $exec->getOp();
-            if ($opCode == 0) {
-                $push = Buffer::hex('00', 1, $this->math);
-            } elseif ($opCode <= 78) {
-                $push = $exec->getData();
-            } else {
-                // None of these are pushdatas, so just an opcode
-                $push = $this->script->getOpcodes()->getOp($opCode);
-            }
-
-            $data[] = $push;
-        }
-
-        return $data;
     }
 
     /**

--- a/src/Script/Parser/Parser.php
+++ b/src/Script/Parser/Parser.php
@@ -128,7 +128,9 @@ class Parser implements \Iterator
                 throw new \RuntimeException('Failed to unpack data from Script');
             }
 
-            $pushData = ($dataSize === 0) ? $this->empty : new Buffer(substr($this->data, $this->position, $dataSize), $dataSize, $this->math);
+            if ($dataSize > 0) {
+                $pushData = new Buffer(substr($this->data, $this->position, $dataSize), $dataSize, $this->math);
+            }
 
             $this->position += $dataSize;
         }

--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -142,8 +142,8 @@ class Script extends Serializable implements ScriptInterface
     public function isPushOnly()
     {
         $pushOnly = true;
-        foreach ($this->getScriptParser()->parse() as $entity) {
-            $pushOnly &= $entity instanceof Buffer;
+        foreach ($this->getScriptParser()->decode() as $entity) {
+            $pushOnly &= $entity->isPush();
         }
         return $pushOnly;
     }

--- a/src/Script/ScriptInfo/PayToPubkey.php
+++ b/src/Script/ScriptInfo/PayToPubkey.php
@@ -8,7 +8,6 @@ use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
-use BitWasp\Buffertools\Buffer;
 
 class PayToPubkey implements ScriptInfoInterface
 {
@@ -28,11 +27,11 @@ class PayToPubkey implements ScriptInfoInterface
     public function __construct(ScriptInterface $script)
     {
         $this->script = $script;
-        $chunks = $script->getScriptParser()->parse();
-        if (count($chunks) < 1 || !$chunks[0] instanceof Buffer) {
+        $chunks = $script->getScriptParser()->decode();
+        if (count($chunks) < 1 || !$chunks[0]->isPush()) {
             throw new \InvalidArgumentException('Malformed pay-to-pubkey script');
         }
-        $this->publicKey = PublicKeyFactory::fromHex($chunks[0]);
+        $this->publicKey = PublicKeyFactory::fromHex($chunks[0]->getData());
     }
 
     /**

--- a/src/Script/ScriptInfo/PayToPubkeyHash.php
+++ b/src/Script/ScriptInfo/PayToPubkeyHash.php
@@ -27,13 +27,13 @@ class PayToPubkeyHash implements ScriptInfoInterface
     public function __construct(ScriptInterface $script)
     {
         $this->script = $script;
-        $chunks = $this->script->getScriptParser()->parse();
-        if (count($chunks) < 5 || !$chunks[2] instanceof Buffer) {
+        $chunks = $this->script->getScriptParser()->decode();
+        if (count($chunks) < 5 || !$chunks[2]->isPush()) {
             throw new \RuntimeException('Malformed pay-to-pubkey-hash script');
         }
 
         /** @var Buffer $hash */
-        $hash = $chunks[2];
+        $hash = $chunks[2]->getData();
         $this->hash = $hash;
     }
 

--- a/tests/Script/Factory/InputScriptFactoryTest.php
+++ b/tests/Script/Factory/InputScriptFactoryTest.php
@@ -25,8 +25,8 @@ class InputScriptFactoryTest extends AbstractTestCase
         $txSig = TransactionSignatureFactory::fromHex($txSigHex);
 
         $script = ScriptFactory::scriptSig()->payToPubKey($txSig);
-        $parsed = $script->getScriptParser()->parse();
-        $this->assertSame($txSigHex, $parsed[0]->getHex());
+        $parsed = $script->getScriptParser()->decode();
+        $this->assertSame($txSigHex, $parsed[0]->getData()->getHex());
         $this->assertEquals(1, count($parsed));
         $this->assertEquals(InputClassifier::PAYTOPUBKEY, ScriptFactory::scriptSig()->classify($script)->classify());
     }
@@ -40,9 +40,9 @@ class InputScriptFactoryTest extends AbstractTestCase
         $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
 
         $script = ScriptFactory::scriptSig()->payToPubKeyHash($txSig, $publicKey);
-        $parsed = $script->getScriptParser()->parse();
-        $this->assertSame($txSigHex, $parsed[0]->getHex());
-        $this->assertSame($publicKeyHex, $parsed[1]->getHex());
+        $parsed = $script->getScriptParser()->decode();
+        $this->assertSame($txSigHex, $parsed[0]->getData()->getHex());
+        $this->assertSame($publicKeyHex, $parsed[1]->getData()->getHex());
         $this->assertEquals(2, count($parsed));
         $this->assertEquals(InputClassifier::PAYTOPUBKEYHASH, ScriptFactory::scriptSig()->classify($script)->classify());
     }
@@ -57,13 +57,13 @@ class InputScriptFactoryTest extends AbstractTestCase
         $sig = TransactionSignatureFactory::fromHex($sigHex);
         $sigs = [$sig];
 
-        $inputScript = ScriptFactory::scriptSig()->multisig($sigs, $script);
+        $inputScript = ScriptFactory::scriptSig()->multisig($sigs);
         $scriptHashSig = ScriptFactory::scriptSig()->payToScriptHash($inputScript, $script);
-        $parsed = $scriptHashSig->getScriptParser()->parse();
+        $parsed = $scriptHashSig->getScriptParser()->decode();
 
-        $this->assertSame('00', $parsed[0]->getHex());
-        $this->assertSame($sigHex, $parsed[1]->getHex());
-        $this->assertSame($script->getHex(), $parsed[2]->getHex());
+        $this->assertSame('', $parsed[0]->getData()->getHex());
+        $this->assertSame($sigHex, $parsed[1]->getData()->getHex());
+        $this->assertSame($script->getHex(), $parsed[2]->getData()->getHex());
         $this->assertEquals(InputClassifier::MULTISIG, ScriptFactory::scriptSig()->classify($scriptHashSig)->classify());
     }
 }

--- a/tests/Script/Factory/OutputScriptFactoryTest.php
+++ b/tests/Script/Factory/OutputScriptFactoryTest.php
@@ -7,6 +7,7 @@ use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Crypto\Random\Random;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
@@ -22,20 +23,20 @@ class OutputScriptFactoryTest extends AbstractTestCase
 
         $p2pkh = $pk1->getAddress();
         $p2pkhScript = ScriptFactory::scriptPubKey()->payToAddress($p2pkh);
-        $parsedScript = $p2pkhScript->getScriptParser()->parse();
-        $this->assertEquals('OP_DUP', $parsedScript[0]);
-        $this->assertEquals('OP_HASH160', $parsedScript[1]);
-        $this->assertEquals($pk1->getAddress()->getHash(), $parsedScript[2]->getHex());
-        $this->assertEquals('OP_EQUALVERIFY', $parsedScript[3]);
-        $this->assertEquals('OP_CHECKSIG', $parsedScript[4]);
+        $parsedScript = $p2pkhScript->getScriptParser()->decode();
+        $this->assertEquals(Opcodes::OP_DUP, $parsedScript[0]->getOp());
+        $this->assertEquals(Opcodes::OP_HASH160, $parsedScript[1]->getOp());
+        $this->assertEquals($pk1->getAddress()->getHash(), $parsedScript[2]->getData()->getHex());
+        $this->assertEquals(Opcodes::OP_EQUALVERIFY, $parsedScript[3]->getOp());
+        $this->assertEquals(Opcodes::OP_CHECKSIG, $parsedScript[4]->getOp());
         $this->assertEquals(OutputClassifier::PAYTOPUBKEYHASH, ScriptFactory::scriptPubKey()->classify($p2pkhScript)->classify());
 
         $p2sh = AddressFactory::fromScript(ScriptFactory::scriptPubKey()->multisig(1, [$pk1->getPublicKey()]));
         $p2shScript = ScriptFactory::scriptPubKey()->payToAddress($p2sh);
-        $parsedScript = $p2shScript->getScriptParser()->parse();
-        $this->assertEquals('OP_HASH160', $parsedScript[0]);
-        $this->assertEquals($p2sh->getHash(), $parsedScript[1]->getHex());
-        $this->assertEquals('OP_EQUAL', $parsedScript[2]);
+        $parsedScript = $p2shScript->getScriptParser()->decode();
+        $this->assertEquals(Opcodes::OP_HASH160, $parsedScript[0]->getOp());
+        $this->assertEquals($p2sh->getHash(), $parsedScript[1]->getData()->getHex());
+        $this->assertEquals(Opcodes::OP_EQUAL, $parsedScript[2]->getOp());
         $this->assertEquals(OutputClassifier::PAYTOSCRIPTHASH, ScriptFactory::scriptPubKey()->classify($p2shScript)->classify());
     }
 
@@ -48,9 +49,9 @@ class OutputScriptFactoryTest extends AbstractTestCase
             $pubkey = $privateKey->getPublicKey();
 
             $script = ScriptFactory::scriptPubKey()->payToPubKey($pubkey);
-            $parsed = $script->getScriptParser()->parse();
-            $this->assertSame($pubkey->getHex(), $parsed[0]->getHex());
-            $this->assertSame('OP_CHECKSIG', $parsed[1]);
+            $parsed = $script->getScriptParser()->decode();
+            $this->assertSame($pubkey->getHex(), $parsed[0]->getData()->getHex());
+            $this->assertSame(Opcodes::OP_CHECKSIG, $parsed[1]->getOp());
 
             $this->assertEquals(OutputClassifier::PAYTOPUBKEY, ScriptFactory::scriptPubKey()->classify($script)->classify());
         }
@@ -67,29 +68,29 @@ class OutputScriptFactoryTest extends AbstractTestCase
         $b2 = PrivateKeyFactory::fromInt(4)->getPublicKey();
 
         $contract = ScriptFactory::scriptPubKey()->payToLightningChannel($bytes, $a1, $a2, $b1, $b2);
-        $parsed = $contract->getScriptParser()->parse();
+        $parsed = $contract->getScriptParser()->decode();
 
-        $this->assertEquals('OP_DEPTH', $parsed[0]);
-        $this->assertEquals('OP_3', $parsed[1]);
-        $this->assertEquals('OP_EQUAL', $parsed[2]);
-        $this->assertEquals('OP_IF', $parsed[3]);
-        $this->assertEquals('OP_HASH160', $parsed[4]);
-        $this->assertEquals(Hash::sha256ripe160($bytes)->getBinary(), $parsed[5]->getBinary());
-        $this->assertEquals('OP_EQUALVERIFY', $parsed[6]);
+        $this->assertEquals(Opcodes::OP_DEPTH, $parsed[0]->getOp());
+        $this->assertEquals(Opcodes::OP_3, $parsed[1]->getOp());
+        $this->assertEquals(Opcodes::OP_EQUAL, $parsed[2]->getOp());
+        $this->assertEquals(Opcodes::OP_IF, $parsed[3]->getOp());
+        $this->assertEquals(Opcodes::OP_HASH160, $parsed[4]->getOp());
+        $this->assertEquals(Hash::sha256ripe160($bytes)->getBinary(), $parsed[5]->getData()->getBinary());
+        $this->assertEquals(Opcodes::OP_EQUALVERIFY, $parsed[6]->getOp());
 
-        $this->assertEquals('OP_2', $parsed[7]);
-        $this->assertEquals($a1->getBinary(), $parsed[8]->getBinary());
-        $this->assertEquals($b1->getBinary(), $parsed[9]->getBinary());
-        $this->assertEquals('OP_2', $parsed[10]);
-        $this->assertEquals('OP_CHECKMULTISIG', $parsed[11]);
-        $this->assertEquals('OP_ELSE', $parsed[12]);
+        $this->assertEquals(Opcodes::OP_2, $parsed[7]->getOp());
+        $this->assertEquals($a1->getBinary(), $parsed[8]->getData()->getBinary());
+        $this->assertEquals($b1->getBinary(), $parsed[9]->getData()->getBinary());
+        $this->assertEquals(Opcodes::OP_2, $parsed[10]->getOp());
+        $this->assertEquals(Opcodes::OP_CHECKMULTISIG, $parsed[11]->getOp());
+        $this->assertEquals(Opcodes::OP_ELSE, $parsed[12]->getOp());
 
-        $this->assertEquals('OP_2', $parsed[13]);
-        $this->assertEquals($a2->getBinary(), $parsed[14]->getBinary());
-        $this->assertEquals($b2->getBinary(), $parsed[15]->getBinary());
-        $this->assertEquals('OP_2', $parsed[16]);
-        $this->assertEquals('OP_CHECKMULTISIG', $parsed[17]);
-        $this->assertEquals('OP_ENDIF', $parsed[18]);
+        $this->assertEquals(Opcodes::OP_2, $parsed[13]->getOp());
+        $this->assertEquals($a2->getBinary(), $parsed[14]->getData()->getBinary());
+        $this->assertEquals($b2->getBinary(), $parsed[15]->getData()->getBinary());
+        $this->assertEquals(Opcodes::OP_2, $parsed[16]->getOp());
+        $this->assertEquals(Opcodes::OP_CHECKMULTISIG, $parsed[17]->getOp());
+        $this->assertEquals(Opcodes::OP_ENDIF, $parsed[18]->getOp());
     }
 
     public function testPayToPubKeyInvalid()
@@ -107,11 +108,11 @@ class OutputScriptFactoryTest extends AbstractTestCase
     {
         $pubkey = PublicKeyFactory::fromHex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb');
         $script = ScriptFactory::scriptPubKey()->payToPubKeyHash($pubkey);
-        $parsed = $script->getScriptParser()->parse();
-        $this->assertSame('OP_DUP', $parsed[0]);
-        $this->assertSame('OP_HASH160', $parsed[1]);
-        $this->assertSame('f0cd7fab8e8f4b335931a77f114a46039068da59', $parsed[2]->getHex());
-        $this->assertSame('OP_EQUALVERIFY', $parsed[3]);
+        $parsed = $script->getScriptParser()->decode()  ;
+        $this->assertSame(Opcodes::OP_DUP, $parsed[0]->getOp());
+        $this->assertSame(Opcodes::OP_HASH160, $parsed[1]->getOp());
+        $this->assertSame('f0cd7fab8e8f4b335931a77f114a46039068da59', $parsed[2]->getData()->getHex());
+        $this->assertSame(Opcodes::OP_EQUALVERIFY, $parsed[3]->getOp());
         $this->assertEquals(OutputClassifier::PAYTOPUBKEYHASH, ScriptFactory::scriptPubKey()->classify($script)->classify());
     }
 
@@ -142,11 +143,11 @@ class OutputScriptFactoryTest extends AbstractTestCase
             ->getScript();
 
         $scriptHash = ScriptFactory::scriptPubKey()->payToScriptHash($script);
-        $parsed = $scriptHash->getScriptParser()->parse();
+        $parsed = $scriptHash->getScriptParser()->decode();
 
-        $this->assertSame('OP_HASH160', $parsed[0]);
-        $this->assertSame('f7c29c0c6d319e33c9250fca0cb61a500621d93e', $parsed[1]->getHex());
-        $this->assertSame('OP_EQUAL', $parsed[2]);
+        $this->assertSame(Opcodes::OP_HASH160, $parsed[0]->getOp());
+        $this->assertSame('f7c29c0c6d319e33c9250fca0cb61a500621d93e', $parsed[1]->getData()->getHex());
+        $this->assertSame(Opcodes::OP_EQUAL, $parsed[2]->getOp());
         $this->assertEquals(OutputClassifier::PAYTOSCRIPTHASH, ScriptFactory::scriptPubKey()->classify($scriptHash)->classify());
     }
 }


### PR DESCRIPTION
Removes Script\Parser\Parser::parse() (which returned a mix of strings and Buffers), in favor of decode(), which returns a list of Operations. 

Works around an issue in substr which returns false when you take a zero length subset of a zero length string. 