### PR TITLE
API break: move HierarchicalKey::decodePath to HierarchicalKeySequence

### DIFF
--- a/src/Key/Deterministic/HierarchicalKeySequence.php
+++ b/src/Key/Deterministic/HierarchicalKeySequence.php
@@ -4,6 +4,12 @@ namespace BitWasp\Bitcoin\Key\Deterministic;
 
 use BitWasp\Bitcoin\Math\Math;
 
+/**
+ * NB: Paths returned by this library omit m/M. This is because
+ * some knowledge is lost during derivations, so the full path
+ * is already considered 'meta-data'. It also allows the library
+ * to assume derivations are relative to the current instance.
+ */
 class HierarchicalKeySequence
 {
     /**
@@ -76,6 +82,7 @@ class HierarchicalKeySequence
 
     /**
      * Given a sequence, get the human readable node. Ie, 0 -> 0, 0x80000000 -> 0h
+     *
      * @param $sequence
      * @return string
      */
@@ -89,6 +96,8 @@ class HierarchicalKeySequence
     }
 
     /**
+     * Decodes a human-readable path, into an array of integers (sequences)
+     *
      * @param string $path
      * @return array
      */
@@ -109,6 +118,8 @@ class HierarchicalKeySequence
     }
 
     /**
+     * Encodes a list of sequences to the human-readable path.
+     *
      * @param array|\stdClass|\Traversable $list
      * @return string
      */
@@ -125,6 +136,8 @@ class HierarchicalKeySequence
     }
 
     /**
+     * Check the list, mainly that it works for foreach()
+     *
      * @param \stdClass|array|\Traversable $list
      */
     public static function validateListType($list)

--- a/src/Key/Deterministic/HierarchicalKeySequence.php
+++ b/src/Key/Deterministic/HierarchicalKeySequence.php
@@ -87,4 +87,51 @@ class HierarchicalKeySequence
 
         return $sequence;
     }
+
+    /**
+     * @param string $path
+     * @return array
+     */
+    public function decodePath($path)
+    {
+        if ($path === '') {
+            throw new \InvalidArgumentException('Invalid path passed to decodePath()');
+        }
+
+        $list = [];
+        foreach (explode('/', $path) as $segment) {
+            if ($segment !== 'm' || $segment !== 'M') {
+                $list[] = $this->fromNode($segment);
+            }
+        }
+
+        return $list;
+    }
+
+    /**
+     * @param array|\stdClass|\Traversable $list
+     * @return string
+     */
+    public function encodePath($list)
+    {
+        self::validateListType($list);
+
+        $path = [];
+        foreach ($list as $sequence) {
+            $path[] = $this->getNode($sequence);
+        }
+
+        return implode('/', $path);
+    }
+
+    /**
+     * @param \stdClass|array|\Traversable $list
+     */
+    public static function validateListType($list)
+    {
+        if (!is_array($list) && !$list instanceof \Traversable && !$list instanceof \stdClass) {
+            throw new \InvalidArgumentException('Sequence list must be an array or \Traversable');
+        }
+
+    }
 }

--- a/src/Key/Deterministic/MultisigHD.php
+++ b/src/Key/Deterministic/MultisigHD.php
@@ -147,6 +147,22 @@ class MultisigHD
     }
 
     /**
+     * @param array|\stdClass|\Traversable $list
+     * @return MultisigHD
+     */
+    public function deriveFromList($list)
+    {
+        HierarchicalKeySequence::validateListType($list);
+
+        $account = $this;
+        foreach ($list as $sequence) {
+            $account = $account->deriveChild($sequence);
+        }
+
+        return $account;
+    }
+
+    /**
      * Derive a path in the tree of available addresses.
      *
      * @param string $path
@@ -154,13 +170,6 @@ class MultisigHD
      */
     public function derivePath($path)
     {
-        $decoded = explode('/', $this->keys[0]->decodePath($path));
-
-        $child = $this;
-        foreach ($decoded as $p) {
-            $child = $child->deriveChild($p);
-        }
-
-        return $child;
+        return $this->deriveFromList($this->sequences->decodePath($path));
     }
 }

--- a/tests/Key/Deterministic/HierarchicalKeySequenceTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeySequenceTest.php
@@ -61,4 +61,40 @@ class HierarchicalKeySequenceTest extends AbstractTestCase
         $expected = ['2147483648','2147483649','444','2147526030'];
         $this->assertEquals($expected, $sequence->decodePath("0'/1'/444/42382'"));
     }
+
+    /**
+     * @dataProvider getSequenceVectors
+     * @param $node
+     * @param $integer
+     */
+    public function testDecodePathVectors($node, $integer)
+    {
+        $sequence = new HierarchicalKeySequence(new Math());
+
+        // There should only be one, just implode to get the value
+        $this->assertEquals($integer, implode("", $sequence->decodePath($node)));
+    }
+
+    public function getEncodePathVectors() {
+        $array = ['2147483648','2147483649','444','2147526030'];
+        $stdClass = (object) $array;
+        $traversable = \SplFixedArray::fromArray($array);
+
+        return [
+            [$array],
+            [$stdClass],
+            [$traversable]
+        ];
+    }
+
+    /**
+     * @dataProvider getEncodePathVectors
+     */
+    public function testEncodePathVectors($list)
+    {
+        $sequence = new HierarchicalKeySequence(new Math());
+
+        $this->assertEquals("0h/1h/444/42382h", $sequence->encodePath($list));
+    }
+
 }

--- a/tests/Key/Deterministic/HierarchicalKeySequenceTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeySequenceTest.php
@@ -44,4 +44,21 @@ class HierarchicalKeySequenceTest extends AbstractTestCase
         // Ensures that requesting a hardened sequence for >= 0x80000000 throws an exception
         $sequence->getHardened(HierarchicalKeySequence::START_HARDENED);
     }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testDecodePathFailure()
+    {
+        $sequence = new HierarchicalKeySequence(new Math());
+        $sequence->decodePath('');
+    }
+
+    public function testDecodePath()
+    {
+        $sequence = new HierarchicalKeySequence(new Math());
+
+        $expected = ['2147483648','2147483649','444','2147526030'];
+        $this->assertEquals($expected, $sequence->decodePath("0'/1'/444/42382'"));
+    }
 }

--- a/tests/Key/Deterministic/HierarchicalKeyTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeyTest.php
@@ -91,15 +91,6 @@ class HierarchicalKeyTest extends AbstractTestCase
     }
 
     /**
-     * @expectedException \InvalidArgumentException
-     */
-    public function testDecodePathFailure()
-    {
-        $key = HierarchicalKeyFactory::generateMasterKey(Bitcoin::getEcAdapter());
-        $key->decodePath('');
-    }
-
-    /**
      * @dataProvider getEcAdapters
      * @param EcAdapterInterface $ecAdapter
      */
@@ -143,18 +134,9 @@ class HierarchicalKeyTest extends AbstractTestCase
         $this->compareToPrivVectors($key, $details);
 
         foreach ($derivs as $childDeriv) {
-            $path = $key->decodePath($childDeriv->path);
-            $key = $key->deriveChild($path);
+            $key = $key->derivePath($childDeriv->path);
             $this->compareToPrivVectors($key, $childDeriv->details);
         }
-    }
-
-    public function testDecodePath()
-    {
-        // need to init a HierarchicalKey to be able to call the method :/
-        $key = HierarchicalKeyFactory::fromExtended('xprv9s21ZrQH143K24zyWeuwtaWrpNjzYRX9VNSFgT6TwC8aBK46j95aWJM7rW9uek4M9BNosaoN8fLFMi3UVMAynimfuf164nXoZpaQJa2FXpU', $this->network);
-
-        $this->assertEquals('2147483648/2147483649/444/2147526030', $key->decodePath("0'/1'/444/42382'"));
     }
 
     public function testDerivePath()


### PR DESCRIPTION
Also refactors MultisigHD class to follow this convention.

New method: HierarchicalKey::deriveFromList(array|\stdClass|\Traversable $list);
New method: HierarchicalKeySequence::encodePath(\array|\stdClass|\Traversable $list);
Moved method: HierarchicalKeySequence::decodePath(string $path);
