### PR TITLE
API break: Remove EcAdapter::associateSigs in favor of SignatureSort

### DIFF
--- a/src/Crypto/EcAdapter/Adapter/EcAdapterInterface.php
+++ b/src/Crypto/EcAdapter/Adapter/EcAdapterInterface.php
@@ -72,11 +72,4 @@ interface EcAdapterInterface
      */
     public function recover(Buffer $messageHash, CompactSignatureInterface $compactSignature);
 
-    /**
-     * @param SignatureInterface[] $signatures
-     * @param Buffer $messageHash
-     * @param PublicKeyInterface[] $publicKeys
-     * @return array
-     */
-    public function associateSigs(array $signatures, Buffer $messageHash, array $publicKeys);
 }

--- a/src/Crypto/EcAdapter/Adapter/EcAdapterInterface.php
+++ b/src/Crypto/EcAdapter/Adapter/EcAdapterInterface.php
@@ -71,5 +71,4 @@ interface EcAdapterInterface
      * @return PublicKeyInterface
      */
     public function recover(Buffer $messageHash, CompactSignatureInterface $compactSignature);
-
 }

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Adapter/EcAdapter.php
@@ -87,32 +87,6 @@ class EcAdapter implements EcAdapterInterface
     }
 
     /**
-     * @param array $signatures
-     * @param Buffer $messageHash
-     * @param \BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface[] $publicKeys
-     * @return array
-     */
-    public function associateSigs(array $signatures, Buffer $messageHash, array $publicKeys)
-    {
-        $sigCount = count($signatures);
-        $linked = [];
-        foreach ($signatures as $c => $signature) {
-            foreach ($publicKeys as $key) {
-                $verify = $this->verify($messageHash, $key, $signature);
-                if ($verify) {
-                    $linked[$key->getPubKeyHash()->getHex()][] = $signature;
-                    if (count($linked) === $sigCount) {
-                        break 2;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-        return $linked;
-    }
-
-    /**
      * @param Buffer $messageHash
      * @param PublicKey $publicKey
      * @param Signature $signature

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
@@ -74,32 +74,6 @@ class EcAdapter implements EcAdapterInterface
     }
 
     /**
-     * @param array $signatures
-     * @param Buffer $messageHash
-     * @param \BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface[] $publicKeys
-     * @return array
-     */
-    public function associateSigs(array $signatures, Buffer $messageHash, array $publicKeys)
-    {
-        $sigCount = count($signatures);
-        $linked = [];
-        foreach ($signatures as $c => $signature) {
-            foreach ($publicKeys as $key) {
-                $verify = $this->verify($messageHash, $key, $signature);
-                if ($verify) {
-                    $linked[$key->getPubKeyHash()->getHex()][] = $signature;
-                    if (count($linked) === $sigCount) {
-                        break 2;
-                    } else {
-                        break;
-                    }
-                }
-            }
-        }
-        return $linked;
-    }
-
-    /**
      * @param int|string $element
      * @param bool $half
      * @return bool

--- a/src/Signature/SignatureSort.php
+++ b/src/Signature/SignatureSort.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BitWasp\Bitcoin\Signature;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Buffertools\Buffer;
+
+class SignatureSort implements SignatureSortInterface
+{
+    /**
+     * @var EcAdapterInterface
+     */
+    private $ecAdapter;
+
+    /**
+     * SignatureSort constructor.
+     * @param EcAdapterInterface $ecAdapter
+     */
+    public function __construct(EcAdapterInterface $ecAdapter)
+    {
+        $this->ecAdapter = $ecAdapter;
+    }
+
+    /**
+     * @param \BitWasp\Bitcoin\Crypto\EcAdapter\Signature\SignatureInterface[] $signatures
+     * @param \BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface[] $publicKeys
+     * @param Buffer $messageHash
+     * @return \SplObjectStorage
+     */
+    public function link(array $signatures, array $publicKeys, Buffer $messageHash)
+    {
+        $sigCount = count($signatures);
+        $storage = new \SplObjectStorage();
+        foreach ($signatures as $signature) {
+            foreach ($publicKeys as $key) {
+                if ($this->ecAdapter->verify($messageHash, $key, $signature)) {
+                    $storage->attach($key, $signature);
+                    if (count($storage) === $sigCount) {
+                        break 2;
+                    }
+
+                    break;
+                }
+            }
+        }
+
+        return $storage;
+    }
+}

--- a/src/Signature/SignatureSortInterface.php
+++ b/src/Signature/SignatureSortInterface.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: tk
+ * Date: 28/12/15
+ * Time: 14:54
+ */
+namespace BitWasp\Bitcoin\Signature;
+
+use BitWasp\Buffertools\Buffer;
+
+interface SignatureSortInterface
+{
+    /**
+     * @param \BitWasp\Bitcoin\Crypto\EcAdapter\Signature\SignatureInterface[] $signatures
+     * @param \BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface[] $publicKeys
+     * @param Buffer $messageHash
+     * @return \SplObjectStorage
+     */
+    public function link(array $signatures, array $publicKeys, Buffer $messageHash);
+}

--- a/src/Signature/SignatureSortInterface.php
+++ b/src/Signature/SignatureSortInterface.php
@@ -1,10 +1,5 @@
 <?php
-/**
- * Created by PhpStorm.
- * User: tk
- * Date: 28/12/15
- * Time: 14:54
- */
+
 namespace BitWasp\Bitcoin\Signature;
 
 use BitWasp\Buffertools\Buffer;

--- a/src/Transaction/Factory/TxSigner.php
+++ b/src/Transaction/Factory/TxSigner.php
@@ -163,13 +163,11 @@ class TxSigner
         // loop over the publicKeys to find the key to sign with
         foreach ($inputState->getPublicKeys() as $idx => $publicKey) {
             if ($privateKey->getPublicKey()->getBinary() === $publicKey->getBinary()) {
-                $signature = $this->makeSignature(
+                $inputState->setSignature($idx, $this->makeSignature(
                     $privateKey,
                     $this->signatureHash->calculate($redeemScript ?: $outputScript, $inputToSign, $sigHashType),
                     $sigHashType
-                );
-
-                $inputState->setSignature($idx, $signature);
+                ));
             }
         }
 


### PR DESCRIPTION
The code for both implementations was duplicated, so separating this out into a separate class. 