### PR TITLE
Fix flags test in Interpreter

### DIFF
--- a/src/Script/Interpreter/Checker.php
+++ b/src/Script/Interpreter/Checker.php
@@ -124,11 +124,11 @@ class Checker
             return $this;
         }
 
-        if ($flags & (Interpreter::VERIFY_DERSIG | Interpreter::VERIFY_LOW_S | Interpreter::VERIFY_STRICTENC) && !$this->isValidSignatureEncoding($signature)) {
+        if (($flags & (Interpreter::VERIFY_DERSIG | Interpreter::VERIFY_LOW_S | Interpreter::VERIFY_STRICTENC)) != 0 && !$this->isValidSignatureEncoding($signature)) {
             throw new ScriptRuntimeException(Interpreter::VERIFY_DERSIG, 'Signature with incorrect encoding');
-        } else if ($flags & Interpreter::VERIFY_LOW_S && !$this->isLowDerSignature($signature)) {
+        } else if (($flags & Interpreter::VERIFY_LOW_S) != 0 && !$this->isLowDerSignature($signature)) {
             throw new ScriptRuntimeException(Interpreter::VERIFY_LOW_S, 'Signature s element was not low');
-        } else if ($flags & Interpreter::VERIFY_STRICTENC && !$this->isDefinedHashtypeSignature($signature)) {
+        } else if (($flags & Interpreter::VERIFY_STRICTENC) != 0 && !$this->isDefinedHashtypeSignature($signature)) {
             throw new ScriptRuntimeException(Interpreter::VERIFY_STRICTENC, 'Signature with invalid hashtype');
         }
 
@@ -143,7 +143,7 @@ class Checker
      */
     public function checkPublicKeyEncoding(BufferInterface $publicKey, $flags)
     {
-        if ($flags & Interpreter::VERIFY_STRICTENC && !PublicKey::isCompressedOrUncompressed($publicKey)) {
+        if (($flags & Interpreter::VERIFY_STRICTENC) != 0 && !PublicKey::isCompressedOrUncompressed($publicKey)) {
             throw new ScriptRuntimeException(Interpreter::VERIFY_STRICTENC, 'Public key with incorrect encoding');
         }
 

--- a/src/Script/Interpreter/Interpreter.php
+++ b/src/Script/Interpreter/Interpreter.php
@@ -391,7 +391,7 @@ class Interpreter implements InterpreterInterface
         $this->opCount = 0;
         $altStack = new Stack();
         $vfStack = new Stack();
-        $minimal = (bool) ($flags & self::VERIFY_MINIMALDATA);
+        $minimal = ($flags & self::VERIFY_MINIMALDATA) != 0;
         $parser = $script->getScriptParser();
 
         if ($script->getBuffer()->getSize() > 10000) {


### PR DESCRIPTION
Some checks weren't written correctly, leading to some features being active when not required.