### PR TITLE
Fix hhvm bug

### DIFF
--- a/src/Collection/Generic/Set.php
+++ b/src/Collection/Generic/Set.php
@@ -12,6 +12,6 @@ class Set extends StaticCollection
      */
     public function __construct(array $values)
     {
-        $this->set = \SplFixedArray::fromArray($values);
+        $this->set = \SplFixedArray::fromArray($values, false);
     }
 }

--- a/src/Collection/Transaction/TransactionCollection.php
+++ b/src/Collection/Transaction/TransactionCollection.php
@@ -20,7 +20,7 @@ class TransactionCollection extends StaticCollection
             }
         }
 
-        $this->set = \SplFixedArray::fromArray($transactions);
+        $this->set = \SplFixedArray::fromArray($transactions, false);
     }
 
     public function __clone()

--- a/src/Transaction/Mutator/InputCollectionMutator.php
+++ b/src/Transaction/Mutator/InputCollectionMutator.php
@@ -20,7 +20,7 @@ class InputCollectionMutator extends MutableCollection
             $set[$i] = new InputMutator($input);
         }
 
-        $this->set = \SplFixedArray::fromArray($set);
+        $this->set = \SplFixedArray::fromArray($set, false);
     }
 
     /**
@@ -69,7 +69,7 @@ class InputCollectionMutator extends MutableCollection
             throw new \RuntimeException('Invalid start or length');
         }
 
-        $this->set = \SplFixedArray::fromArray(array_slice($this->set->toArray(), $start, $length));
+        $this->set = \SplFixedArray::fromArray(array_slice($this->set->toArray(), $start, $length), false);
         return $this;
     }
 

--- a/src/Transaction/Mutator/OutputCollectionMutator.php
+++ b/src/Transaction/Mutator/OutputCollectionMutator.php
@@ -67,7 +67,7 @@ class OutputCollectionMutator extends MutableCollection
             throw new \RuntimeException('Invalid start or length');
         }
 
-        $this->set = \SplFixedArray::fromArray(array_slice($this->set->toArray(), $start, $length));
+        $this->set = \SplFixedArray::fromArray(array_slice($this->set->toArray(), $start, $length), false);
         return $this;
     }
 

--- a/src/Transaction/Mutator/WitnessCollectionMutator.php
+++ b/src/Transaction/Mutator/WitnessCollectionMutator.php
@@ -20,7 +20,7 @@ class WitnessCollectionMutator extends MutableCollection
             $set[$i] = new InputMutator($input);
         }
 
-        $this->set = \SplFixedArray::fromArray($set);
+        $this->set = \SplFixedArray::fromArray($set, false);
     }
 
     /**
@@ -69,7 +69,7 @@ class WitnessCollectionMutator extends MutableCollection
             throw new \RuntimeException('Invalid start or length');
         }
 
-        $this->set = \SplFixedArray::fromArray(array_slice($this->set->toArray(), $start, $length));
+        $this->set = \SplFixedArray::fromArray(array_slice($this->set->toArray(), $start, $length), false);
         return $this;
     }
 

--- a/tests/Key/Deterministic/HierarchicalKeySequenceTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeySequenceTest.php
@@ -78,8 +78,12 @@ class HierarchicalKeySequenceTest extends AbstractTestCase
     public function getEncodePathVectors()
     {
         $array = ['2147483648','2147483649','444','2147526030'];
-        $stdClass = (object) $array;
-        $traversable = \SplFixedArray::fromArray($array);
+        $stdClass = new \stdClass();
+        $stdClass->a = '2147483648';
+        $stdClass->b = '2147483649';
+        $stdClass->c = '444';
+        $stdClass->d  = '2147526030';
+        $traversable = \SplFixedArray::fromArray($array, false);
 
         return [
             [$array],


### PR DESCRIPTION
SplFixedArray in HHVM uses max on a list of values without first checking it's count. Since there is no max in an empty array, it throws an exception (deviation from PHP). Fixed by setting $save_indexes = false