### PR TITLE
Add Bitcoin::getParams

### DIFF
--- a/src/Bitcoin.php
+++ b/src/Bitcoin.php
@@ -2,6 +2,8 @@
 
 namespace BitWasp\Bitcoin;
 
+use BitWasp\Bitcoin\Chain\Params;
+use BitWasp\Bitcoin\Chain\ParamsInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\EcAdapterFactory;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Math\Math;
@@ -18,7 +20,15 @@ class Bitcoin
      */
     private static $network;
 
+    /**
+     * @var EcAdapterInterface
+     */
     private static $adapter;
+
+    /**
+     * @var ParamsInterface
+     */
+    private static $params;
 
     /**
      * @return Math
@@ -53,6 +63,38 @@ class Bitcoin
         return self::$adapter;
     }
 
+    /**
+     * @param ParamsInterface $params
+     */
+    public static function setParams(ParamsInterface $params)
+    {
+        self::$params = $params;
+    }
+
+    /**
+     * @return ParamsInterface
+     */
+    public function getParams()
+    {
+        if (null === self::$params) {
+            self::$params = self::getDefaultParams();
+        }
+
+        return self::$params;
+    }
+
+    /**
+     * @param Math|null $math
+     * @return ParamsInterface
+     */
+    public static function getDefaultParams(Math $math = null)
+    {
+        return new Params($math ?: Bitcoin::getMath());
+    }
+
+    /**
+     * @param EcAdapterInterface $adapter
+     */
     public static function setAdapter(EcAdapterInterface $adapter)
     {
         self::$adapter = $adapter;
@@ -78,6 +120,9 @@ class Bitcoin
         return self::$network;
     }
 
+    /**
+     * @return NetworkInterface
+     */
     public static function getDefaultNetwork()
     {
         return NetworkFactory::bitcoin();

--- a/src/Block/BlockInterface.php
+++ b/src/Block/BlockInterface.php
@@ -10,7 +10,6 @@ use BitWasp\Buffertools\BufferInterface;
 
 interface BlockInterface extends SerializableInterface
 {
-    const CURRENT_VERSION = 2;
     const MAX_BLOCK_SIZE = 1000000;
 
     /**


### PR DESCRIPTION
`ParamsInterface` isn't heavily utilized in this library, but it's important elsewhere. It's essentially a clone of Core's chainparams file, certainly not something to tinker with without reason. 

All the same, it's a very global setting, so adding static methods to the `Bitcoin` class: `getParams`, `getDefaultParams`, `setParams`