### PR TITLE
prevent requirements upgrading minor versions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,18 +26,18 @@
     "php": ">=5.6",
     "ext-gmp": "*",
     "ext-openssl": "*",
-    "paragonie/random_compat": "~1.4|~2.0",
+    "paragonie/random_compat": "~1.4.0|~2.0.0",
     "pleonasm/merkle-tree": "1.0.0",
-    "lastguest/murmurhash": "~1.1",
-    "rgooding/protobuf-php": "~0.0",
-    "symfony/http-foundation": "~3.0",
-    "mdanter/ecc": "~0.4",
-    "bitwasp/buffertools": "~0.3",
+    "lastguest/murmurhash": "~1.1.0",
+    "rgooding/protobuf-php": "~0.0.1",
+    "symfony/http-foundation": "~3.0.0",
+    "mdanter/ecc": "~0.4.0",
+    "bitwasp/buffertools": "~0.3.0",
     "bitwasp/secp256k1-php": "~0.0.7"
   },
   "require-dev": {
     "ext-json": "*",
-    "bitwasp/testing-php": "~0.1",
-    "symfony/yaml": "~2.6"
+    "bitwasp/testing-php": "~0.1.0",
+    "symfony/yaml": "~2.6.0"
   }
 }


### PR DESCRIPTION
They shouldn't, but minor versions tend to contain BC breaks, rather not excidently get those ...  

Using the tilde `~` is always a bit funky imo, cuz: `~1.2` is equivalent to `>=1.2 <2.0.0`, while `~1.2.3` is equivalent to `>=1.2.3 <1.3.0`...

So I added the patch version for each dep.

*ref; https://getcomposer.org/doc/articles/versions.md*