### PR TITLE
Avoid unnecessary point multiplication in test setup

### DIFF
--- a/src/Key/PrivateKeyFactory.php
+++ b/src/Key/PrivateKeyFactory.php
@@ -5,6 +5,7 @@ namespace BitWasp\Bitcoin\Key;
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PrivateKey;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PrivateKeySerializerInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Crypto\Random\Random;
@@ -37,7 +38,7 @@ class PrivateKeyFactory
      * @param int|string $int
      * @param bool $compressed
      * @param EcAdapterInterface|null $ecAdapter
-     * @return PrivateKey
+     * @return PrivateKeyInterface
      */
     public static function fromInt($int, $compressed = false, EcAdapterInterface $ecAdapter = null)
     {
@@ -48,7 +49,7 @@ class PrivateKeyFactory
     /**
      * @param bool $compressed
      * @param EcAdapterInterface|null $ecAdapter
-     * @return PrivateKey
+     * @return PrivateKeyInterface
      */
     public static function create($compressed = false, EcAdapterInterface $ecAdapter = null)
     {
@@ -78,7 +79,7 @@ class PrivateKeyFactory
      * @param \BitWasp\Buffertools\BufferInterface|string $hex
      * @param bool $compressed
      * @param EcAdapterInterface|null $ecAdapter
-     * @return PrivateKey
+     * @return PrivateKeyInterface
      */
     public static function fromHex($hex, $compressed = false, EcAdapterInterface $ecAdapter = null)
     {

--- a/src/Key/PrivateKeyFactory.php
+++ b/src/Key/PrivateKeyFactory.php
@@ -4,7 +4,6 @@ namespace BitWasp\Bitcoin\Key;
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PrivateKey;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PrivateKeySerializerInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -81,15 +81,10 @@ class AddressTest extends AbstractTestCase
         AddressFactory::fromString($add, $network);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Script type is not associated with an address
-     */
-    public function testFromOutputScript()
+    public function testFromOutputScriptSuccess()
     {
         $outputScriptFactory = ScriptFactory::scriptPubKey();
-        $privateKey = PrivateKeyFactory::create();
-        $publicKey = $privateKey->getPublicKey();
+        $publicKey = PublicKeyFactory::fromHex('045b81f0017e2091e2edcd5eecf10d5bdd120a5514cb3ee65b8447ec18bfc4575c6d5bf415e54e03b1067934a0f0ba76b01c6b9ab227142ee1d543764b69d901e0');
 
         $pubkeyHash = $outputScriptFactory->payToPubKeyHash($publicKey);
         $scriptHash = $outputScriptFactory->payToScriptHash($outputScriptFactory->multisig(1, [$publicKey]));
@@ -99,7 +94,14 @@ class AddressTest extends AbstractTestCase
 
         $scriptAddress = AddressFactory::fromOutputScript($scriptHash);
         $this->assertInstanceOf(ScriptHashAddress::class, $scriptAddress);
+    }
 
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptionMessage Script type is not associated with an address
+     */
+    public function testFromOutputScript()
+    {
         $unknownScript = ScriptFactory::create()->op('OP_0')->op('OP_1')->getScript();
         AddressFactory::fromOutputScript($unknownScript);
     }

--- a/tests/Key/Deterministic/ElectrumKeyTest.php
+++ b/tests/Key/Deterministic/ElectrumKeyTest.php
@@ -7,6 +7,7 @@ use BitWasp\Bitcoin\Crypto\Random\Random;
 use BitWasp\Bitcoin\Key\Deterministic\ElectrumKey;
 use BitWasp\Bitcoin\Key\Deterministic\ElectrumKeyFactory;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
 
 class ElectrumKeyTest extends AbstractTestCase
@@ -100,7 +101,7 @@ class ElectrumKeyTest extends AbstractTestCase
      */
     public function testFailsWithoutMasterPrivateKey()
     {
-        $key = PrivateKeyFactory::create()->getPublicKey();
+        $key = PublicKeyFactory::fromHex('045b81f0017e2091e2edcd5eecf10d5bdd120a5514cb3ee65b8447ec18bfc4575c6d5bf415e54e03b1067934a0f0ba76b01c6b9ab227142ee1d543764b69d901e0');
         $e = ElectrumKeyFactory::fromKey($key);
         $e->getMasterPrivateKey();
     }

--- a/tests/Key/Deterministic/HierarchicalKeyTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeyTest.php
@@ -5,6 +5,7 @@ namespace BitWasp\Bitcoin\Tests\Key\Deterministic;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
@@ -365,8 +366,9 @@ class HierarchicalKeyTest extends AbstractTestCase
         $math = new Math();
         $generator = EccFactory::getSecgCurves($math)->generator256k1();
 
-        $k = gmp_strval($math->sub($generator->getOrder(), gmp_init(1)), 10);
-        $startPub = PrivateKeyFactory::fromInt($k, true)->getPublicKey();
+
+        $k = $math->sub($generator->getOrder(), gmp_init(1));
+        $startPub = PublicKeyFactory::fromHex('0379be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798');
 
         $mock = $this->getMockBuilder('\BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface')
             ->setMethods([
@@ -470,6 +472,6 @@ class HierarchicalKeyTest extends AbstractTestCase
         $this->assertNotEquals($expected, $child->getSequence());
         $this->assertEquals(2, $child->getSequence());
         $this->assertEquals(2, $this->HK_run_count);
-        $this->assertEquals(gmp_strval($math->add(gmp_init($k), gmp_init(1)), 10), gmp_strval($child->getPrivateKey()->getSecret(), 10));
+        $this->assertEquals(gmp_strval($math->add($k, gmp_init(1)), 10), gmp_strval($child->getPrivateKey()->getSecret(), 10));
     }
 }

--- a/tests/Script/Classifier/OutputClassifierTest.php
+++ b/tests/Script/Classifier/OutputClassifierTest.php
@@ -4,6 +4,7 @@ namespace BitWasp\Bitcoin\Tests\Script\Classifier;
 
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
 use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\Script;
@@ -33,7 +34,7 @@ class OutputClassifierTest extends AbstractTestCase
 
     public function generateVectors()
     {
-        $publicKey1 = PrivateKeyFactory::create()->getPublicKey();
+        $publicKey1 = PublicKeyFactory::fromHex('045b81f0017e2091e2edcd5eecf10d5bdd120a5514cb3ee65b8447ec18bfc4575c6d5bf415e54e03b1067934a0f0ba76b01c6b9ab227142ee1d543764b69d901e0');
         $buffer1 = $publicKey1->getBuffer();
         $p2pk = ScriptFactory::sequence([$buffer1, Opcodes::OP_CHECKSIG]);
 

--- a/tests/Script/P2shScriptTest.php
+++ b/tests/Script/P2shScriptTest.php
@@ -4,6 +4,7 @@ namespace BitWasp\Bitcoin\Tests\Script;
 
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
 
@@ -11,7 +12,7 @@ class P2shScriptTest extends AbstractTestCase
 {
     public function testOutputScript()
     {
-        $key = PrivateKeyFactory::create()->getPublicKey();
+        $key = PublicKeyFactory::fromHex('045b81f0017e2091e2edcd5eecf10d5bdd120a5514cb3ee65b8447ec18bfc4575c6d5bf415e54e03b1067934a0f0ba76b01c6b9ab227142ee1d543764b69d901e0');
         $script = ScriptFactory::p2sh()->multisig(1, [$key]);
 
         $hash = Hash::sha256ripe160($script->getBuffer());

--- a/tests/Script/ScriptCountSigOpsTest.php
+++ b/tests/Script/ScriptCountSigOpsTest.php
@@ -2,7 +2,7 @@
 
 namespace BitWasp\Bitcoin\Tests\Script;
 
-use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
@@ -67,9 +67,9 @@ class ScriptCountSigOpsTest extends AbstractTestCase
     public function testMultisig()
     {
         $pk = [];
-        for ($i = 0; $i < 3; $i++) {
-            $pk[] = PrivateKeyFactory::create()->getPublicKey();
-        }
+        $pk[] = PublicKeyFactory::fromHex('045b81f0017e2091e2edcd5eecf10d5bdd120a5514cb3ee65b8447ec18bfc4575c6d5bf415e54e03b1067934a0f0ba76b01c6b9ab227142ee1d543764b69d901e0');
+        $pk[] = $pk[0]->tweakAdd(gmp_init(1));
+        $pk[] = $pk[0]->tweakAdd(gmp_init(2));
 
         $p2shScript = ScriptFactory::scriptPubKey()->multisig(1, $pk);
         $this->assertEquals(3, $p2shScript->countSigOps(true));

--- a/tests/Script/ScriptInfo/MultisigTest.php
+++ b/tests/Script/ScriptInfo/MultisigTest.php
@@ -3,22 +3,18 @@
 namespace BitWasp\Bitcoin\Tests\Script\ScriptInfo;
 
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInfo\Multisig;
-use BitWasp\Bitcoin\Script\ScriptInfo\PayToPubkey;
-use BitWasp\Bitcoin\Script\ScriptInfo\PayToPubkeyHash;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
 
 class MultisigTest extends AbstractTestCase
 {
     public function testMethods()
     {
-        $priv = PrivateKeyFactory::create();
-        $pub = $priv->getPublicKey();
-
-        $otherpriv = PrivateKeyFactory::create();
-        $otherpub = $otherpriv->getPublicKey();
+        $pub = PublicKeyFactory::fromHex('045b81f0017e2091e2edcd5eecf10d5bdd120a5514cb3ee65b8447ec18bfc4575c6d5bf415e54e03b1067934a0f0ba76b01c6b9ab227142ee1d543764b69d901e0');
+        $otherpub = $pub->tweakAdd(gmp_init(1));
 
         $script = ScriptFactory::scriptPubKey()->multisig(2, [$pub, $otherpub]);
         $classifier = new OutputClassifier();
@@ -30,7 +26,7 @@ class MultisigTest extends AbstractTestCase
         $this->assertTrue($info->checkInvolvesKey($pub));
         $this->assertTrue($info->checkInvolvesKey($otherpub));
 
-        $unrelatedPub = PrivateKeyFactory::create()->getPublicKey();
+        $unrelatedPub = $otherpub->tweakAdd(gmp_init(1));
         $this->assertFalse($info->checkInvolvesKey($unrelatedPub));
 
     }


### PR DESCRIPTION
Reduces the number of scalar multiplications executed in the test function by favoring static keys where possible. 