### PR TITLE
Sanity checks for entropy size

### DIFF
--- a/src/Mnemonic/Bip39/Bip39Mnemonic.php
+++ b/src/Mnemonic/Bip39/Bip39Mnemonic.php
@@ -70,6 +70,16 @@ class Bip39Mnemonic implements MnemonicInterface
      */
     public function entropyToWords(BufferInterface $entropy)
     {
+        if ($entropy->getSize() === 0) {
+            throw new \InvalidArgumentException('Invalid entropy, empty');
+        }
+        if ($entropy->getSize() > 1024) {
+            throw new \InvalidArgumentException('Invalid entropy, max 1024 bytes');
+        }
+        if ($entropy->getSize() % 4 !== 0) {
+            throw new \InvalidArgumentException('Invalid entropy, must be multitude of 4 bytes');
+        }
+
         $math = $this->ecAdapter->getMath();
 
         $ENT = $entropy->getSize() * 8;
@@ -116,6 +126,11 @@ class Bip39Mnemonic implements MnemonicInterface
         }
 
         $bits = implode('', $bits);
+
+        // max entropy is 1024; (1024×8)+((1024×8)÷32) = 8448
+        if (strlen($bits) > 8448) {
+            throw new \InvalidArgumentException('Invalid mnemonic, too long');
+        }
 
         $CS = strlen($bits) / 33;
         $ENT = strlen($bits) - $CS;

--- a/tests/Mnemonic/Bip39/Bip39MnemonicTest.php
+++ b/tests/Mnemonic/Bip39/Bip39MnemonicTest.php
@@ -5,6 +5,7 @@ namespace BitWasp\Bitcoin\Tests\Mnemonic\Bip39;
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Mnemonic\Bip39\Bip39Mnemonic;
 use BitWasp\Bitcoin\Mnemonic\Bip39\Wordlist\EnglishWordList;
+use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
 
 class Bip39MnemonicTest extends AbstractBip39Case
@@ -55,5 +56,37 @@ class Bip39MnemonicTest extends AbstractBip39Case
         $bip39 = new Bip39Mnemonic(Bitcoin::getEcAdapter(), new EnglishWordList());
         $mnemonic = 'jelly better achieve collect unaware mountain thought cargo oxygen act hood oxygen';
         $bip39->mnemonicToEntropy($mnemonic);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid entropy, must be multitude of 4 bytes
+     */
+    public function testFailsOnEntropyMod4()
+    {
+        $bip39 = new Bip39Mnemonic(Bitcoin::getEcAdapter(), new EnglishWordList());
+        $bip39->entropyToMnemonic(Buffer::hex(str_repeat('00', 5)));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid entropy, max 1024 bytes
+     */
+    public function testFailsOnEntropyTooLong()
+    {
+        $bip39 = new Bip39Mnemonic(Bitcoin::getEcAdapter(), new EnglishWordList());
+        $bip39->entropyToMnemonic(Buffer::hex(str_repeat('00', 1028)));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage Invalid mnemonic, too long
+     */
+    public function testFailsOnMnemonicOfEntropyTooLong()
+    {
+        $bip39 = new Bip39Mnemonic(Bitcoin::getEcAdapter(), new EnglishWordList());
+        $mnemonic = 'abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about end grace oxygen maze bright face loan ticket trial leg cruel lizard bread worry reject journey perfect chef section caught neither install industry';
+        $bip39->mnemonicToEntropy($mnemonic);
+
     }
 }


### PR DESCRIPTION
The only sane solution seems to be to do better sanity checks in the entropy;
 1. It should always be a multitude of 4 bytes, that way it will always result in a multitude of 11 bits (including checksum) and no weird padding things will happen with the checksum.
 2. It should not allow entropy above 1024 bytes, because at that point we've reached the max length of the checksum (sha256) and if we continue (without padding the checksum) the above rule won't hold

The only alternative for the max 1024 bytes would be to pad the checksum to keep the first rule in tact, but since the BIP39 spec doesn't mention anything like that it doesn't seem like a good choice.