### PR TITLE
Trim opcodes debug info

### DIFF
--- a/src/Script/Opcodes.php
+++ b/src/Script/Opcodes.php
@@ -361,4 +361,12 @@ class Opcodes implements \ArrayAccess
     {
         $this->errorNoWrite();
     }
+
+    /**
+     * @return array
+     */
+    public function __debugInfo()
+    {
+        return [];
+    }
 }

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -63,9 +63,12 @@ class AddressTest extends AbstractTestCase
             throw new \Exception('Unknown address type');
         }
 
-        $fromString = AddressFactory::fromString($address);
         $this->assertEquals($address, $obj->getAddress($network));
-        $this->assertEquals($obj, $fromString);
+
+        $fromString = AddressFactory::fromString($address);
+        $this->assertTrue($obj->getHash()->equals($fromString->getHash()));
+        $this->assertEquals($obj->getPrefixByte($network), $fromString->getPrefixByte($network));
+        $this->assertEquals($obj->getAddress($network), $fromString->getAddress($network));
     }
 
     /**

--- a/tests/Script/OpcodesTest.php
+++ b/tests/Script/OpcodesTest.php
@@ -65,4 +65,10 @@ class OpcodesTest extends AbstractTestCase
         $op = new Opcodes();
         unset($op[Opcodes::OP_1]);
     }
+
+    public function testDebugInfo()
+    {
+        $op = new Opcodes();
+        $this->assertEquals([], $op->__debugInfo());
+    }
 }


### PR DESCRIPTION
`Opcodes` has a really long array in it, making a transactions debugging info quite unfriendly. This PR solves this, and fixes an error in the tests due to mb-string