### PR TITLE
Script Parser::toHumanReadable() - better support pushdata opcodes

### DIFF
--- a/src/Script/Parser/Parser.php
+++ b/src/Script/Parser/Parser.php
@@ -205,9 +205,14 @@ class Parser implements \Iterator
     {
         return implode(' ', array_map(
             function (Operation $operation) {
-                return $operation->isPush()
-                    ? $operation->getData()->getHex()
-                    : $this->script->getOpcodes()->getOp($operation->getOp());
+                $op = $operation->getOp();
+                if ($op === Opcodes::OP_0 || $op === Opcodes::OP_1NEGATE || $op >= Opcodes::OP_1 && $op <= Opcodes::OP_16) {
+                    return $this->script->getOpcodes()->getOp($op);
+                } else if ($operation->isPush()) {
+                    return $operation->getData()->getHex();
+                } else {
+                    return $this->script->getOpcodes()->getOp($operation->getOp());
+                }
             },
             $this->decode()
         ));


### PR DESCRIPTION
Since isPush returns true for OP_0, etc, check so the opcode is at least displayed.