### PR TITLE
v0.0.7: Fix versions in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,19 +27,20 @@
     "ext-json": "*",
     "ext-openssl": "*",
     "ext-mcrypt": "*",
-    "mdanter/ecc": "~0.3",
-    "pleonasm/merkle-tree": "1.0.0",
-    "doctrine/cache": "~1.4",
-    "fguillot/json-rpc": "0.0.1",
-    "rych/hash_pbkdf2-compat": "~1.0",
-    "lastguest/murmurhash": "~1.0",
-    "rgooding/protobuf-php": "~0.0",
-    "react/react": "~0.4",
-    "react/socket-client": "~0.4",
-    "bitwasp/buffertools": "~0.1",
-    "bitwasp/stratum": "~0.1"
+    "mdanter/ecc": "v0.3.0",
+    "pleonasm/merkle-tree": "v1.0.0",
+    "doctrine/cache": "v1.4",
+    "fguillot/json-rpc": "v0.0.1",
+    "rych/hash_pbkdf2-compat": "v1.0.0",
+    "lastguest/murmurhash": "v1.0",
+    "rgooding/protobuf-php": "v0.0.1",
+    "react/react": "v0.4.0",
+    "react/socket-client": "^0.4.0",
+    "bitwasp/buffertools": "v0.1.5",
+    "bitwasp/stratum": "v0.1.0"
   },
   "require-dev": {
+    "phpunit/phpunit": "4.0",
     "bitwasp/testing-php": "~0.0",
     "symfony/yaml": "~2.6"
   }

--- a/src/Block/GenesisMiningBlockHeader.php
+++ b/src/Block/GenesisMiningBlockHeader.php
@@ -6,7 +6,6 @@ class GenesisMiningBlockHeader extends BlockHeader
 {
     public function __construct()
     {
-        
     }
 
     /**

--- a/src/Block/MerkleRoot.php
+++ b/src/Block/MerkleRoot.php
@@ -79,7 +79,6 @@ class MerkleRoot
 
         if ($txCount == 1) {
             $buffer = $hashFxn($this->transactions->getTransaction(0)->getBinary());
-
         } else {
             // Create a fixed size Merkle Tree
             $tree = new FixedSizeTree($txCount + ($txCount % 2), $hashFxn);

--- a/src/Key/Deterministic/ElectrumKey.php
+++ b/src/Key/Deterministic/ElectrumKey.php
@@ -44,7 +44,6 @@ class ElectrumKey
         }
 
         $this->publicKey = $masterKey;
-
     }
 
     /**

--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -67,7 +67,6 @@ class HierarchicalKey
         $this->parentFingerprint = $parentFingerprint;
         $this->chainCode = $chainCode;
         $this->key = $key;
-
     }
 
     /**
@@ -205,7 +204,6 @@ class HierarchicalKey
             $parser
                 ->writeBytes(1, '00')
                 ->writeBytes(32, $this->getPrivateKey()->getBuffer());
-
         } else {
             $parser->writeBytes(33, $this->getPublicKey()->getBuffer());
         }

--- a/src/PaymentProtocol/PaymentRequestSigner.php
+++ b/src/PaymentProtocol/PaymentRequestSigner.php
@@ -75,7 +75,6 @@ class PaymentRequestSigner
                 ? OPENSSL_ALGO_SHA256
                 : OPENSSL_ALGO_SHA1;
         }
-
     }
 
     /**

--- a/src/Script/Factory/OutputScriptFactory.php
+++ b/src/Script/Factory/OutputScriptFactory.php
@@ -40,7 +40,6 @@ class OutputScriptFactory
                 ->push(Buffer::hex($address->getHash()))
                 ->op('OP_EQUALVERIFY')
                 ->op('OP_CHECKSIG'));
-
     }
 
     /**

--- a/src/Script/Interpreter/Interpreter.php
+++ b/src/Script/Interpreter/Interpreter.php
@@ -666,7 +666,6 @@ class Interpreter implements InterpreterInterface
                     if ($mainStack->size() + $altStack->size() > 1000) {
                         throw new \Exception('Invalid stack size, exceeds 1000');
                     }
-
                 }
             }
 

--- a/src/Script/Interpreter/Operation/FlowControlOperation.php
+++ b/src/Script/Interpreter/Operation/FlowControlOperation.php
@@ -59,21 +59,18 @@ class FlowControlOperation
             }
             $vfStack->push($value);
             return;
-
         } else if ($opName == 'OP_ELSE') {
             if ($vfStack->size() == 0) {
                 throw new \Exception('Unbalanced conditional');
             }
             $vfStack->set($vfStack->end() - 1, !$vfStack->end());
             return;
-
         } else if ($opName == 'OP_ENDIF') {
             if ($vfStack->size() == 0) {
                 throw new \Exception('Unbalanced conditional');
             }
             // todo
             return;
-
         } else if ($opName == 'OP_VERIFY') {
             if ($mainStack->size() < 1) {
                 throw new \Exception('Invalid stack operation');
@@ -84,7 +81,6 @@ class FlowControlOperation
             }
             $mainStack->pop();
             return;
-
         } else if ($opName == 'OP_RETURN') {
             throw new \Exception('Error: OP_RETURN');
         }

--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -116,17 +116,14 @@ class Script extends Serializable implements ScriptInterface
 
         if ($length < $this->opcodes->getOpByName('OP_PUSHDATA1')) {
             $parsed = $parsed->writeWithLength($data);
-
         } elseif ($length <= 0xff) {
             $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA1'))
                 ->writeInt(1, $length, false)
                 ->writeBytes($length, $data);
-
         } elseif ($length <= 0xffff) {
             $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA2'))
                 ->writeInt(2, $length, true)
                 ->writeBytes($length, $data);
-
         } else {
             $parsed->writeInt(1, $this->opcodes->getOpByName('OP_PUSHDATA4'))
                 ->writeInt(4, $length, true)

--- a/src/Serializer/Block/HexBlockHeaderSerializer.php
+++ b/src/Serializer/Block/HexBlockHeaderSerializer.php
@@ -56,7 +56,6 @@ class HexBlockHeaderSerializer
                 $nBits,
                 $nonce
             );
-
         } catch (ParserOutOfRange $e) {
             throw new ParserOutOfRange('Failed to extract full block header from parser');
         }

--- a/src/Serializer/Block/HexBlockSerializer.php
+++ b/src/Serializer/Block/HexBlockSerializer.php
@@ -66,7 +66,6 @@ class HexBlockSerializer
             );
 
             $block->getTransactions()->addTransactions($this->getTxsTemplate()->parse($parser)[0]);
-
         } catch (ParserOutOfRange $e) {
             throw new ParserOutOfRange('Failed to extract full block header from parser');
         }

--- a/src/Signature/TransactionSignature.php
+++ b/src/Signature/TransactionSignature.php
@@ -106,7 +106,6 @@ class TransactionSignature extends Serializable implements TransactionSignatureI
         $checkVal('S', $startS, $lenS, $bin);
 
         return true;
-
     }
 
     /**

--- a/src/Transaction/SignatureHash.php
+++ b/src/Transaction/SignatureHash.php
@@ -67,7 +67,6 @@ class SignatureHash implements SignatureHashInterface
                     $inputs->getInput($i)->setSequence(0);
                 }
             }
-
         } elseif ($math->bitwiseAnd($sighashType, 31) == SignatureHashInterface::SIGHASH_SINGLE) {
             // Resize output array to $inputToSign + 1, set remaining scripts to null,
             // and set sequence's to zero.

--- a/src/Transaction/TransactionBuilderInputState.php
+++ b/src/Transaction/TransactionBuilderInputState.php
@@ -354,6 +354,5 @@ class TransactionBuilderInputState
                     return true;
             }
         ) && (count($this->signatures) == $this->getRequiredSigCount());
-
     }
 }

--- a/tests/AmountTest.php
+++ b/tests/AmountTest.php
@@ -34,6 +34,5 @@ class AmountTest extends AbstractTestCase
         $value = '1.123456789';
         $expected = '112345678';
         $this->assertEquals($expected, ($amount->toSatoshis($value)));
-
     }
 }

--- a/tests/Base58Test.php
+++ b/tests/Base58Test.php
@@ -79,6 +79,5 @@ class Base58Test extends \PHPUnit_Framework_TestCase
         //              ^
 
         Base58::decodeCheck('12D2adLM3UKy4cH891ZFDkWmXmotrMoF');
-
     }
 }

--- a/tests/BitcoinTest.php
+++ b/tests/BitcoinTest.php
@@ -13,7 +13,6 @@ class BitcoinTest extends \PHPUnit_Framework_TestCase
 {
     public function tearDown()
     {
-
     }
 
     public function testGetMath()

--- a/tests/Block/BlockTest.php
+++ b/tests/Block/BlockTest.php
@@ -222,6 +222,5 @@ class BlockTest extends \PHPUnit_Framework_TestCase
 
         $newBlock = BlockFactory::fromHex($blockHex);
         $this->assertSame($blockHex, $newBlock->getBuffer()->getHex());
-
     }
 }

--- a/tests/Chain/BlockchainTest.php
+++ b/tests/Chain/BlockchainTest.php
@@ -55,7 +55,6 @@ class BlockchainTest extends AbstractTestCase
         $this->assertEquals($utxos, $blockchain->utxos());
         $this->assertEquals(0, $blockchain->currentHeight());
         $this->assertEquals("1.000000000000", $blockchain->difficulty());
-
     }
 
     public function testFirstBlocks()

--- a/tests/Chain/DifficultyTest.php
+++ b/tests/Chain/DifficultyTest.php
@@ -46,7 +46,6 @@ class DifficultyTest extends AbstractTestCase
         foreach ($vectors as $v) {
             $this->assertEquals($v[1], $difficulty->getWork($v[0]));
         }
-
     }
 
     public function testDefaultLowestDifficulty()

--- a/tests/Crypto/EcAdapter/EcAdapterTest.php
+++ b/tests/Crypto/EcAdapter/EcAdapterTest.php
@@ -85,7 +85,6 @@ class EcAdapterTest extends AbstractTestCase
             $key = Buffer::hex($key, 32);
             $this->assertFalse($ecAdapter->validatePrivateKey($key));
         }
-
     }
 
     /**

--- a/tests/Crypto/HashTest.php
+++ b/tests/Crypto/HashTest.php
@@ -84,7 +84,6 @@ class HashTest extends \PHPUnit_Framework_TestCase
         foreach ($json->test as $test) {
             $this->assertSame($test->result, Hash::sha256ripe160(Buffer::hex($test->data))->getHex());
         }
-
     }
     public function testSha1()
     {

--- a/tests/Key/Deterministic/MultisigHDTest.php
+++ b/tests/Key/Deterministic/MultisigHDTest.php
@@ -98,7 +98,6 @@ class MultisigHDTest extends AbstractTestCase
         $this->assertEquals('0318c49f3d850f37d93314cb9b08ed3e864af991dc109da5b3e23a0ef4c518e5d2', $childKeys[1]->getPublicKey()->getHex());
         $this->assertEquals('522102d5514b338973151bdedf58a08cb0c912807ac9c7e026e6dc0f11abf8073be99e210318c49f3d850f37d93314cb9b08ed3e864af991dc109da5b3e23a0ef4c518e5d252ae', $child->getRedeemScript()->getHex());
         $this->assertEquals('3GX7j2puUbkyMiWu3YYYEczJQ1ZPS9vdam', $child->getRedeemScript()->getAddress()->getAddress());
-
     }
 
     public function testDerivePath()

--- a/tests/Key/PublicKeyTest.php
+++ b/tests/Key/PublicKeyTest.php
@@ -68,7 +68,6 @@ class PublicKeyTest extends AbstractTestCase
         $this->assertSame($publicKey->getBuffer()->getHex(), $eUncompressed);
         $this->assertFalse($publicKey->isCompressed());
         $this->assertFalse($publicKey->isPrivate());
-        
     }
 
     /**
@@ -106,7 +105,6 @@ class PublicKeyTest extends AbstractTestCase
         $this->assertFalse(PublicKey::isCompressedOrUncompressed(Buffer::hex('0300010203040506070809000102030405060708090001020304050607080900')));
 
         $this->assertFalse(PublicKey::isCompressedOrUncompressed(Buffer::hex('050001020304050607080900010203040506070809000102030405060708090001')));
-
     }
 
     /**

--- a/tests/Math/NumberTheoryTest.php
+++ b/tests/Math/NumberTheoryTest.php
@@ -67,7 +67,6 @@ class NumberTheoryTest extends AbstractTestCase
             $root1 = $theory->squareRootModP($r->a, $r->p);
             $this->assertTrue(in_array($root1, $r->res));
             $this->assertTrue(in_array($root1, $r->res));
-
         }
     }
 

--- a/tests/Rpc/BitcoindTest.php
+++ b/tests/Rpc/BitcoindTest.php
@@ -358,6 +358,5 @@ class BitcoindTest extends AbstractTestCase
         $bitcoind = new Bitcoind($json);
         $tx = $bitcoind->signrawtransaction($t, $inputs, [$priv]);
         $this->assertEquals(TransactionFactory::fromHex('01000000017dfd7f9356ff570cab318383a30c52f77f31d923f2c17da876ecc3a117a3004f010000006a473044022067fae0180dc75d4e4713502d80d915e912f73f84d41a7e56c0cedc0ef6b12bd7022048fab8f21508e6e7a4221047cf2afa5e63abfc96a1e8a028c37b9734b38140970121027431c86d5f701959a92c5c47bce58e2db85b377a263ede522cd7aaa77f1384a4ffffffff0182de0e00000000001976a91477c42a179e7f74bc5851ea7b0e326f430418625b88ac00000000'), $tx);
-
     }
 }

--- a/tests/Script/Consensus/ConsensusTest.php
+++ b/tests/Script/Consensus/ConsensusTest.php
@@ -86,7 +86,5 @@ class ConsensusTest
         } else {
             $this->assertEquals($result, $r);
         }
-
-
     }
 }

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -53,7 +53,6 @@ class InterpreterTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals(0, $i->getStackState()->getAltStack()->size());
         $i->getStackState()->restoreMainStack($testStack);
         $this->assertEquals($testStack, $i->getStackState()->getMainStack());
-
     }
 
     /**

--- a/tests/Script/RedeemScriptTest.php
+++ b/tests/Script/RedeemScriptTest.php
@@ -151,6 +151,5 @@ class RedeemScriptTest extends AbstractTestCase
         $outputScript = $rs->getOutputScript();
         $parsed = $outputScript->getScriptParser()->parse();
         $this->assertEquals($hash, $parsed[1]->getBinary());
-
     }
 }

--- a/tests/Script/ScriptStackTest.php
+++ b/tests/Script/ScriptStackTest.php
@@ -124,7 +124,6 @@ class ScriptStackTest extends \PHPUnit_Framework_TestCase
 
         $stack->insert(2, 'do');
         $this->assertEquals('do', $stack->top(-3));
-
     }
 
     public function testEnd()
@@ -163,6 +162,5 @@ class ScriptStackTest extends \PHPUnit_Framework_TestCase
         $this->assertEquals('00', $stack->top(-1));
         $this->assertEquals('22', $stack->top(-2));
         $this->assertEquals('11', $stack->top(-3));
-
     }
 }

--- a/tests/Script/ScriptTest.php
+++ b/tests/Script/ScriptTest.php
@@ -184,7 +184,6 @@ class ScriptTest extends \PHPUnit_Framework_TestCase
 
         // Validate it's correct
         $this->assertSame($script->getScriptHash()->getHex(), 'f7c29c0c6d319e33c9250fca0cb61a500621d93e');
-
     }
 
     public function testGetVarInt()

--- a/tests/Transaction/LocktimeTest.php
+++ b/tests/Transaction/LocktimeTest.php
@@ -15,12 +15,10 @@ class LocktimeTest extends AbstractTestCase
 
     public function __construct()
     {
-
     }
 
     public function fromTimestampVectors()
     {
-
     }
 
     public function testToTimestamp()
@@ -72,7 +70,6 @@ class LocktimeTest extends AbstractTestCase
 
         $disallowed = $math->add($allowed, 1);
         $locktime->fromTimestamp($disallowed);
-
     }
 
     /**

--- a/tests/Transaction/SignatureHashTest.php
+++ b/tests/Transaction/SignatureHashTest.php
@@ -63,7 +63,6 @@ class SignatureHashTest extends \PHPUnit_Framework_TestCase
             $h = $t->getSignatureHash()->calculate($script, 0);
 
             $this->assertEquals($h->getHex(), $test->sighash);
-
         }
     }
 

--- a/tests/Transaction/TransactionBuilderTest.php
+++ b/tests/Transaction/TransactionBuilderTest.php
@@ -189,7 +189,6 @@ class TransactionBuilderTest extends AbstractTestCase
 
             // Verify that repeatedly doing a deterministic signature yields the same result
             $this->compareTwoSignRuns($builder, $outputScript, $privateKey, true);
-
         }
     }
 
@@ -217,7 +216,6 @@ class TransactionBuilderTest extends AbstractTestCase
         // Switch to random signatures now.
         // They should not yield the same script each time. Assuming the only thing that can change is the signature..
         $this->compareTwoSignRuns($builder->useRandomSignatures(), $outputScript, $privateKey, false);
-
     }
 
     /**

--- a/tests/Transaction/TransactionInputCollectionTest.php
+++ b/tests/Transaction/TransactionInputCollectionTest.php
@@ -27,6 +27,5 @@ class TransactionInputCollectionTest extends AbstractTestCase
         $this->assertEquals(1, count($collection->slice(0, 1)));
         $this->assertSame($in0, $collection->getInput(0));
         $this->assertEquals($arr, $collection->getInputs());
-
     }
 }

--- a/tests/Transaction/TransactionOutputCollectionTest.php
+++ b/tests/Transaction/TransactionOutputCollectionTest.php
@@ -28,6 +28,5 @@ class TransactionOutputCollectionTest extends AbstractTestCase
         $this->assertEquals(1, count($collection->slice(0, 1)));
         $this->assertSame($in0, $collection->getOutput(0));
         $this->assertEquals($arr, $collection->getOutputs());
-
     }
 }


### PR DESCRIPTION
Ping @josecelano

You may as well check this works before I merge, by adding the following to your composer.json and changing the required version from `v0.0.7` to `v0.0.7-fix-phpecc`. Once that works I'll make an official tag

    "repositories": [  
          {  
              "type": "vcs",  
              "url": "https://github.com/afk11/bitcoin-php"  
          }  
      ],  

Background: https://github.com/Bit-Wasp/bitcoin-php/issues/381