### PR TITLE
Consolidate InputSigner::solve / InputSigner::extractSignatures

### DIFF
--- a/tests/Data/signer_fixtures.json
+++ b/tests/Data/signer_fixtures.json
@@ -1529,7 +1529,7 @@
       "description": "Bad P2SH script found during extraction",
       "exception": {
         "type": "\\RuntimeException",
-        "message": "Extracted redeemScript did not match script-hash"
+        "message": "Extracted redeemScript did not match sign data"
       },
       "txOut": {
         "value": "1",
@@ -1548,7 +1548,7 @@
       "description": "Bad P2WSH script found during extraction",
       "exception": {
         "type": "\\RuntimeException",
-        "message": "Extracted witnessScript did not match witness-script-hash"
+        "message": "Extracted witnessScript did not match sign data"
       },
       "txOut": {
         "value": "1",
@@ -1570,7 +1570,7 @@
       "description": "Bad P2SH|P2WSH script found during extraction",
       "exception": {
         "type": "\\RuntimeException",
-        "message": "Extracted witnessScript did not match witness-script-hash"
+        "message": "Extracted witnessScript did not match sign data"
       },
       "txOut": {
         "value": "1",

--- a/tests/Transaction/Factory/InputSignerTest.php
+++ b/tests/Transaction/Factory/InputSignerTest.php
@@ -16,6 +16,10 @@ use BitWasp\Buffertools\Buffer;
 
 class InputSignerTest extends AbstractTestCase
 {
+    /**
+     * @param array $signDataArr
+     * @return SignData
+     */
     private function decodeSignData(array $signDataArr)
     {
         $signData = new SignData();
@@ -31,11 +35,18 @@ class InputSignerTest extends AbstractTestCase
         return $signData;
     }
 
+    /**
+     * @param array $txOutArr
+     * @return TransactionOutput
+     */
     private function decodeTxOut(array $txOutArr)
     {
         return new TransactionOutput($txOutArr['value'], ScriptFactory::fromHex($txOutArr['script']));
     }
 
+    /**
+     * @return array
+     */
     public function getVectors()
     {
         $fixtures = json_decode($this->dataFile('signer_fixtures.json'), true)['invalid_solve'];
@@ -81,6 +92,6 @@ class InputSignerTest extends AbstractTestCase
             return;
         }
 
-        throw new \RuntimeException('Didn\'t lead to exception as expected');
+        throw new \RuntimeException("Didn't lead to exception: expected {$exception} with message {$exceptionMsg}");
     }
 }


### PR DESCRIPTION
By consolidating extractSignatures & solve into one function, we can attempt to find the redeemScript / witnessScript in the scriptSig / witness (respectively), whilst preserving the assurances documented in `InputSigner::solve()`