### PR TITLE
Specify length to Buffers when known

### DIFF
--- a/src/Chain/Params.php
+++ b/src/Chain/Params.php
@@ -113,7 +113,7 @@ class Params implements ParamsInterface
 
         $inputScript = ScriptFactory::create()
             ->push(Buffer::int('486604799', 4, $this->math)->flip())
-            ->push(Buffer::int('4', null, $this->math))
+            ->push(Buffer::int('4', 1, $this->math))
             ->push($timestamp)
             ->getScript();
 

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Key/PublicKeySerializer.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Key/PublicKeySerializer.php
@@ -50,19 +50,15 @@ class PublicKeySerializer implements PublicKeySerializerInterface
     {
         $math = $this->ecAdapter->getMath();
         $point = $publicKey->getPoint();
-        $compressed = $publicKey->isCompressed();
 
-        $parser = new Parser('', $math);
-        $parser->writeBytes(1, new Buffer($this->getPrefix($publicKey)));
+        $length = 33;
+        $data = $this->getPrefix($publicKey) . Buffer::int(gmp_strval($point->getX(), 10), 32, $math)->getBinary();
+        if (!$publicKey->isCompressed()) {
+            $length = 65;
+            $data .= Buffer::int(gmp_strval($point->getY(), 10), 32, $math)->getBinary();
+        }
 
-        $compressed
-            ? $parser
-            ->writeBytes(32, Buffer::int(gmp_strval($point->getX(), 10), null, $math))
-            : $parser
-            ->writeBytes(32, Buffer::int(gmp_strval($point->getX(), 10), null, $math))
-            ->writeBytes(32, Buffer::int(gmp_strval($point->getY(), 10), null, $math));
-
-        return $parser->getBuffer();
+        return new Buffer($data, $length, $math);
     }
 
     /**

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Key/PublicKeySerializer.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Key/PublicKeySerializer.php
@@ -83,6 +83,8 @@ class PublicKeySerializer implements PublicKeySerializerInterface
             throw new \Exception('Invalid hex string, must match size of compressed or uncompressed public key');
         }
 
-        return $this->ecAdapter->publicKeyFromBuffer($buffer);
+        /** @var PublicKey $key */
+        $key = $this->ecAdapter->publicKeyFromBuffer($buffer);
+        return $key;
     }
 }

--- a/src/Crypto/Hash.php
+++ b/src/Crypto/Hash.php
@@ -15,7 +15,7 @@ class Hash
      */
     public static function sha256ripe160(BufferInterface $data)
     {
-        return new Buffer(hash('ripemd160', hash('sha256', $data->getBinary(), true), true));
+        return new Buffer(hash('ripemd160', hash('sha256', $data->getBinary(), true), true), 20);
     }
 
     /**
@@ -26,7 +26,7 @@ class Hash
      */
     public static function sha256(BufferInterface $data)
     {
-        return new Buffer(hash('sha256', $data->getBinary(), true));
+        return new Buffer(hash('sha256', $data->getBinary(), true), 32);
     }
 
     /**
@@ -37,7 +37,7 @@ class Hash
      */
     public static function sha256d(BufferInterface $data)
     {
-        return new Buffer(hash('sha256', hash('sha256', $data->getBinary(), true), true));
+        return new Buffer(hash('sha256', hash('sha256', $data->getBinary(), true), true), 32);
     }
 
     /**
@@ -48,7 +48,7 @@ class Hash
      */
     public static function ripemd160(BufferInterface $data)
     {
-        return new Buffer(hash('ripemd160', $data->getBinary(), true));
+        return new Buffer(hash('ripemd160', $data->getBinary(), true), 20);
     }
 
     /**
@@ -59,7 +59,7 @@ class Hash
      */
     public static function ripemd160d(BufferInterface $data)
     {
-        return new Buffer(hash('ripemd160', hash('ripemd160', $data->getBinary(), true), true));
+        return new Buffer(hash('ripemd160', hash('ripemd160', $data->getBinary(), true), true), 20);
     }
 
     /**
@@ -70,7 +70,7 @@ class Hash
      */
     public static function sha1(BufferInterface $data)
     {
-        return new Buffer(hash('sha1', $data->getBinary(), true));
+        return new Buffer(hash('sha1', $data->getBinary(), true), 20);
     }
 
     /**
@@ -86,6 +86,10 @@ class Hash
      */
     public static function pbkdf2($algorithm, BufferInterface $password, BufferInterface $salt, $count, $keyLength)
     {
+        if ($keyLength < 0) {
+            throw new \InvalidArgumentException('Cannot have a negative key-length for PBKDF2');
+        }
+
         $algorithm  = strtolower($algorithm);
 
         if (!in_array($algorithm, hash_algos(), true)) {
@@ -96,7 +100,7 @@ class Hash
             throw new \Exception('PBKDF2 ERROR: Invalid parameters.');
         }
 
-        return new Buffer(\hash_pbkdf2($algorithm, $password->getBinary(), $salt->getBinary(), $count, $keyLength, true));
+        return new Buffer(\hash_pbkdf2($algorithm, $password->getBinary(), $salt->getBinary(), $count, $keyLength, true), $keyLength);
     }
 
     /**
@@ -106,7 +110,7 @@ class Hash
      */
     public static function murmur3(BufferInterface $data, $seed)
     {
-        return new Buffer(pack('N', murmurhash3_int($data->getBinary(), (int)$seed)));
+        return new Buffer(pack('N', murmurhash3_int($data->getBinary(), (int)$seed)), 4);
     }
 
     /**

--- a/src/Script/Interpreter/Checker.php
+++ b/src/Script/Interpreter/Checker.php
@@ -173,8 +173,8 @@ class Checker
             ->checkPublicKeyEncoding($keyBuf, $flags);
 
         try {
-            $txSignature = TransactionSignatureFactory::fromHex($sigBuf->getHex());
-            $publicKey = PublicKeyFactory::fromHex($keyBuf->getHex());
+            $txSignature = TransactionSignatureFactory::fromHex($sigBuf);
+            $publicKey = PublicKeyFactory::fromHex($keyBuf);
 
             if ($sigVersion === 1) {
                 $hasher = new V1Hasher($this->transaction, $this->amount);

--- a/src/Transaction/SignatureHash/V1Hasher.php
+++ b/src/Transaction/SignatureHash/V1Hasher.php
@@ -58,7 +58,7 @@ class V1Hasher extends SigHash
         if (!($sighashType & SigHash::ANYONECANPAY) && ($sighashType & 0x1f) !== SigHash::SINGLE && ($sighashType & 0x1f) !== SigHash::NONE) {
             $binary = '';
             foreach ($this->tx->getInputs() as $input) {
-                $binary .= Buffer::int($input->getSequence())->flip()->getBinary();
+                $binary .= Buffer::int($input->getSequence(), 4)->flip()->getBinary();
             }
 
             return Hash::sha256d(new Buffer($binary));


### PR DESCRIPTION
This has saved us elsewhere, where PHP quirks resulted in too big a value being provided to a buffer. This PR specifies the length whenever the field is fixed size.