### PR TITLE
ExtendedKeySerializer / Base58ExtendedKeySerializer parameterize Network

### DIFF
--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -306,8 +306,8 @@ class HierarchicalKey
     {
         $network = $network ?: Bitcoin::getNetwork();
 
-        $extendedSerializer = new Base58ExtendedKeySerializer(new ExtendedKeySerializer($this->ecAdapter, $network));
-        $extended = $extendedSerializer->serialize($this);
+        $extendedSerializer = new Base58ExtendedKeySerializer(new ExtendedKeySerializer($this->ecAdapter));
+        $extended = $extendedSerializer->serialize($network, $this);
         return $extended;
     }
 

--- a/src/Key/Deterministic/HierarchicalKeyFactory.php
+++ b/src/Key/Deterministic/HierarchicalKeyFactory.php
@@ -65,8 +65,7 @@ class HierarchicalKeyFactory
      */
     public static function fromExtended($extendedKey, NetworkInterface $network = null, EcAdapterInterface $ecAdapter = null)
     {
-        $network = $network ?: Bitcoin::getNetwork();
-        $extSerializer = self::getSerializer($ecAdapter ?: Bitcoin::getEcAdapter(), $network);
-        return $extSerializer->parse($extendedKey);
+        $extSerializer = self::getSerializer($ecAdapter ?: Bitcoin::getEcAdapter());
+        return $extSerializer->parse($network ?: Bitcoin::getNetwork(), $extendedKey);
     }
 }

--- a/src/Serializer/Key/HierarchicalKey/Base58ExtendedKeySerializer.php
+++ b/src/Serializer/Key/HierarchicalKey/Base58ExtendedKeySerializer.php
@@ -4,6 +4,7 @@ namespace BitWasp\Bitcoin\Serializer\Key\HierarchicalKey;
 
 use BitWasp\Bitcoin\Base58;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKey;
+use BitWasp\Bitcoin\Network\NetworkInterface;
 
 class Base58ExtendedKeySerializer
 {
@@ -21,21 +22,22 @@ class Base58ExtendedKeySerializer
     }
 
     /**
+     * @param NetworkInterface $network
      * @param HierarchicalKey $key
      * @return string
      */
-    public function serialize(HierarchicalKey $key)
+    public function serialize(NetworkInterface $network, HierarchicalKey $key)
     {
-        return Base58::encodeCheck($this->serializer->serialize($key));
+        return Base58::encodeCheck($this->serializer->serialize($network, $key));
     }
 
     /**
+     * @param NetworkInterface $network
      * @param string $base58
      * @return HierarchicalKey
-     * @throws \BitWasp\Bitcoin\Exceptions\Base58ChecksumFailure
      */
-    public function parse($base58)
+    public function parse(NetworkInterface $network, $base58)
     {
-        return $this->serializer->parse(Base58::decodeCheck($base58));
+        return $this->serializer->parse($network, Base58::decodeCheck($base58));
     }
 }

--- a/src/Serializer/Key/PrivateKey/WifPrivateKeySerializer.php
+++ b/src/Serializer/Key/PrivateKey/WifPrivateKeySerializer.php
@@ -28,12 +28,12 @@ class WifPrivateKeySerializer
 
     /**
      * @param Math $math
-     * @param PrivateKeySerializerInterface $hexSerializer
+     * @param PrivateKeySerializerInterface $serializer
      */
-    public function __construct(Math $math, PrivateKeySerializerInterface $hexSerializer)
+    public function __construct(Math $math, PrivateKeySerializerInterface $serializer)
     {
         $this->math = $math;
-        $this->keySerializer = $hexSerializer;
+        $this->keySerializer = $serializer;
     }
 
     /**
@@ -61,7 +61,7 @@ class WifPrivateKeySerializer
     /**
      * @param string $wif
      * @param NetworkInterface|null $network
-     * @return \BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PrivateKey
+     * @return PrivateKeyInterface
      * @throws Base58ChecksumFailure
      * @throws InvalidPrivateKey
      */

--- a/tests/Serializer/Key/HierarchicalKey/HexExtendedKeySerializerTest.php
+++ b/tests/Serializer/Key/HierarchicalKey/HexExtendedKeySerializerTest.php
@@ -19,6 +19,6 @@ class HexExtendedKeySerializerTest extends AbstractTestCase
     {
         $network = NetworkFactory::bitcoinTestnet();
         $serializer = new ExtendedKeySerializer($adapter, $network);
-        $serializer->parse(new Buffer());
+        $serializer->parse($network, new Buffer());
     }
 }


### PR DESCRIPTION
`ExtendedKeySerializer` depends on a `NetworkInterface` to do it's business, since the HD bytes are network specific. Currently the $network is provided as a constructor param to `ExtendedKeySerializer`, making that instance useless for parsing/serializing for different networks. 

This PR parameterizes the ExtendedKeySerializer & Base58ExtendedKeySerializer so the methods `serialize` and `parse` accept $network. Calls to these are usually done from a method which defaults to `Bitcoin::getNetwork()` anyway, so it shouldn't interfere with high-level usage (the change is a BC break for the ExtendedKeySerializer)