### PR TITLE
InputSigner sanity checks

### DIFF
--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -201,8 +201,7 @@ class InputSigner
     private function evalPushOnly(ScriptInterface $script)
     {
         $stack = new Stack();
-        $interpreter = new Interpreter();
-        $interpreter->evaluate($script, $stack, SigHash::V0, $this->flags | Interpreter::VERIFY_SIGPUSHONLY, $this->signatureChecker);
+        $this->interpreter->evaluate($script, $stack, SigHash::V0, $this->flags | Interpreter::VERIFY_SIGPUSHONLY, $this->signatureChecker);
         return $stack->all();
     }
 

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -289,21 +289,16 @@ class InputSigner
                 $this->signatures = [$this->txSigSerializer->parse($stack[0])];
                 $this->publicKeys = [$this->pubKeySerializer->parse($stack[1])];
             }
-        }
-
-        if ($type === ScriptType::P2PK && count($stack) === 1) {
+        } else if ($type === ScriptType::P2PK) {
             $this->requiredSigs = 1;
             if ($size === 1) {
                 if (!$this->evaluateSolution($outputData->getScript(), $stack, $sigVersion)) {
                     throw new \RuntimeException('Existing signatures are invalid!');
                 }
-
                 $this->signatures = [$this->txSigSerializer->parse($stack[0])];
-                $this->publicKeys = [$this->pubKeySerializer->parse($outputData->getSolution())];
             }
-        }
-
-        if ($type === ScriptType::MULTISIG) {
+            $this->publicKeys = [$this->pubKeySerializer->parse($outputData->getSolution())];
+        } else if ($type === ScriptType::MULTISIG) {
             $info = new Multisig($outputData->getScript());
             $this->requiredSigs = $info->getRequiredSigCount();
             $this->publicKeys = $info->getKeys();
@@ -332,6 +327,8 @@ class InputSigner
                 }
                 // Don't evaluate, already checked sigs during sort. Todo: fix this.
             }
+        } else {
+            throw new \RuntimeException('Unsupported output type passed to extractFromValues');
         }
 
         return $type;

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -649,6 +649,8 @@ class InputSigner
                     $result[] = $this->txSigSerializer->serialize($this->signatures[$i]);
                 }
             }
+        } else {
+            throw new \RuntimeException('Parameter 0 for serializeSolution was a non-standard input type');
         }
 
         return $result;

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -564,6 +564,8 @@ class InputSigner
             if (!$signed) {
                 throw new \RuntimeException('Signing with the wrong private key');
             }
+        } else {
+            throw new \RuntimeException('Unexpected error - sign script had an unexpected type');
         }
 
         return $this;


### PR DESCRIPTION
Adds sanity checks to some functions, mostly checking that an impossible request hasn't been made. 
Checks and rejects signing if the output is segwit and the key isn't compressed.