### PR TITLE
Cache signatures and sighash's in Checker

### DIFF
--- a/src/Script/Interpreter/Checker.php
+++ b/src/Script/Interpreter/Checker.php
@@ -3,19 +3,23 @@
 namespace BitWasp\Bitcoin\Script\Interpreter;
 
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PublicKey;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Signature\DerSignatureSerializerInterface;
 use BitWasp\Bitcoin\Exceptions\ScriptRuntimeException;
 use BitWasp\Bitcoin\Exceptions\SignatureNotCanonical;
-use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Locktime;
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Serializer\Signature\TransactionSignatureSerializer;
+use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializer;
 use BitWasp\Bitcoin\Signature\TransactionSignature;
-use BitWasp\Bitcoin\Signature\TransactionSignatureFactory;
 use BitWasp\Bitcoin\Transaction\SignatureHash\Hasher;
 use BitWasp\Bitcoin\Transaction\SignatureHash\SigHash;
 use BitWasp\Bitcoin\Transaction\SignatureHash\V1Hasher;
 use BitWasp\Bitcoin\Transaction\TransactionInputInterface;
 use BitWasp\Bitcoin\Transaction\TransactionInterface;
+use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
 
 class Checker
@@ -41,24 +45,47 @@ class Checker
     private $amount;
 
     /**
+     * @var Hasher
+     */
+    private $hasherV0;
+
+    /**
      * @var array
      */
-    private $cache = [];
+    private $sigHashCache = [];
+
+    /**
+     * @var array
+     */
+    private $sigCache = [];
+
+    /**
+     * @var TransactionSignatureSerializer
+     */
+    private $sigSerializer;
+
+    /**
+     * @var PublicKeySerializerInterface
+     */
+    private $pubKeySerializer;
 
     /**
      * Checker constructor.
      * @param EcAdapterInterface $ecAdapter
      * @param TransactionInterface $transaction
      * @param int $nInput
-     * @param int|string $amount
+     * @param int $amount
+     * @param TransactionSignatureSerializer|null $sigSerializer
+     * @param PublicKeySerializerInterface|null $pubKeySerializer
      */
-    public function __construct(EcAdapterInterface $ecAdapter, TransactionInterface $transaction, $nInput, $amount)
+    public function __construct(EcAdapterInterface $ecAdapter, TransactionInterface $transaction, $nInput, $amount, TransactionSignatureSerializer $sigSerializer = null, PublicKeySerializerInterface $pubKeySerializer = null)
     {
+        $this->sigSerializer = $sigSerializer ?: new TransactionSignatureSerializer(EcSerializer::getSerializer(DerSignatureSerializerInterface::class, $ecAdapter));
+        $this->pubKeySerializer = $pubKeySerializer ?: EcSerializer::getSerializer(PublicKeySerializerInterface::class, $ecAdapter);
         $this->adapter = $ecAdapter;
         $this->transaction = $transaction;
         $this->nInput = $nInput;
         $this->amount = $amount;
-        $this->cache = [];
     }
 
     /**
@@ -165,6 +192,35 @@ class Checker
 
     /**
      * @param ScriptInterface $script
+     * @param int $sigHashType
+     * @param int $sigVersion
+     * @return BufferInterface
+     */
+    public function getSigHash(ScriptInterface $script, $sigHashType, $sigVersion)
+    {
+        $cacheCheck = $sigVersion . $sigHashType . $script->getBuffer()->getBinary();
+        if (!isset($this->sigHashCache[$cacheCheck])) {
+            if ($sigVersion === 1) {
+                $hasher = new V1Hasher($this->transaction, $this->amount);
+            } else {
+                if ($this->hasherV0) {
+                    $hasher = $this->hasherV0;
+                } else {
+                    $hasher = $this->hasherV0 = new Hasher($this->transaction, new TransactionSerializer());
+                }
+            }
+
+            $hash = $hasher->calculate($script, $this->nInput, $sigHashType);
+            $this->sigHashCache[$cacheCheck] = $hash->getBinary();
+        } else {
+            $hash = new Buffer($this->sigHashCache[$cacheCheck], 32, $this->adapter->getMath());
+        }
+
+        return $hash;
+    }
+
+    /**
+     * @param ScriptInterface $script
      * @param BufferInterface $sigBuf
      * @param BufferInterface $keyBuf
      * @param int $sigVersion
@@ -180,20 +236,14 @@ class Checker
 
         try {
             $cacheCheck = $flags . $sigVersion . $keyBuf->getBinary() . $sigBuf->getBinary();
-            if (!isset($this->cache[$cacheCheck])) {
-                $txSignature = TransactionSignatureFactory::fromHex($sigBuf);
-                $publicKey = PublicKeyFactory::fromHex($keyBuf);
+            if (!isset($this->sigCache[$cacheCheck])) {
+                $txSignature = $this->sigSerializer->parse($sigBuf);
+                $publicKey = $this->pubKeySerializer->parse($keyBuf);
 
-                if ($sigVersion === 1) {
-                    $hasher = new V1Hasher($this->transaction, $this->amount);
-                } else {
-                    $hasher = new Hasher($this->transaction);
-                }
-
-                $hash = $hasher->calculate($script, $this->nInput, $txSignature->getHashType());
-                $result = $this->cache[$cacheCheck] = $this->adapter->verify($hash, $publicKey, $txSignature->getSignature());
+                $hash = $this->getSigHash($script, $txSignature->getHashType(), $sigVersion);
+                $result = $this->sigCache[$cacheCheck] = $this->adapter->verify($hash, $publicKey, $txSignature->getSignature());
             } else {
-                $result = $this->cache[$cacheCheck];
+                $result = $this->sigCache[$cacheCheck];
             }
 
             return $result;

--- a/src/Script/Interpreter/Checker.php
+++ b/src/Script/Interpreter/Checker.php
@@ -200,7 +200,7 @@ class Checker
     {
         $cacheCheck = $sigVersion . $sigHashType . $script->getBuffer()->getBinary();
         if (!isset($this->sigHashCache[$cacheCheck])) {
-            if ($sigVersion === 1) {
+            if (SigHash::V1 === $sigVersion) {
                 $hasher = new V1Hasher($this->transaction, $this->amount);
             } else {
                 if ($this->hasherV0) {

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -355,6 +355,10 @@ class InputSigner
     }
 
     /**
+     * Checks $chunks (a decompiled scriptSig) for it's last element,
+     * or defers to SignData. If both are provided, it checks the
+     * value from $chunks against SignData.
+     *
      * @param BufferInterface[] $chunks
      * @param SignData $signData
      * @return ScriptInterface
@@ -384,6 +388,10 @@ class InputSigner
     }
 
     /**
+     * Checks $witness (a witness structure) for it's last element,
+     * or defers to SignData. If both are provided, it checks the
+     * value from $chunks against SignData.
+     *
      * @param BufferInterface[] $witness
      * @param SignData $signData
      * @return ScriptInterface
@@ -513,7 +521,7 @@ class InputSigner
      * @param ScriptInterface $scriptCode
      * @param int $sigHashType
      * @param int $sigVersion
-     * @return TransactionSignature
+     * @return TransactionSignatureInterface
      */
     private function calculateSignature(PrivateKeyInterface $key, ScriptInterface $scriptCode, $sigHashType, $sigVersion)
     {
@@ -583,10 +591,8 @@ class InputSigner
             $this->signatures[0] = $this->calculateSignature($key, $this->signScript->getScript(), $sigHashType, $this->sigVersion);
             $this->publicKeys[0] = $key->getPublicKey();
         } else if ($this->signScript->getType() === ScriptType::MULTISIG) {
-            $info = new Multisig($this->signScript->getScript(), $this->pubKeySerializer);
-
             $signed = false;
-            foreach ($info->getKeys() as $keyIdx => $publicKey) {
+            foreach ($this->publicKeys as $keyIdx => $publicKey) {
                 if ($key->getPublicKey()->equals($publicKey)) {
                     $this->signatures[$keyIdx] = $this->calculateSignature($key, $this->signScript->getScript(), $sigHashType, $this->sigVersion);
                     $signed = true;

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -158,7 +158,7 @@ class InputSigner
         $this->txSigSerializer = $sigSerializer ?: new TransactionSignatureSerializer(EcSerializer::getSerializer(DerSignatureSerializerInterface::class, $ecAdapter));
         $this->pubKeySerializer = $pubKeySerializer ?: EcSerializer::getSerializer(PublicKeySerializerInterface::class, $ecAdapter);
         $this->signatureChecker = new Checker($this->ecAdapter, $this->tx, $nInput, $txOut->getValue(), $this->txSigSerializer, $this->pubKeySerializer);
-        $this->interpreter = new Interpreter();
+        $this->interpreter = new Interpreter($this->ecAdapter);
 
         $this->solve($signData, $txOut->getScript(), $inputs[$nInput]->getScript(), isset($tx->getWitnesses()[$nInput]) ? $tx->getWitnesses()[$nInput]->all() : []);
     }

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -300,7 +300,7 @@ class InputSigner
         $type = $outputData->getType();
         $size = count($stack);
 
-        if ($type === ScriptType::P2PKH) {
+        if (ScriptType::P2PKH === $type) {
             $this->requiredSigs = 1;
             if ($size === 2) {
                 if (!$this->evaluateSolution($outputData->getScript(), $stack, $sigVersion)) {
@@ -309,7 +309,7 @@ class InputSigner
                 $this->signatures = [$this->txSigSerializer->parse($stack[0])];
                 $this->publicKeys = [$this->pubKeySerializer->parse($stack[1])];
             }
-        } else if ($type === ScriptType::P2PK) {
+        } else if (ScriptType::P2PK === $type) {
             $this->requiredSigs = 1;
             if ($size === 1) {
                 if (!$this->evaluateSolution($outputData->getScript(), $stack, $sigVersion)) {
@@ -318,7 +318,7 @@ class InputSigner
                 $this->signatures = [$this->txSigSerializer->parse($stack[0])];
             }
             $this->publicKeys = [$this->pubKeySerializer->parse($outputData->getSolution())];
-        } else if ($type === ScriptType::MULTISIG) {
+        } else if (ScriptType::MULTISIG === $type) {
             $info = new Multisig($outputData->getScript(), $this->pubKeySerializer);
             $this->requiredSigs = $info->getRequiredSigCount();
             $this->publicKeys = $info->getKeys();
@@ -575,7 +575,7 @@ class InputSigner
             return $this;
         }
 
-        if ($this->sigVersion === 1 && !$key->isCompressed()) {
+        if (SigHash::V1 === $this->sigVersion && !$key->isCompressed()) {
             throw new \RuntimeException('Uncompressed keys are disallowed in segwit scripts - refusing to sign');
         }
 
@@ -624,7 +624,7 @@ class InputSigner
         }
 
         $flags |= Interpreter::VERIFY_P2SH;
-        if ($this->sigVersion === 1) {
+        if (SigHash::V1 === $this->sigVersion) {
             $flags |= Interpreter::VERIFY_WITNESS;
         }
 
@@ -633,7 +633,8 @@ class InputSigner
         // Take serialized signatures, and use mutator to add this inputs sig data
         $mutator = TransactionFactory::mutate($this->tx);
         $mutator->inputsMutator()[$this->nInput]->script($sig->getScriptSig());
-        if ($this->sigVersion === 1) {
+
+        if (SigHash::V1 === $this->sigVersion) {
             $witness = [];
             for ($i = 0, $j = count($this->tx->getInputs()); $i < $j; $i++) {
                 if ($i === $this->nInput) {
@@ -658,15 +659,15 @@ class InputSigner
     private function serializeSolution($outputType)
     {
         $result = [];
-        if ($outputType === ScriptType::P2PK) {
+        if (ScriptType::P2PK === $outputType) {
             if (count($this->signatures) === 1) {
                 $result = [$this->txSigSerializer->serialize($this->signatures[0])];
             }
-        } else if ($outputType === ScriptType::P2PKH) {
+        } else if (ScriptType::P2PKH === $outputType) {
             if (count($this->signatures) === 1 && count($this->publicKeys) === 1) {
                 $result = [$this->txSigSerializer->serialize($this->signatures[0]), $this->pubKeySerializer->serialize($this->publicKeys[0])];
             }
-        } else if ($outputType === ScriptType::MULTISIG) {
+        } else if (ScriptType::MULTISIG === $outputType) {
             $result[] = new Buffer();
             for ($i = 0, $nPubKeys = count($this->publicKeys); $i < $nPubKeys; $i++) {
                 if (isset($this->signatures[$i])) {

--- a/src/Transaction/Factory/Signer.php
+++ b/src/Transaction/Factory/Signer.php
@@ -84,7 +84,7 @@ class Signer
         }
 
         if (!isset($this->signatureCreator[$nIn])) {
-            $this->signatureCreator[$nIn] = new InputSigner($this->ecAdapter, $this->tx, $nIn, $txOut, $signData);
+            $this->signatureCreator[$nIn] = new InputSigner($this->ecAdapter, $this->tx, $nIn, $txOut, $signData, $this->sigSerializer, $this->pubKeySerializer);
         }
 
         return $this->signatureCreator[$nIn];

--- a/src/Transaction/Factory/Signer.php
+++ b/src/Transaction/Factory/Signer.php
@@ -4,7 +4,11 @@ namespace BitWasp\Bitcoin\Transaction\Factory;
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Signature\DerSignatureSerializerInterface;
+use BitWasp\Bitcoin\Serializer\Signature\TransactionSignatureSerializer;
 use BitWasp\Bitcoin\Transaction\SignatureHash\SigHash;
 use BitWasp\Bitcoin\Transaction\TransactionFactory;
 use BitWasp\Bitcoin\Transaction\TransactionInterface;
@@ -23,6 +27,16 @@ class Signer
     private $tx;
 
     /**
+     * @var TransactionSignatureSerializer
+     */
+    private $sigSerializer;
+
+    /**
+     * @var PublicKeySerializerInterface
+     */
+    private $pubKeySerializer;
+
+    /**
      * @var InputSigner[]
      */
     private $signatureCreator = [];
@@ -36,6 +50,8 @@ class Signer
     {
         $this->tx = $tx;
         $this->ecAdapter = $ecAdapter ?: Bitcoin::getEcAdapter();
+        $this->sigSerializer = new TransactionSignatureSerializer(EcSerializer::getSerializer(DerSignatureSerializerInterface::class, $this->ecAdapter));
+        $this->pubKeySerializer = EcSerializer::getSerializer(PublicKeySerializerInterface::class, $this->ecAdapter);
     }
 
     /**

--- a/src/Transaction/SignatureHash/Hasher.php
+++ b/src/Transaction/SignatureHash/Hasher.php
@@ -6,12 +6,31 @@ use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializer;
+use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializerInterface;
 use BitWasp\Bitcoin\Transaction\Mutator\TxMutator;
+use BitWasp\Bitcoin\Transaction\TransactionInterface;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
 
 class Hasher extends SigHash
 {
+    /**
+     * @var TransactionSerializer
+     */
+    private $txSerializer;
+
+    /**
+     * Hasher constructor.
+     * @param TransactionInterface $transaction
+     * @param TransactionSerializerInterface|null $txSerializer
+     */
+    public function __construct(TransactionInterface $transaction, TransactionSerializerInterface $txSerializer = null)
+    {
+        $this->txSerializer = $txSerializer ?: new TransactionSerializer();
+        parent::__construct($transaction);
+    }
+
     /**
      * Calculate the hash of the current transaction, when you are looking to
      * spend $txOut, and are signing $inputToSign. The SigHashType defaults to
@@ -77,10 +96,7 @@ class Hasher extends SigHash
         }
 
         return Hash::sha256d(new Buffer(
-            $tx
-                ->done()
-                ->getBaseSerialization()
-                ->getBinary() .
+            $this->txSerializer->serialize($tx->done(), TransactionSerializer::NO_WITNESS)->getBinary() .
             pack('V', $sighashType)
         ));
     }


### PR DESCRIPTION
Makes a map of [serializedArgs => result] for getSigHash($script, $sigHashType, $sigVersion), and checkSig(script, sig, pubkey, sigVersion, flags) since checking signatures is done in a few places. 

I avoided passing multisig scripts to the interpreter during extraction because we also need to sort signatures which requires verifications. It's better to have the interpreter do this, because other aspects of the script can be checked (with interpreter flags)

Since we evaluate during extraction, and also expose verify, and sometimes (multisig sorting) verifications are required, this seems a nice thing to have. 