### PR TITLE
WitnessScript helper class

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ phpcs: pretest
 endif
 
 phpcbf: pretest
-		vendor/bin/phpcbf --standard=PSR1,PSR2 -n src tests/
+		vendor/bin/phpcbf --standard=PSR1,PSR2 -n src tests/ examples/
 
 ocular:
 		wget https://scrutinizer-ci.com/ocular.phar

--- a/examples/tx.fund.p2sh.p2wpkh.php
+++ b/examples/tx.fund.p2sh.p2wpkh.php
@@ -7,16 +7,16 @@ use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
-use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
+// Setup network and private key to segnet
 Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
 $key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
 
 // Utxo
@@ -24,8 +24,8 @@ $outpoint = new OutPoint(Buffer::hex('703f50920bff10e1622117af81b622d8bbd625460e
 $txOut = new TransactionOutput(100000000, $scriptPubKey);
 
 // Move UTXO to P2SH | P2WPKH
-$destination = new WitnessProgram(0, $key->getPubKeyHash());
-$p2sh = new P2shScript($destination->getScript());
+$destination = ScriptFactory::scriptPubKey()->p2wkh($key->getPubKeyHash());
+$p2sh = new P2shScript($destination);
 
 // Create unsigned transaction
 $tx = (new TxBuilder())

--- a/examples/tx.fund.p2sh.p2wsh.php
+++ b/examples/tx.fund.p2sh.p2wsh.php
@@ -3,31 +3,29 @@
 require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
-use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
-use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
+// Setup network and private key to segnet
 Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
 $key = PrivateKeyFactory::fromWif('QUgHwHaG1wDweqo8nYKBhGrCZVvgm6yRDh9egxn7qZbEzwzeRiUk');
+
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
-echo $key->getPublicKey()->getAddress()->getAddress() . PHP_EOL;
 
 // Utxo
 $outpoint = new OutPoint(Buffer::hex('703f50920bff10e1622117af81b622d8bbd625460e61909cc3f8b8ee78a59c0d', 32), 0);
 $txOut = new TransactionOutput(100000000, $scriptPubKey);
 
 // Script is P2SH | P2WSH | P2PKH
-$p2wsh = new WitnessProgram(0, Hash::sha256($scriptPubKey->getBuffer()));
-$p2sh = new P2shScript($p2wsh->getScript());
+$p2wsh = new \BitWasp\Bitcoin\Script\WitnessScript($scriptPubKey);
+$p2sh = new P2shScript($p2wsh);
 
 $unsigned = (new TxBuilder())
     ->spendOutPoint($outpoint)

--- a/examples/tx.fund.p2sh.p2wsh.php
+++ b/examples/tx.fund.p2sh.p2wsh.php
@@ -6,6 +6,7 @@ use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\P2shScript;
+use BitWasp\Bitcoin\Script\WitnessScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
@@ -24,7 +25,7 @@ $outpoint = new OutPoint(Buffer::hex('703f50920bff10e1622117af81b622d8bbd625460e
 $txOut = new TransactionOutput(100000000, $scriptPubKey);
 
 // Script is P2SH | P2WSH | P2PKH
-$p2wsh = new \BitWasp\Bitcoin\Script\WitnessScript($scriptPubKey);
+$p2wsh = new WitnessScript($scriptPubKey);
 $p2sh = new P2shScript($p2wsh);
 
 $unsigned = (new TxBuilder())

--- a/examples/tx.fund.p2wpkh.php
+++ b/examples/tx.fund.p2wpkh.php
@@ -13,11 +13,11 @@ use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
+// Setup network and private key to segnet
 Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
 $key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
-echo $key->getPublicKey()->getAddress()->getAddress() . PHP_EOL;
 
 // Utxo
 $outpoint = new OutPoint(Buffer::hex('874381bb431eaaae16e94f8b88e4ea7baf2ebf541b2ae11ec10d54c8e03a237f', 32), 0);

--- a/examples/tx.fund.p2wsh.php
+++ b/examples/tx.fund.p2wsh.php
@@ -3,35 +3,34 @@
 require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
-use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Script\ScriptFactory;
-use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
+use BitWasp\Bitcoin\Script\WitnessScript;
 
+// Setup network and private key to segnet
 Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
 $key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+
+// Spend from P2PKH
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
-echo $key->getPublicKey()->getAddress()->getAddress() . PHP_EOL;
 
 // UTXO
 $outpoint = new OutPoint(Buffer::hex('499c2bff1499bf84bc63058fda3ed112c2c663389f108353798a1bd6a6651afe', 32), 0);
 $txOut = new TransactionOutput(100000000, $scriptPubKey);
 
-// Create the program, and send to P2WSH address
-$program = Hash::sha256($scriptPubKey->getBuffer());
-$p2wsh = new WitnessProgram(0, $program);
+// Move funds into P2WSH P2PKH
+$destination = new WitnessScript($scriptPubKey);
 
 // Create unsigned transaction
 $tx = (new TxBuilder())
     ->spendOutPoint($outpoint)
-    ->output(99990000, $p2wsh->getScript())
+    ->output(99990000, $destination->getOutputScript())
     ->get();
 
 // Sign trasaction

--- a/examples/tx.spend.p2sh.p2wpkh.php
+++ b/examples/tx.spend.p2sh.p2wpkh.php
@@ -9,7 +9,6 @@ use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
-use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
@@ -21,12 +20,12 @@ Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
 $key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
 
 // scriptPubKey is P2SH | P2WPKH
-$destination = new WitnessProgram(0, $key->getPubKeyHash());
-$p2sh = new P2shScript($destination->getScript());
+$redeemScript = ScriptFactory::scriptPubKey()->p2wkh($key->getPubKeyHash());
+$p2shScript = new P2shScript($redeemScript);
 
 // UTXO
 $outpoint = new OutPoint(Buffer::hex('23d6640c3f3383ffc8233fbd830ee49162c720389bbba1c313a43b06a235ae13', 32), 0);
-$txOut = new TransactionOutput(95590000, $p2sh->getOutputScript());
+$txOut = new TransactionOutput(95590000, $p2shScript->getOutputScript());
 
 // Move UTXO to a pub-key-hash address
 $tx = (new TxBuilder())
@@ -35,7 +34,8 @@ $tx = (new TxBuilder())
     ->get();
 
 // Sign transaction
-$signData = (new SignData())->p2sh($destination->getScript());
+$signData = (new SignData())->p2sh($redeemScript);
+
 $signer = new Signer($tx);
 $input = $signer->input(0, $txOut, $signData);
 $input->sign($key);

--- a/examples/tx.spend.p2sh.p2wsh.php
+++ b/examples/tx.spend.p2sh.p2wsh.php
@@ -3,7 +3,6 @@
 require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
-use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
@@ -14,34 +13,36 @@ use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\Transaction\Factory\SignData;
+use BitWasp\Bitcoin\Script\WitnessScript;
+use BitWasp\Bitcoin\Script\P2shScript;
 
+// Setup network and private key to segnet
 Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
 $key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
 
 // Script is P2SH | P2WSH | P2PKH
-$witnessScript = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
-$p2shScript = ScriptFactory::scriptPubKey()->witnessScriptHash(Hash::sha256($witnessScript->getBuffer()));
-$scriptPubKey = ScriptFactory::scriptPubKey()->payToScriptHash($p2shScript->getScriptHash());
+$witnessScript = new WitnessScript(ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash()));
+$p2shScript = new P2shScript($witnessScript);
+
+// Utxo
+$outpoint = new OutPoint(Buffer::hex('5df04c88810066136619ce715ae9350113b0d4157f5b40ea860204b481bb0cc9', 32), 0);
+$txOut = new TransactionOutput(95590000, $p2shScript->getOutputScript());
+
+// Move UTXO to pub-key-hash
+($builder = new TxBuilder())
+    ->spendOutPoint($outpoint)
+    ->payToAddress(94550000, $key->getPublicKey()->getAddress());
+
+// Sign the transaction
 
 $signData = (new SignData())
     ->p2sh($p2shScript)
     ->p2wsh($witnessScript);
 
-// Utxo
-$outpoint = new OutPoint(Buffer::hex('5df04c88810066136619ce715ae9350113b0d4157f5b40ea860204b481bb0cc9', 32), 0);
-$txOut = new TransactionOutput(95590000, $scriptPubKey);
-
-// Move UTXO to pub-key-hash
-$tx = (new TxBuilder())
-    ->spendOutPoint($outpoint)
-    ->payToAddress(94550000, $key->getPublicKey()->getAddress())
-    ->get();
-
-// Sign the transaction
-$signer = (new Signer($tx, Bitcoin::getEcAdapter()));
+$signer = new Signer($builder->get(), Bitcoin::getEcAdapter());
 $input = $signer->input(0, $txOut, $signData);
 $input->sign($key);
+
 $signed = $signer->get();
 
 // Verify what we've produced
@@ -52,4 +53,3 @@ echo "Script validation result: " . ($input->verify(I::VERIFY_P2SH | I::VERIFY_W
 echo PHP_EOL;
 echo "Witness serialized transaction: " . $signed->getHex() . PHP_EOL. PHP_EOL;
 echo "Base serialized transaction: " . $signed->getBaseSerialization()->getHex() . PHP_EOL;
-

--- a/examples/tx.spend.p2wpkh.php
+++ b/examples/tx.spend.p2wpkh.php
@@ -6,23 +6,23 @@ use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
-use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
+use BitWasp\Bitcoin\Script\ScriptFactory;
 
+// Setup network and private key to segnet
 Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
 $key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
 
 // scriptPubKey is P2WKH
-$program = new WitnessProgram(0, $key->getPubKeyHash());
+$program = ScriptFactory::scriptPubKey()->p2wkh($key->getPubKeyHash());
 
 // UTXO
 $outpoint = new OutPoint(Buffer::hex('3a4242c32cf9dca64df73450c7a6141840538b90ccf5d5206b3482e52f7486fc', 32), 0);
-$txOut = new TransactionOutput(99900000, $program->getScript());
+$txOut = new TransactionOutput(99900000, $program);
 
 // Create unsigned transaction
 $tx = (new TxBuilder())
@@ -42,4 +42,3 @@ echo "Script validation result: " . ($input->verify(I::VERIFY_P2SH | I::VERIFY_W
 echo PHP_EOL;
 echo "Witness serialized transaction: " . $signed->getHex() . PHP_EOL. PHP_EOL;
 echo "Base serialized transaction: " . $signed->getBaseSerialization()->getHex() . PHP_EOL;
-

--- a/examples/tx.spend.p2wsh.php
+++ b/examples/tx.spend.p2wsh.php
@@ -3,31 +3,28 @@
 require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
-use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
 use BitWasp\Bitcoin\Script\ScriptFactory;
-use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
+use BitWasp\Bitcoin\Script\WitnessScript;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
 
+// Setup network and private key to segnet
 Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
 $key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
 
-$signData = new \BitWasp\Bitcoin\Transaction\Factory\SignData();
-$signData->p2wsh(ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash()));
-
-// scriptPubKey is P2WSH | P2PKH
-$program = new WitnessProgram(0, Hash::sha256($signData->getWitnessScript()->getBuffer()));
+// Spend from a P2WSH P2PKH
+$witnessScript = new WitnessScript(ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash()));
 
 // UTXO
 $outpoint = new OutPoint(Buffer::hex('c2197f15d510304f1463230c0e61566bfb8dcadb7e1c510d3c0470bcfbca2194', 32), 0);
-$txOut = new TransactionOutput(99990000, $program->getScript());
+$txOut = new TransactionOutput(99990000, $witnessScript->getOutputScript());
 
 // Create unsigned transaction
 $tx = (new TxBuilder())
@@ -35,7 +32,10 @@ $tx = (new TxBuilder())
     ->payToAddress(97900000, $key->getPublicKey()->getAddress())
     ->get();
 
-// Sign4
+// Sign
+$signData = (new SignData())
+    ->p2wsh($witnessScript);
+
 $signer = new Signer($tx);
 $input = $signer->input(0, $txOut, $signData);
 $input->sign($key);

--- a/src/Exceptions/P2shScriptException.php
+++ b/src/Exceptions/P2shScriptException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class P2shScriptException extends \Exception
+{
+
+}

--- a/src/Exceptions/WitnessScriptException.php
+++ b/src/Exceptions/WitnessScriptException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class WitnessScriptException extends \Exception
+{
+
+}

--- a/src/Script/P2shScript.php
+++ b/src/Script/P2shScript.php
@@ -3,6 +3,7 @@
 namespace BitWasp\Bitcoin\Script;
 
 use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use BitWasp\Bitcoin\Exceptions\P2shScriptException;
 
 class P2shScript extends Script
 {
@@ -18,17 +19,19 @@ class P2shScript extends Script
     private $outputScript;
 
     /**
-     * @var \BitWasp\Buffertools\BufferInterface
-     */
-    private $scriptHash;
-
-    /**
      * P2shScript constructor.
      * @param ScriptInterface $script
      * @param Opcodes|null $opcodes
+     * @throws P2shScriptException
      */
     public function __construct(ScriptInterface $script, Opcodes $opcodes = null)
     {
+        if ($script instanceof WitnessScript) {
+            $script = $script->getOutputScript();
+        } else if ($script instanceof self) {
+            throw new P2shScriptException("Cannot nest P2SH scripts.");
+        }
+
         parent::__construct($script->getBuffer(), $opcodes);
         $this->scriptHash = $script->getScriptHash();
         $this->outputScript = ScriptFactory::scriptPubKey()->p2sh($this->scriptHash);
@@ -36,11 +39,11 @@ class P2shScript extends Script
     }
 
     /**
-     * @return \BitWasp\Buffertools\BufferInterface
+     * @throws P2shScriptException
      */
-    public function getScriptHash()
+    public function getWitnessScriptHash()
     {
-        return $this->scriptHash;
+        throw new P2shScriptException("Cannot compute witness-script-hash for a P2shScript");
     }
 
     /**

--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -25,6 +25,16 @@ class Script extends Serializable implements ScriptInterface
     protected $script;
 
     /**
+     * @var BufferInterface|null
+     */
+    protected $scriptHash;
+
+    /**
+     * @var BufferInterface|null
+     */
+    protected $witnessScriptHash;
+
+    /**
      * @param BufferInterface $script
      * @param Opcodes|null $opCodes
      */
@@ -61,21 +71,31 @@ class Script extends Serializable implements ScriptInterface
     }
 
     /**
-     * Return a buffer containing the hash of this script.
+     * Return a buffer containing the HASH160 of this script.
      *
      * @return BufferInterface
      */
     public function getScriptHash()
     {
-        return Hash::sha256ripe160($this->getBuffer());
+        if (null === $this->scriptHash) {
+            $this->scriptHash = Hash::sha256ripe160($this->getBuffer());
+        }
+
+        return $this->scriptHash;
     }
 
     /**
+     * Return a buffer containing the SHA256 of this script.
+     *
      * @return BufferInterface
      */
     public function getWitnessScriptHash()
     {
-        return Hash::sha256($this->getBuffer());
+        if (null === $this->witnessScriptHash) {
+            $this->witnessScriptHash = Hash::sha256($this->getBuffer());
+        }
+
+        return $this->witnessScriptHash;
     }
 
     /**

--- a/src/Script/WitnessProgram.php
+++ b/src/Script/WitnessProgram.php
@@ -19,6 +19,11 @@ class WitnessProgram
     private $program;
 
     /**
+     * @var
+     */
+    private $outputScript;
+
+    /**
      * WitnessProgram constructor.
      * @param int $version
      * @param BufferInterface $program
@@ -37,7 +42,7 @@ class WitnessProgram
     {
         if ($program->getSize() === 20) {
             return new self(self::V0, $program);
-        } else if ($program->getSize() === 20) {
+        } else if ($program->getSize() === 32) {
             return new self(self::V0, $program);
         } else {
             throw new \RuntimeException('Invalid size for V0 witness program - must be 20 or 32 bytes');
@@ -65,9 +70,10 @@ class WitnessProgram
      */
     public function getScript()
     {
-        return ScriptFactory::create()
-            ->int($this->version)
-            ->push($this->program)
-            ->getScript();
+        if (null === $this->outputScript) {
+            $this->outputScript = ScriptFactory::sequence([$this->version, $this->program]);
+        }
+
+        return $this->outputScript;
     }
 }

--- a/src/Script/WitnessScript.php
+++ b/src/Script/WitnessScript.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace BitWasp\Bitcoin\Script;
+
+use BitWasp\Bitcoin\Exceptions\WitnessScriptException;
+
+class WitnessScript extends Script
+{
+
+    /**
+     * @var ScriptInterface
+     */
+    private $outputScript;
+
+    /**
+     * @var WitnessProgram|null
+     */
+    private $witnessProgram;
+
+    /**
+     * WitnessScript constructor.
+     * @param ScriptInterface $script
+     * @param Opcodes|null $opcodes
+     * @throws WitnessScriptException
+     */
+    public function __construct(ScriptInterface $script, Opcodes $opcodes = null)
+    {
+        if ($script instanceof self) {
+            throw new WitnessScriptException("Cannot nest V0 P2WSH scripts.");
+        } else if ($script instanceof P2shScript) {
+            throw new WitnessScriptException("Cannot embed a P2SH script in a V2 P2WSH script.");
+        }
+
+        parent::__construct($script->getBuffer(), $opcodes);
+
+        $this->witnessScriptHash = $script->getWitnessScriptHash();
+        $this->outputScript = ScriptFactory::scriptPubKey()->p2wsh($this->witnessScriptHash);
+    }
+
+    /**
+     * @return WitnessProgram
+     */
+    public function getWitnessProgram()
+    {
+        if (null === $this->witnessProgram) {
+            $this->witnessProgram = WitnessProgram::v0($this->witnessScriptHash);
+        }
+
+        return $this->witnessProgram;
+    }
+
+    /**
+     * @return ScriptInterface
+     */
+    public function getOutputScript()
+    {
+        return $this->getWitnessProgram()->getScript();
+    }
+}

--- a/tests/Script/P2shScriptTest.php
+++ b/tests/Script/P2shScriptTest.php
@@ -1,0 +1,110 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Script;
+
+use BitWasp\Bitcoin\Address\AddressFactory;
+use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use BitWasp\Bitcoin\Exceptions\P2shScriptException;
+use BitWasp\Bitcoin\Script\Opcodes;
+use BitWasp\Bitcoin\Script\P2shScript;
+use BitWasp\Bitcoin\Script\Script;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\WitnessProgram;
+use BitWasp\Bitcoin\Script\WitnessScript;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Buffertools\Buffer;
+use BitWasp\Buffertools\BufferInterface;
+
+class P2shScriptTest extends AbstractTestCase
+{
+    /**
+     * @return array
+     */
+    public function getCannotNestVectors()
+    {
+        return [
+            [new P2shScript(new Script(new Buffer())), "Cannot nest P2SH scripts."],
+        ];
+    }
+
+    /**
+     * @param ScriptInterface $testScript
+     * @param string $exceptionMsg
+     * @dataProvider getCannotNestVectors
+     */
+    public function testCannotNestWitnessScripts(ScriptInterface $testScript, $exceptionMsg)
+    {
+        $this->expectException(P2shScriptException::class);
+        $this->expectExceptionMessage($exceptionMsg);
+
+        new P2shScript($testScript);
+    }
+
+    public function testP2WSHForP2SHIsForbidden()
+    {
+        $this->expectException(P2shScriptException::class);
+        $this->expectExceptionMessage("Cannot compute witness-script-hash for a P2shScript");
+
+        (new P2shScript(new Script(new Buffer())))->getWitnessScriptHash();
+    }
+
+    public function testNormalScriptHasSameBuffer()
+    {
+        $script = ScriptFactory::sequence([Opcodes::OP_0]);
+        $p2shScript = new P2shScript($script);
+        $this->assertTrue($p2shScript->equals($script));
+
+        $expectedP2sh = ScriptFactory::scriptPubKey()->p2sh($script->getScriptHash());
+        $this->assertTrue($p2shScript->getOutputScript()->equals($expectedP2sh));
+
+        $expectedAddress = AddressFactory::fromScript($script)->getAddress();
+        $this->assertEquals($expectedAddress, $p2shScript->getAddress()->getAddress());
+    }
+
+    public function testConsumesWitnessScriptOutputScript()
+    {
+        $script = ScriptFactory::sequence([Opcodes::OP_0]);
+
+        $witnessScript = new WitnessScript($script);
+        $p2shScript = new P2shScript($witnessScript);
+        $this->assertTrue($p2shScript->equals($witnessScript->getOutputScript()));
+
+        // be absolutely sure
+        $expectedP2sh = ScriptFactory::scriptPubKey()->p2sh($witnessScript->getWitnessProgram()->getScript()->getScriptHash());
+        $this->assertTrue($p2shScript->getOutputScript()->equals($expectedP2sh));
+    }
+
+    public function getOutputScriptAndAddressVectors()
+    {
+        $script = ScriptFactory::sequence([Opcodes::OP_0]);
+        $scriptHash = $script->getScriptHash();
+        $witnessScript = new WitnessScript($script);
+        $wpScriptHash = $witnessScript->getWitnessProgram()->getScript()->getScriptHash();
+        return [
+            [$script, $script, $scriptHash],
+            [$witnessScript, $witnessScript->getOutputScript(), $wpScriptHash],
+        ];
+    }
+
+    /**
+     * @param ScriptInterface $script
+     * @param ScriptInterface $expectedP2SH
+     * @param BufferInterface $expectedScriptHash
+     * @dataProvider getOutputScriptAndAddressVectors
+     */
+    public function testOutputScriptAndAddress(ScriptInterface $script, ScriptInterface $expectedP2SH, BufferInterface $expectedScriptHash)
+    {
+        $p2shScript = new P2shScript($script);
+        $this->assertTrue($p2shScript->equals($expectedP2SH));
+        $this->assertTrue($expectedScriptHash->equals($p2shScript->getScriptHash()));
+
+        $expectedOutputScript = ScriptFactory::scriptPubKey()->p2sh($expectedScriptHash);
+        $outputScript = $p2shScript->getOutputScript();
+        $this->assertTrue($outputScript->equals($expectedOutputScript));
+
+        $expectedAddress = (new ScriptHashAddress($expectedScriptHash))->getAddress();
+        $address = $p2shScript->getAddress()->getAddress();
+        $this->assertEquals($expectedAddress, $address);
+    }
+}

--- a/tests/Script/WitnessScriptTest.php
+++ b/tests/Script/WitnessScriptTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Script;
+
+use BitWasp\Bitcoin\Exceptions\WitnessScriptException;
+use BitWasp\Bitcoin\Script\P2shScript;
+use BitWasp\Bitcoin\Script\Script;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\WitnessScript;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Buffertools\Buffer;
+
+class WitnessScriptTest extends AbstractTestCase
+{
+    /**
+     * @return array
+     */
+    public function getCannotNestVectors()
+    {
+        return [
+            [new WitnessScript(new Script(new Buffer())), "Cannot nest V0 P2WSH scripts."],
+            [new P2shScript(new Script(new Buffer())), "Cannot embed a P2SH script in a V2 P2WSH script."],
+        ];
+    }
+
+    /**
+     * @param ScriptInterface $testScript
+     * @param string $exceptionMsg
+     * @dataProvider getCannotNestVectors
+     */
+    public function testCannotNestWitnessScripts(ScriptInterface $testScript, $exceptionMsg)
+    {
+        $this->expectException(WitnessScriptException::class);
+        $this->expectExceptionMessage($exceptionMsg);
+
+        new WitnessScript($testScript);
+    }
+
+    public function testNormalScriptHasSameBuffer()
+    {
+        $script = new Script(new Buffer());
+        $witnessScriptHash = $script->getWitnessScriptHash();
+
+        $witnessScript = new WitnessScript($script);
+        $this->assertTrue($witnessScript->equals($script));
+
+        $expectedOutputScript = ScriptFactory::scriptPubKey()->p2wsh($witnessScriptHash);
+        $this->assertTrue($expectedOutputScript->equals($witnessScript->getOutputScript()));
+    }
+}


### PR DESCRIPTION
The WitnessScript class is similar to P2shScript:
 - it decorates a normal ScriptInterface with cached witnessScriptHash / outputScript

P2shScript can now decorate a WitnessScript as well as ScriptInterface. (Overall, the allowed combinations are P2SH|P2WSH, P2SH, and P2WSH)