### PR TITLE
Input signer type

### DIFF
--- a/src/Signature/TransactionSignatureInterface.php
+++ b/src/Signature/TransactionSignatureInterface.php
@@ -16,4 +16,10 @@ interface TransactionSignatureInterface extends SerializableInterface
      * @return int|string
      */
     public function getHashType();
+
+    /**
+     * @param TransactionSignatureInterface $other
+     * @return bool
+     */
+    public function equals(TransactionSignatureInterface $other);
 }

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -571,6 +571,38 @@ class InputSigner
     }
 
     /**
+     * @return OutputData
+     */
+    public function getScriptPubKey()
+    {
+        return $this->scriptPubKey;
+    }
+
+    /**
+     * @return OutputData
+     */
+    public function getRedeemScript()
+    {
+        if (null === $this->redeemScript) {
+            throw new \RuntimeException("Input has no redeemScript, cannot call getRedeemScript");
+        }
+
+        return $this->redeemScript;
+    }
+
+    /**
+     * @return OutputData
+     */
+    public function getWitnessScript()
+    {
+        if (null === $this->witnessScript) {
+            throw new \RuntimeException("Input has no witnessScript, cannot call getWitnessScript");
+        }
+
+        return $this->witnessScript;
+    }
+
+    /**
      * @return bool
      */
     public function isP2SH()

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -563,6 +563,44 @@ class InputSigner
     }
 
     /**
+     * @return OutputData
+     */
+    public function getSignScript()
+    {
+        return $this->signScript;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isP2SH()
+    {
+        if ($this->scriptPubKey->getType() === ScriptType::P2SH && ($this->redeemScript instanceof OutputData)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * @return bool
+     */
+    public function isP2WSH()
+    {
+        if ($this->redeemScript instanceof OutputData) {
+            if ($this->redeemScript->getType() === ScriptType::P2WSH && ($this->witnessScript instanceof OutputData)) {
+                return true;
+            }
+        }
+
+        if ($this->scriptPubKey->getType() === ScriptType::P2WSH && ($this->witnessScript instanceof OutputData)) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
      * Sign the input using $key and $sigHashTypes
      *
      * @param PrivateKeyInterface $key

--- a/tests/Transaction/Factory/SignerTest.php
+++ b/tests/Transaction/Factory/SignerTest.php
@@ -235,6 +235,15 @@ class SignerTest extends AbstractTestCase
             $this->assertEquals($signData->hasRedeemScript(), $inSigner->isP2SH());
             $this->assertEquals($signData->hasWitnessScript(), $inSigner->isP2WSH());
 
+            if ($signData->hasRedeemScript()) {
+                $this->assertEquals(ScriptType::P2SH, $inSigner->getScriptPubKey()->getType());
+                if ($signData->hasWitnessScript()) {
+                    $this->assertEquals(ScriptType::P2WSH, $inSigner->getRedeemScript()->getType());
+                }
+            } else if ($signData->hasWitnessScript()) {
+                $this->assertEquals(ScriptType::P2WSH, $inSigner->getScriptPubKey()->getType());
+            }
+
             foreach ($signSteps as $keyAndHashType) {
                 list ($privateKey, $sigHashType) = $keyAndHashType;
                 $signer->sign($i, $privateKey, $utxo->getOutput(), $signData, $sigHashType);

--- a/tests/Transaction/Factory/SignerTest.php
+++ b/tests/Transaction/Factory/SignerTest.php
@@ -140,22 +140,28 @@ class SignerTest extends AbstractTestCase
 
             $this->assertEquals($signData->hasRedeemScript(), $inSigner->isP2SH());
             $this->assertEquals($signData->hasWitnessScript(), $inSigner->isP2WSH());
+
+            // in default mode, signScript is always set and always canSign(),
+            // implicitly meaning it can never contain a script-hash type
             $this->assertTrue($inSigner->getSignScript() instanceof OutputData);
             $this->assertTrue($inSigner->getSignScript()->canSign());
-
             $this->assertNotEquals(ScriptType::P2SH, $inSigner->getSignScript());
             $this->assertNotEquals(ScriptType::P2WSH, $inSigner->getSignScript());
 
+            // Check some of the script-hash constraints
             if ($signData->hasRedeemScript()) {
                 $this->assertEquals(ScriptType::P2SH, $inSigner->getScriptPubKey()->getType());
+                // hash in spk matches hash160(rs)
                 $this->assertTrue($inSigner->getRedeemScript()->getScript()->getScriptHash()->equals($inSigner->getScriptPubKey()->getSolution()));
 
                 if ($signData->hasWitnessScript()) {
                     $this->assertEquals(ScriptType::P2WSH, $inSigner->getRedeemScript()->getType());
+                    // redeem script solution is the witness script hash
                     $this->assertTrue($inSigner->getWitnessScript()->getScript()->getWitnessScriptHash()->equals($inSigner->getRedeemScript()->getSolution()));
                 }
             } else if ($signData->hasWitnessScript()) {
                 $this->assertEquals(ScriptType::P2WSH, $inSigner->getScriptPubKey()->getType());
+                // spk solution is the witness script hash
                 $this->assertTrue($inSigner->getWitnessScript()->getScript()->getWitnessScriptHash()->equals($inSigner->getScriptPubKey()->getSolution()));
             }
 


### PR DESCRIPTION
Expose some internals of the InputSigner:

 * getScriptPubKey - contains details of the scriptPubKey
 * getSignScript - contains the full script to be signed and any details (currently only OutputData::canSign() types)
 * isP2SH and isP2WSH - whether the input is P2SH, and/or P2WSH. 
 * getRedeemScript - returns the redeemScript details or an exception if not set.
 * getWitnessScript - returns the witnessScript OutputData or an exception if not set.