### PR TITLE
Pad multisig zeroes

### DIFF
--- a/src/Script/Parser/Operation.php
+++ b/src/Script/Parser/Operation.php
@@ -76,4 +76,16 @@ class Operation
 
         return $this->pushDataSize;
     }
+
+    /**
+     * @return BufferInterface|int
+     */
+    public function encode()
+    {
+        if ($this->push) {
+            return $this->pushData;
+        } else {
+            return $this->opCode;
+        }
+    }
 }

--- a/src/Script/ScriptFactory.php
+++ b/src/Script/ScriptFactory.php
@@ -9,6 +9,7 @@ use BitWasp\Bitcoin\Script\Consensus\BitcoinConsensus;
 use BitWasp\Bitcoin\Script\Consensus\NativeConsensus;
 use BitWasp\Bitcoin\Script\Factory\OutputScriptFactory;
 use BitWasp\Bitcoin\Script\Factory\ScriptCreator;
+use BitWasp\Bitcoin\Script\Parser\Operation;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
 
@@ -46,6 +47,24 @@ class ScriptFactory
     public static function sequence(array $sequence)
     {
         return self::create()->sequence($sequence)->getScript();
+    }
+
+    /**
+     * @param Operation[] $operations
+     * @return ScriptInterface
+     */
+    public static function fromOperations(array $operations)
+    {
+        $sequence = [];
+        foreach ($operations as $operation) {
+            if (!($operation instanceof Operation)) {
+                throw new \RuntimeException("Invalid input to fromOperations");
+            }
+
+            $sequence[] = $operation->encode();
+        }
+
+        return self::sequence($sequence);
     }
 
     /**

--- a/src/Transaction/Factory/InputSigner.php
+++ b/src/Transaction/Factory/InputSigner.php
@@ -502,7 +502,6 @@ class InputSigner implements InputSignerInterface
                     $this->signatures[$idx] = $this->txSigSerializer->parse($keyToSigMap[$key]);
                 }
             }
-
         } else {
             throw new \RuntimeException('Unsupported output type passed to extractFromValues');
         }

--- a/src/Transaction/Factory/Signer.php
+++ b/src/Transaction/Factory/Signer.php
@@ -47,6 +47,11 @@ class Signer
     private $redeemBitcoinCash = false;
 
     /**
+     * @var bool
+     */
+    private $padUnsignedMultisigs = false;
+
+    /**
      * @var InputSignerInterface[]
      */
     private $signatureCreator = [];
@@ -75,7 +80,20 @@ class Signer
         }
 
         $this->redeemBitcoinCash = $setting;
+        return $this;
+    }
 
+    /**
+     * @param bool $setting
+     * @return $this
+     */
+    public function padUnsignedMultisigs($setting)
+    {
+        if (!is_bool($setting)) {
+            throw new \InvalidArgumentException("Boolean value expected");
+        }
+
+        $this->padUnsignedMultisigs = $setting;
         return $this;
     }
 
@@ -90,7 +108,6 @@ class Signer
         }
 
         $this->tolerateInvalidPublicKey = $setting;
-
         return $this;
     }
 
@@ -125,6 +142,7 @@ class Signer
 
         if (!isset($this->signatureCreator[$nIn])) {
             $input = (new InputSigner($this->ecAdapter, $this->tx, $nIn, $txOut, $signData, $this->sigSerializer, $this->pubKeySerializer))
+                ->padUnsignedMultisigs($this->padUnsignedMultisigs)
                 ->tolerateInvalidPublicKey($this->tolerateInvalidPublicKey)
                 ->redeemBitcoinCash($this->redeemBitcoinCash)
                 ->extract();


### PR DESCRIPTION
Adds optional behavior to the transaction signer `BitWasp\Bitcoin\Transaction\Factory\Signer`

NB: Enabling this feature bypasses signature verification if the script is padded 'as expected', because it would fail to verify anyway. But it will not detect if any signature is invalid or in the wrong order (unlike when sorting is used), so use with caution. It's at least recommended to verify signatures when fully signed to see if any are incorrect before trusting the transaction.

Enabled calling `$signer->padUnsignedMultisigs(true)`, when the script to be signed is multisig, will cause it to embed `n` OP_0's (in place of missing signatures) into the input scriptSig (or witness), where `n` is the number of public keys, but only while the transaction input is partially signed. 

If the transaction input is fully signed, it will be serialized in the normal, ready to validate format. 

It will also enable the extraction of the `[idx => signature]` array used by InputSigner (since each public key has a signature or OP_0/empty byte vector (in the bare/P2SH and witness case respectively)). 
* If the signatures contain `1 + $keyCount` values (including mandatory null dummy), we will extract the signatures assuming that a `1 + $keyCount` _may_ have a signature at `signatures[x + 1]`
* If the stack does not contain exactly `1 + $keyCount` values, no new action is taken, and signatures will be verified/sorted as normal. This allows for incomplete transactions from implementations which do not implement the padding.

BitcoinJS also has the same feature, so if this is used around your stack, depending on your setup you may save some unnecessary CPU cycles while signing. 