### PR TITLE
Address type examples

### DIFF
--- a/examples/addresstypes.php
+++ b/examples/addresstypes.php
@@ -1,0 +1,38 @@
+<?php
+
+use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
+use BitWasp\Bitcoin\Address\ScriptHashAddress;
+use BitWasp\Bitcoin\Address\SegwitAddress;
+use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Script\WitnessProgram;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$priv = PrivateKeyFactory::fromWif('L1U6RC3rXfsoAx3dxsU1UcBaBSRrLWjEwUGbZPxWX9dBukN345R1');
+$publicKey = $priv->getPublicKey();
+$pubKeyHash = $publicKey->getPubKeyHash();
+
+### Key hash types
+echo "key hash types\n";
+$p2pkh = new PayToPubKeyHashAddress($pubKeyHash);
+echo " * p2pkh address: {$p2pkh->getAddress()}\n";
+
+$p2wpkhWP = WitnessProgram::v0($publicKey->getPubKeyHash());
+$p2wpkh = new SegwitAddress($p2wpkhWP);
+echo " * v0 key hash address: {$p2wpkh->getAddress()}\n";
+
+#### Script hash types
+
+echo "\nscript hash types:\n";
+// taking an available script to be another addresses redeem script..
+$redeemScript = $p2pkh->getScriptPubKey();
+
+$p2sh = new ScriptHashAddress($redeemScript->getScriptHash());
+echo " * p2sh: {$p2sh->getAddress()}\n";
+
+$p2wshWP = WitnessProgram::v0($redeemScript->getWitnessScriptHash());
+$p2wsh = new SegwitAddress($p2wshWP);
+echo " * p2wsh: {$p2wsh->getAddress()}\n";
+
+$p2shP2wsh = new ScriptHashAddress($p2wshWP->getScript()->getScriptHash());
+echo " * p2sh|p2wsh: {$p2shP2wsh->getAddress()}\n";

--- a/examples/addresstypes.script.php
+++ b/examples/addresstypes.script.php
@@ -1,0 +1,37 @@
+<?php
+
+use BitWasp\Bitcoin\Address\AddressFactory;
+use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Script\P2shScript;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\WitnessScript;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$priv = PrivateKeyFactory::fromWif('L1U6RC3rXfsoAx3dxsU1UcBaBSRrLWjEwUGbZPxWX9dBukN345R1');
+$publicKey = $priv->getPublicKey();
+$pubKeyHash = $publicKey->getPubKeyHash();
+
+$script = ScriptFactory::scriptPubKey()->p2pkh($pubKeyHash);
+
+### Key hash types
+echo "key hash types\n";
+$p2pkh = AddressFactory::fromOutputScript($script);
+echo " * p2pkh address: {$p2pkh->getAddress()}\n";
+
+#### Script hash types
+
+echo "\nscript hash types:\n";
+// taking an available script to be another addresses redeem script..
+$redeemScript = new P2shScript($p2pkh->getScriptPubKey());
+$p2shAddr = $redeemScript->getAddress();
+echo " * p2sh: {$p2shAddr->getAddress()}\n";
+
+
+$p2wshScript = new WitnessScript($p2pkh->getScriptPubKey());
+$p2wshAddr = $p2wshScript->getAddress();
+echo " * p2wsh: {$p2wshAddr->getAddress()}\n";
+
+$p2shP2wshScript = new P2shScript(new WitnessScript($p2pkh->getScriptPubKey()));
+$p2shP2wshAddr = $p2shP2wshScript->getAddress();
+echo " * p2sh|p2wsh: {$p2shP2wshAddr->getAddress()}\n";

--- a/src/Address/AddressFactory.php
+++ b/src/Address/AddressFactory.php
@@ -8,9 +8,11 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
+use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Bitcoin\Script\ScriptType;
 use BitWasp\Bitcoin\Script\WitnessProgram;
+use BitWasp\Bitcoin\Script\WitnessScript;
 use BitWasp\Bitcoin\SegwitBech32;
 use BitWasp\Buffertools\BufferInterface;
 
@@ -53,6 +55,10 @@ class AddressFactory
      */
     public static function fromOutputScript(ScriptInterface $outputScript)
     {
+        if ($outputScript instanceof P2shScript || $outputScript instanceof WitnessScript) {
+            throw new \RuntimeException("P2shScript & WitnessScript's are not accepted by fromOutputScript");
+        }
+
         $wp = null;
         if ($outputScript->isWitness($wp)) {
             /** @var WitnessProgram $wp */


### PR DESCRIPTION
Shows examples for base58 addresses (`P2SH|P2WSH` & `P2SH` & `P2PKH`), and bech32 addresses (`P2WSH`, `P2WPKH`)