### PR TITLE
AddressFactory: no more fromKey & fromScript

### DIFF
--- a/src/Address/AddressFactory.php
+++ b/src/Address/AddressFactory.php
@@ -24,7 +24,7 @@ class AddressFactory
      * @param KeyInterface $key
      * @return PayToPubKeyHashAddress
      */
-    public static function fromKey(KeyInterface $key)
+    public static function p2pkh(KeyInterface $key)
     {
         return new PayToPubKeyHashAddress($key->getPubKeyHash());
     }
@@ -35,7 +35,7 @@ class AddressFactory
      * @param ScriptInterface $p2shScript
      * @return ScriptHashAddress
      */
-    public static function fromScript(ScriptInterface $p2shScript)
+    public static function p2sh(ScriptInterface $p2shScript)
     {
         return new ScriptHashAddress($p2shScript->getScriptHash());
     }

--- a/src/Crypto/EcAdapter/Key/Key.php
+++ b/src/Crypto/EcAdapter/Key/Key.php
@@ -47,6 +47,6 @@ abstract class Key extends Serializable implements KeyInterface
      */
     public function getAddress()
     {
-        return AddressFactory::fromKey($this);
+        return AddressFactory::p2pkh($this);
     }
 }

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -22,7 +22,8 @@ use BitWasp\Buffertools\Buffer;
 class AddressTest extends AbstractTestCase
 {
 
-    public function getNetwork($network) {
+    public function getNetwork($network)
+    {
         switch ($network) {
             case 'btc':
                 return NetworkFactory::bitcoin();
@@ -85,7 +86,7 @@ class AddressTest extends AbstractTestCase
     {
         if ($type === 'pubkeyhash') {
             $pubKey = PublicKeyFactory::fromHex($data);
-            $obj = AddressFactory::fromKey($pubKey);
+            $obj = AddressFactory::p2pkh($pubKey);
             $this->assertInstanceOf(PayToPubKeyHashAddress::class, $obj);
 
             $pubKeyHash = $pubKey->getPubKeyHash();
@@ -94,12 +95,11 @@ class AddressTest extends AbstractTestCase
             $script = ScriptFactory::scriptPubKey()->payToPubKeyHash($obj->getHash());
         } else if ($type === 'script') {
             $redeemScript = ScriptFactory::fromHex($data);
-            $obj = AddressFactory::fromScript($redeemScript);
+            $obj = AddressFactory::p2sh($redeemScript);
             $this->assertInstanceOf(ScriptHashAddress::class, $obj);
 
             $scriptHash = $redeemScript->getScriptHash() ;
             $this->assertTrue($scriptHash->equals($obj->getHash()));
-
             $script = ScriptFactory::scriptPubKey()->payToScriptHash($obj->getHash());
         } else if ($type === 'witness') {
             $script = ScriptFactory::fromHex($data);
@@ -196,7 +196,7 @@ class AddressTest extends AbstractTestCase
         $this->assertEquals($p2pkhAddress, $p2pkhResult);
 
         $publicKey = PublicKeyFactory::fromHex('03a3f20be479bce0b17589cc526983f544dce3f80ff8b7ec46d2ee3362c3c6e775');
-        $pubKeyHash = AddressFactory::fromKey($publicKey);
+        $pubKeyHash = AddressFactory::p2pkh($publicKey);
         $p2pubkey = ScriptFactory::scriptPubKey()->payToPubKey($publicKey);
         $address = AddressFactory::getAssociatedAddress($p2pubkey);
         $this->assertEquals($pubKeyHash->getAddress($network), $address->getAddress($network));

--- a/tests/PaymentProtocol/RequestBuilderTest.php
+++ b/tests/PaymentProtocol/RequestBuilderTest.php
@@ -55,7 +55,7 @@ class RequestBuilderTest extends Bip70Test
         $builder =  new RequestBuilder();
         $builder->setTime(1);
         $pubkey = PublicKeyFactory::fromHex('0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee');
-        $address = AddressFactory::fromKey($pubkey);
+        $address = AddressFactory::p2pkh($pubkey);
         $script = ScriptFactory::scriptPubKey()->payToAddress($address);
 
         $builder->addAddressPayment($address, 50);

--- a/tests/Script/Factory/OutputScriptFactoryTest.php
+++ b/tests/Script/Factory/OutputScriptFactoryTest.php
@@ -22,7 +22,7 @@ class OutputScriptFactoryTest extends AbstractTestCase
     public function testPayToAddress()
     {
         $publicKey = PublicKeyFactory::fromHex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb');
-        $p2pkh = AddressFactory::fromKey($publicKey);
+        $p2pkh = AddressFactory::p2pkh($publicKey);
         $p2pkhScript = ScriptFactory::scriptPubKey()->payToAddress($p2pkh);
         $parsedScript = $p2pkhScript->getScriptParser()->decode();
 
@@ -34,7 +34,7 @@ class OutputScriptFactoryTest extends AbstractTestCase
         $this->assertEquals(Opcodes::OP_CHECKSIG, $parsedScript[4]->getOp());
         $this->assertEquals(ScriptType::P2PKH, $classifier->classify($p2pkhScript));
 
-        $p2sh = AddressFactory::fromScript(ScriptFactory::scriptPubKey()->multisig(1, [$publicKey]));
+        $p2sh = AddressFactory::p2sh(ScriptFactory::scriptPubKey()->multisig(1, [$publicKey]));
         $p2shScript = ScriptFactory::scriptPubKey()->payToAddress($p2sh);
         $parsedScript = $p2shScript->getScriptParser()->decode();
         $this->assertEquals(Opcodes::OP_HASH160, $parsedScript[0]->getOp());

--- a/tests/Script/P2shScriptTest.php
+++ b/tests/Script/P2shScriptTest.php
@@ -58,7 +58,7 @@ class P2shScriptTest extends AbstractTestCase
         $expectedP2sh = ScriptFactory::scriptPubKey()->p2sh($script->getScriptHash());
         $this->assertTrue($p2shScript->getOutputScript()->equals($expectedP2sh));
 
-        $expectedAddress = AddressFactory::fromScript($script)->getAddress();
+        $expectedAddress = AddressFactory::p2sh($script)->getAddress();
         $this->assertEquals($expectedAddress, $p2shScript->getAddress()->getAddress());
     }
 

--- a/tests/Transaction/Factory/TxBuilderTest.php
+++ b/tests/Transaction/Factory/TxBuilderTest.php
@@ -131,7 +131,7 @@ class TxBuilderTest extends AbstractTestCase
     {
         $key = PrivateKeyFactory::create(false);
         $script = ScriptFactory::scriptPubKey()->multisig(1, [$key->getPublicKey()]);
-        $scriptAddress = AddressFactory::fromScript($script);
+        $scriptAddress = AddressFactory::p2sh($script);
         return [
             [$key->getAddress()],
             [$scriptAddress],


### PR DESCRIPTION
With the introduction of segwit pubKeyHash and scriptHash types, `AddressFactory::fromKey()` and `fromScript` aren't really the best names.. renaming these methods to `p2pkh` and `p2sh` respectively, and segwit already has `fromWitnessProgram`