### PR TITLE
InputSigner BC break: Extract logic for script qualification from a spk/rs/ws

### DIFF
--- a/src/Exceptions/MissingScriptException.php
+++ b/src/Exceptions/MissingScriptException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class MissingScriptException extends ScriptQualificationError
+{
+
+}

--- a/src/Exceptions/ScriptHashMismatch.php
+++ b/src/Exceptions/ScriptHashMismatch.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class ScriptHashMismatch extends ScriptQualificationError
+{
+
+}

--- a/src/Exceptions/ScriptQualificationError.php
+++ b/src/Exceptions/ScriptQualificationError.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class ScriptQualificationError extends \RuntimeException
+{
+
+}

--- a/src/Exceptions/SuperfluousScriptData.php
+++ b/src/Exceptions/SuperfluousScriptData.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class SuperfluousScriptData extends ScriptQualificationError
+{
+
+}

--- a/src/Exceptions/UnsupportedScript.php
+++ b/src/Exceptions/UnsupportedScript.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class UnsupportedScript extends \RuntimeException
+{
+
+}

--- a/src/Script/FullyQualifiedScript.php
+++ b/src/Script/FullyQualifiedScript.php
@@ -1,0 +1,363 @@
+<?php
+
+namespace BitWasp\Bitcoin\Script;
+
+use BitWasp\Bitcoin\Exceptions\MissingScriptException;
+use BitWasp\Bitcoin\Exceptions\ScriptHashMismatch;
+use BitWasp\Bitcoin\Exceptions\ScriptQualificationError;
+use BitWasp\Bitcoin\Exceptions\SuperfluousScriptData;
+use BitWasp\Bitcoin\Script\Classifier\OutputClassifier;
+use BitWasp\Bitcoin\Script\Classifier\OutputData;
+use BitWasp\Bitcoin\Script\Interpreter\Stack;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+use BitWasp\Bitcoin\Transaction\Factory\SigValues;
+use BitWasp\Bitcoin\Transaction\SignatureHash\SigHash;
+use BitWasp\Buffertools\BufferInterface;
+
+class FullyQualifiedScript
+{
+
+    /**
+     * @var OutputData
+     */
+    private $spkData;
+
+    /**
+     * @var OutputData|null
+     */
+    private $rsData;
+
+    /**
+     * @var OutputData|null
+     */
+    private $wsData;
+
+    /**
+     * @var OutputData
+     */
+    private $signData;
+
+    /**
+     * @var int
+     */
+    private $sigVersion;
+
+    /**
+     * This is responsible for checking that the script-hash
+     * commitments between scripts were satisfied, and determines
+     * the sigVersion.
+     *
+     * It rejects superfluous redeem & witness scripts, and refuses
+     * to construct unless all necessary scripts are provided.
+     *
+     * @param OutputData $spkData
+     * @param OutputData|null $rsData
+     * @param OutputData|null $wsData
+     */
+    public function __construct(
+        OutputData $spkData,
+        OutputData $rsData = null,
+        OutputData $wsData = null
+    ) {
+        $signScript = $spkData;
+        $sigVersion = SigHash::V0;
+
+        if ($spkData->getType() === ScriptType::P2SH) {
+            if (!($rsData instanceof OutputData)) {
+                throw new MissingScriptException("Missing redeemScript");
+            }
+            if (!$rsData->getScript()->getScriptHash()->equals($spkData->getSolution())) {
+                throw new ScriptHashMismatch("Redeem script fails to solve pay-to-script-hash");
+            }
+            $signScript = $rsData;
+        } else if ($rsData) {
+            throw new SuperfluousScriptData("Data provided for redeemScript was not necessary");
+        }
+
+        if ($signScript->getType() === ScriptType::P2WKH) {
+            $classifier = new OutputClassifier();
+            $signScript = $classifier->decode(ScriptFactory::scriptPubKey()->p2pkh($signScript->getSolution()));
+            $sigVersion = SigHash::V1;
+        } else if ($signScript->getType() === ScriptType::P2WSH) {
+            if (!($wsData instanceof OutputData)) {
+                throw new MissingScriptException("Missing witnessScript");
+            }
+            if (!$wsData->getScript()->getWitnessScriptHash()->equals($signScript->getSolution())) {
+                $origin = $rsData ? "redeemScript" : "scriptPubKey";
+                throw new ScriptHashMismatch("Witness script does not match witness program in $origin");
+            }
+            $signScript = $wsData;
+            $sigVersion = SigHash::V1;
+        } else if ($wsData) {
+            throw new SuperfluousScriptData("Data provided for witnessScript was not necessary");
+        }
+
+        $this->spkData = $spkData;
+        $this->rsData = $rsData;
+        $this->wsData = $wsData;
+        $this->signData = $signScript;
+        $this->sigVersion = $sigVersion;
+    }
+
+    /**
+     * Checks $chunks (a decompiled scriptSig) for it's last element,
+     * or defers to SignData. If both are provided, it checks the
+     * value obtained from $chunks against SignData.
+     *
+     * @param BufferInterface[] $chunks
+     * @param SignData $signData
+     * @return P2shScript
+     */
+    public static function findRedeemScript(array $chunks, SignData $signData)
+    {
+        if (count($chunks) > 0) {
+            $redeemScript = new Script($chunks[count($chunks) - 1]);
+            if ($signData->hasRedeemScript()) {
+                if (!$redeemScript->equals($signData->getRedeemScript())) {
+                    throw new ScriptQualificationError('Extracted redeemScript did not match sign data');
+                }
+            }
+        } else {
+            if (!$signData->hasRedeemScript()) {
+                throw new ScriptQualificationError('Redeem script not provided in sign data or scriptSig');
+            }
+            $redeemScript = $signData->getRedeemScript();
+        }
+
+        if (!($redeemScript instanceof P2shScript)) {
+            $redeemScript = new P2shScript($redeemScript);
+        }
+
+        return $redeemScript;
+    }
+
+    /**
+     * Checks the witness for it's last element, or whatever
+     * the SignData happens to have. If SignData has a WS,
+     * it will ensure that if chunks has a script, it matches WS.
+     * @param ScriptWitnessInterface $witness
+     * @param SignData $signData
+     * @return Script|ScriptInterface|WitnessScript
+     */
+    public static function findWitnessScript(ScriptWitnessInterface $witness, SignData $signData)
+    {
+        if (count($witness) > 0) {
+            $witnessScript = new Script($witness->bottom());
+            if ($signData->hasWitnessScript()) {
+                if (!$witnessScript->equals($signData->getWitnessScript())) {
+                    throw new ScriptQualificationError('Extracted witnessScript did not match sign data');
+                }
+            }
+        } else {
+            if (!$signData->hasWitnessScript()) {
+                throw new ScriptQualificationError('Witness script not provided in sign data or witness');
+            }
+            $witnessScript = $signData->getWitnessScript();
+        }
+
+        if (!($witnessScript instanceof WitnessScript)) {
+            $witnessScript = new WitnessScript($witnessScript);
+        }
+
+        return $witnessScript;
+    }
+
+    /**
+     * This function attempts to produce a FQS from
+     * raw scripts and witnesses. High level checking
+     * of script types is done to determine what we need
+     * from all this, before initializing the constructor
+     * for final validation.
+     *
+     * @param ScriptInterface $scriptPubKey
+     * @param ScriptInterface|null $scriptSig
+     * @param ScriptWitnessInterface|null $witness
+     * @param SignData|null $signData
+     * @param OutputClassifier|null $classifier
+     * @return FullyQualifiedScript
+     */
+    public static function fromTxData(
+        ScriptInterface $scriptPubKey,
+        ScriptInterface $scriptSig = null,
+        ScriptWitnessInterface $witness = null,
+        SignData $signData = null,
+        OutputClassifier $classifier = null
+    ) {
+        $classifier = $classifier ?: new OutputClassifier();
+        $signData = $signData ?: new SignData();
+
+        $wsData = null;
+        $rsData = null;
+        $solution = $spkData = $classifier->decode($scriptPubKey);
+
+        $sigChunks = [];
+        if (!$scriptSig->isPushOnly($sigChunks)) {
+            throw new ScriptQualificationError("Invalid script signature - must be PUSHONLY.");
+        }
+
+        if ($solution->getType() === ScriptType::P2SH) {
+            $redeemScript = self::findRedeemScript($sigChunks, $signData);
+            $solution = $rsData = $classifier->decode($redeemScript);
+        }
+
+        if ($solution->getType() === ScriptType::P2WSH) {
+            $witnessScript = self::findWitnessScript($witness, $signData);
+            $wsData = $classifier->decode($witnessScript);
+        }
+
+        return new FullyQualifiedScript($spkData, $rsData, $wsData);
+    }
+
+    /**
+     * Was the FQS's scriptPubKey P2SH?
+     * @return bool
+     */
+    public function isP2SH()
+    {
+        return $this->rsData instanceof OutputData;
+    }
+
+    /**
+     * Was the FQS's scriptPubKey, or redeemScript, P2WSH?
+     * @return bool
+     */
+    public function isP2WSH()
+    {
+        return $this->wsData instanceof OutputData;
+    }
+
+    /**
+     * Returns the scriptPubKey.
+     * @return OutputData
+     */
+    public function scriptPubKey()
+    {
+        return $this->spkData;
+    }
+
+    /**
+     * Returns the sign script we qualified from
+     * the spk/rs/ws. Essentially this is the script
+     * that actually locks the coins (the CScript
+     * passed into EvalScript in interpreter.cpp)
+     *
+     * @return OutputData
+     */
+    public function signScript()
+    {
+        return $this->signData;
+    }
+
+    /**
+     * Returns the signature hashing algorithm version.
+     * Defaults to V0, unless script was segwit.
+     * @return int
+     */
+    public function sigVersion()
+    {
+        return $this->sigVersion;
+    }
+
+    /**
+     * Returns the redeemScript, if we had one.
+     * Throws an exception otherwise.
+     * @return OutputData
+     * @throws \RuntimeException
+     */
+    public function redeemScript()
+    {
+        if (null === $this->rsData) {
+            throw new \RuntimeException("No redeemScript for this script!");
+        }
+
+        return $this->rsData;
+    }
+
+    /**
+     * Returns the witnessScript, if we had one.
+     * Throws an exception otherwise.
+     * @return OutputData
+     * @throws \RuntimeException
+     */
+    public function witnessScript()
+    {
+        if (null === $this->wsData) {
+            throw new \RuntimeException("No witnessScript for this script!");
+        }
+
+        return $this->wsData;
+    }
+
+    /**
+     * Encodes the stack (the stack passed as an
+     * argument to EvalScript in interpreter.cpp)
+     * into a scriptSig and witness structure. These
+     * are suitable for directly encoding in a transaction.
+     * @param Stack $stack
+     * @return SigValues
+     */
+    public function encodeStack(Stack $stack)
+    {
+        $scriptSigChunks = $stack->all();
+        $witness = [];
+
+        $solution = $this->spkData;
+        $p2sh = false;
+        if ($solution->getType() === ScriptType::P2SH) {
+            $p2sh = true;
+            $solution = $this->rsData;
+        }
+
+        if ($solution->getType() === ScriptType::P2WKH) {
+            $witness = $stack->all();
+            $scriptSigChunks = [];
+        } else if ($solution->getType() === ScriptType::P2WSH) {
+            $witness = $stack->all();
+            $witness[] = $this->wsData->getScript()->getBuffer();
+            $scriptSigChunks = [];
+        }
+
+        if ($p2sh) {
+            $scriptSigChunks[] = $this->rsData->getScript()->getBuffer();
+        }
+
+        return new SigValues(
+            ScriptFactory::pushAll($scriptSigChunks),
+            new ScriptWitness($witness)
+        );
+    }
+
+    /**
+     * @param ScriptInterface $scriptSig
+     * @param ScriptWitnessInterface $witness
+     * @return Stack
+     */
+    public function extractStack(ScriptInterface $scriptSig, ScriptWitnessInterface $witness)
+    {
+        $sigChunks = [];
+        if (!$scriptSig->isPushOnly($sigChunks)) {
+            throw new \RuntimeException("Invalid signature script - must be push only");
+        }
+
+        $solution = $this->spkData;
+        if ($solution->getType() === ScriptType::P2SH) {
+            $solution = $this->rsData;
+            $nChunks = count($sigChunks);
+            if ($nChunks > 0 && $sigChunks[$nChunks - 1]->equals($this->rsData->getScript()->getBuffer())) {
+                $sigChunks = array_slice($sigChunks, 0, -1);
+            }
+        }
+
+        if ($solution->getType() === ScriptType::P2WKH) {
+            $sigChunks = $witness->all();
+        } else if ($solution->getType() === ScriptType::P2WSH) {
+            $sigChunks = $witness->all();
+            $nChunks = count($sigChunks);
+            if ($nChunks > 0 && $sigChunks[$nChunks - 1]->equals($this->wsData->getScript()->getBuffer())) {
+                $sigChunks = array_slice($sigChunks, 0, -1);
+            }
+        }
+
+        return new Stack($sigChunks);
+    }
+}

--- a/src/Script/ScriptFactory.php
+++ b/src/Script/ScriptFactory.php
@@ -41,6 +41,34 @@ class ScriptFactory
     }
 
     /**
+     * Create a script consisting only of push-data operations.
+     * Suitable for a scriptSig.
+     *
+     * @param BufferInterface[] $buffers
+     * @return ScriptInterface
+     */
+    public static function pushAll(array $buffers)
+    {
+        return self::sequence(array_map(function ($buffer) {
+            if (!($buffer instanceof BufferInterface)) {
+                throw new \RuntimeException('Script contained a non-push opcode');
+            }
+
+            $size = $buffer->getSize();
+            if ($size === 0) {
+                return Opcodes::OP_0;
+            }
+
+            $first = ord($buffer->getBinary()[0]);
+            if ($size === 1 && $first >= 1 && $first <= 16) {
+                return \BitWasp\Bitcoin\Script\encodeOpN($first);
+            } else {
+                return $buffer;
+            }
+        }, $buffers));
+    }
+
+    /**
      * @param int[]|\BitWasp\Bitcoin\Script\Interpreter\Number[]|BufferInterface[] $sequence
      * @return ScriptInterface
      */

--- a/src/Script/ScriptInterface.php
+++ b/src/Script/ScriptInterface.php
@@ -29,9 +29,13 @@ interface ScriptInterface extends SerializableInterface
     public function getOpcodes();
 
     /**
+     * Returns boolean indicating whether script
+     * was push only. If true, $ops is populated
+     * with the contained buffers
+     * @param array $ops
      * @return bool
      */
-    public function isPushOnly();
+    public function isPushOnly(array &$ops = null);
 
     /**
      * @param WitnessProgram|null $witness

--- a/src/Script/ScriptWitnessInterface.php
+++ b/src/Script/ScriptWitnessInterface.php
@@ -3,10 +3,16 @@
 namespace BitWasp\Bitcoin\Script;
 
 use BitWasp\Bitcoin\Collection\CollectionInterface;
+use BitWasp\Buffertools\BufferInterface;
 use BitWasp\Buffertools\SerializableInterface;
 
 interface ScriptWitnessInterface extends CollectionInterface, SerializableInterface
 {
+    /**
+     * @return BufferInterface[]
+     */
+    public function all();
+
     /**
      * @param ScriptWitnessInterface $witness
      * @return bool

--- a/src/Transaction/Factory/InputSignerInterface.php
+++ b/src/Transaction/Factory/InputSignerInterface.php
@@ -5,6 +5,7 @@ namespace BitWasp\Bitcoin\Transaction\Factory;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
 use BitWasp\Bitcoin\Script\Classifier\OutputData;
+use BitWasp\Bitcoin\Script\FullyQualifiedScript;
 use BitWasp\Bitcoin\Signature\TransactionSignatureInterface;
 use BitWasp\Bitcoin\Transaction\SignatureHash\SigHash;
 use BitWasp\Buffertools\BufferInterface;
@@ -55,49 +56,15 @@ interface InputSignerInterface
     public function getPublicKeys();
 
     /**
-     * OutputData for the script to be signed (will be
-     * equal to getScriptPubKey, or getRedeemScript, or
-     * getWitnessScript.
-     *
-     * @return OutputData
-     */
-    public function getSignScript();
-
-    /**
      * OutputData for the txOut script.
      *
-     * @return OutputData
+     * @return FullyQualifiedScript
      */
-    public function getScriptPubKey();
+    public function getInputScripts();
 
     /**
-     * Returns OutputData for the P2SH redeemScript.
-     *
-     * @return OutputData
+     * @return mixed
      */
-    public function getRedeemScript();
-
-    /**
-     * Returns OutputData for the P2WSH witnessScript.
-     *
-     * @return OutputData
-     */
-    public function getWitnessScript();
-
-    /**
-     * Returns whether the scriptPubKey is P2SH.
-     *
-     * @return bool
-     */
-    public function isP2SH();
-
-    /**
-     * Returns whether the scriptPubKey or redeemScript is P2WSH.
-     *
-     * @return bool
-     */
-    public function isP2WSH();
-
     public function getSteps();
 
     /**

--- a/src/Transaction/Factory/SignData.php
+++ b/src/Transaction/Factory/SignData.php
@@ -3,6 +3,7 @@
 namespace BitWasp\Bitcoin\Transaction\Factory;
 
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\WitnessScript;
 
 class SignData
 {
@@ -32,6 +33,9 @@ class SignData
      */
     public function p2sh(ScriptInterface $redeemScript)
     {
+        if ($redeemScript instanceof WitnessScript) {
+            throw new \InvalidArgumentException("Cannot pass WitnessScript as a redeemScript");
+        }
         $this->redeemScript = $redeemScript;
         return $this;
     }

--- a/tests/Data/signer_fixtures.json
+++ b/tests/Data/signer_fixtures.json
@@ -1381,7 +1381,7 @@
     },
     {
       "exception": {
-        "type": "\\RuntimeException",
+        "type": "\\BitWasp\\Bitcoin\\Exceptions\\ScriptHashMismatch",
         "message": "Redeem script fails to solve pay-to-script-hash"
       },
       "txOut": {
@@ -1400,7 +1400,7 @@
     {
       "description": "Unsupported P2SH scripts are rejected",
       "exception": {
-        "type": "\\RuntimeException",
+        "type": "\\BitWasp\\Bitcoin\\Exceptions\\UnsupportedScript",
         "message": "Unsupported pay-to-script-hash script"
       },
       "txOut": {
@@ -1419,7 +1419,7 @@
     {
       "description": "Unsupported P2WSH scripts are rejected",
       "exception": {
-        "type": "\\RuntimeException",
+        "type": "\\BitWasp\\Bitcoin\\Exceptions\\UnsupportedScript",
         "message": "Unsupported witness-script-hash script"
       },
       "txOut": {
@@ -1438,8 +1438,8 @@
     {
       "description": "Unsupported P2SH|P2WSH scripts are rejected",
       "exception": {
-        "type": "\\RuntimeException",
-        "message": "Witness script fails to solve witness-script-hash"
+        "type": "\\BitWasp\\Bitcoin\\Exceptions\\ScriptHashMismatch",
+        "message": "Witness script does not match witness program in redeemScript"
       },
       "txOut": {
         "value": "1",


### PR DESCRIPTION
Introduces FullyQualifiedScript for capturing the entire state of a script. By script, I mean the actual opcodes we want to run (whether it's multisig, etc - I'll refer to it as signScript), and by state, I mean whether it has been embedded in P2SH, P2WSH, or the nested form. 

The motivation for capturing all this is because extracting the signScript/sigVersion is nice to isolated as pure code, but also because it's enough state to determine where the signatures are contained and hence can extract the stack run by our opcodes. Hence we can expose the following functions for extracting/encoding this:
 * `encodeStack(Stack $stack): SigValues` 
 * `extractStack(Script $scriptSig, ScriptWitness $witness): Stack`.

FullyQualifiedScript takes an OutputData (output of OutputClassifier::decode()) for the spk, rs, ws, and checks that the script-hash checks are satisfied. 

```php
$fqs = new FullyQualifiedScript($spkData, [$rsData], [$wsData])
```

A static function is exposed for taking just a scriptPubKey, scriptSig, and scriptWitness, since the P2SH and P2WSH scripts are embedded in a fully signed transaction. If the transaction is indeed fully signed, all that's needed is a call like this:

```php
$fqs = FullyQualifiedScript::fromTxData($scriptPubKey, [$input->getScript()], [$txinWitness])
```
However, if the transaction has yet to be signed, you'll need to supplement the likely empty scriptSig and txinWitness with the redeem & witness scripts if they are required. This is done by passing a SignData instance (the same used for signing P2SH or P2WSH transactions) into fromTxData:

```php
$fqs = FullyQualifiedScript::fromTxData($scriptPubKey, null, null, $signData)
```