### PR TITLE
Network & NetworkFactory BC break: Make Network immutable, named classes for networks

### DIFF
--- a/examples/tx.fund.p2sh.p2wpkh.php
+++ b/examples/tx.fund.p2sh.p2wpkh.php
@@ -4,7 +4,6 @@ require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
@@ -14,8 +13,7 @@ use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
 // Setup network and private key to segnet
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-$key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
 

--- a/examples/tx.fund.p2sh.p2wsh.php
+++ b/examples/tx.fund.p2sh.p2wsh.php
@@ -4,7 +4,6 @@ require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\WitnessScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
@@ -15,8 +14,7 @@ use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
 // Setup network and private key to segnet
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-$key = PrivateKeyFactory::fromWif('QUgHwHaG1wDweqo8nYKBhGrCZVvgm6yRDh9egxn7qZbEzwzeRiUk');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
 

--- a/examples/tx.fund.p2wpkh.php
+++ b/examples/tx.fund.p2wpkh.php
@@ -4,7 +4,6 @@ require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
@@ -14,8 +13,7 @@ use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
 // Setup network and private key to segnet
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-$key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());
 

--- a/examples/tx.fund.p2wsh.php
+++ b/examples/tx.fund.p2wsh.php
@@ -8,14 +8,12 @@ use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
 use BitWasp\Bitcoin\Transaction\OutPoint;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\Script\WitnessScript;
 
 // Setup network and private key to segnet
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-$key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 // Spend from P2PKH
 $scriptPubKey = ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash());

--- a/examples/tx.spend.p2sh.p2wpkh.php
+++ b/examples/tx.spend.p2sh.p2wpkh.php
@@ -3,9 +3,7 @@
 require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Transaction\Factory\SignData;
-use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
@@ -15,9 +13,7 @@ use BitWasp\Bitcoin\Transaction\OutPoint;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Buffertools\Buffer;
 
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-
-$key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 // scriptPubKey is P2SH | P2WPKH
 $redeemScript = ScriptFactory::scriptPubKey()->p2wkh($key->getPubKeyHash());

--- a/examples/tx.spend.p2sh.p2wsh.php
+++ b/examples/tx.spend.p2sh.p2wsh.php
@@ -4,7 +4,6 @@ require __DIR__ . "/../vendor/autoload.php";
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
@@ -17,8 +16,7 @@ use BitWasp\Bitcoin\Script\WitnessScript;
 use BitWasp\Bitcoin\Script\P2shScript;
 
 // Setup network and private key to segnet
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-$key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 // Script is P2SH | P2WSH | P2PKH
 $witnessScript = new WitnessScript(ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash()));

--- a/examples/tx.spend.p2wpkh.php
+++ b/examples/tx.spend.p2wpkh.php
@@ -2,9 +2,7 @@
 
 require __DIR__ . "/../vendor/autoload.php";
 
-use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
 use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
@@ -14,8 +12,7 @@ use BitWasp\Buffertools\Buffer;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 
 // Setup network and private key to segnet
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-$key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 // scriptPubKey is P2WKH
 $program = ScriptFactory::scriptPubKey()->p2wkh($key->getPubKeyHash());

--- a/examples/tx.spend.p2wsh.php
+++ b/examples/tx.spend.p2wsh.php
@@ -2,9 +2,7 @@
 
 require __DIR__ . "/../vendor/autoload.php";
 
-use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
-use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface as I;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Transaction\Factory\Signer;
@@ -16,8 +14,7 @@ use BitWasp\Bitcoin\Script\WitnessScript;
 use BitWasp\Bitcoin\Transaction\Factory\SignData;
 
 // Setup network and private key to segnet
-Bitcoin::setNetwork(NetworkFactory::bitcoinSegnet());
-$key = PrivateKeyFactory::fromWif('QP3p9tRpTGTefG4a8jKoktSWC7Um8qzvt8wGKMxwWyW3KTNxMxN7');
+$key = PrivateKeyFactory::fromHex("4242424242424242424242424242424242424242424242424242424242424242", true);
 
 // Spend from a P2WSH P2PKH
 $witnessScript = new WitnessScript(ScriptFactory::scriptPubKey()->payToPubKeyHash($key->getPubKeyHash()));

--- a/src/Bitcoin.php
+++ b/src/Bitcoin.php
@@ -7,7 +7,6 @@ use BitWasp\Bitcoin\Chain\ParamsInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\EcAdapterFactory;
 use BitWasp\Bitcoin\Math\Math;
-use BitWasp\Bitcoin\Network\Network;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use Mdanter\Ecc\EccFactory;
@@ -109,7 +108,7 @@ class Bitcoin
     }
 
     /**
-     * @return Network
+     * @return NetworkInterface
      */
     public static function getNetwork()
     {

--- a/src/Exceptions/InvalidNetworkParameter.php
+++ b/src/Exceptions/InvalidNetworkParameter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class InvalidNetworkParameter extends \Exception
+{
+
+}

--- a/src/Exceptions/MissingBase58Prefix.php
+++ b/src/Exceptions/MissingBase58Prefix.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class MissingBase58Prefix extends \Exception
+{
+
+}

--- a/src/Exceptions/MissingBech32Prefix.php
+++ b/src/Exceptions/MissingBech32Prefix.php
@@ -1,0 +1,9 @@
+<?php
+
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class MissingBech32Prefix extends \Exception
+{
+
+}

--- a/src/Exceptions/MissingBip32Prefix.php
+++ b/src/Exceptions/MissingBip32Prefix.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class MissingBip32Prefix extends \Exception
+{
+
+}

--- a/src/Exceptions/MissingNetworkParameter.php
+++ b/src/Exceptions/MissingNetworkParameter.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class MissingNetworkParameter extends \Exception
+{
+
+}

--- a/src/Network/NetworkFactory.php
+++ b/src/Network/NetworkFactory.php
@@ -5,32 +5,12 @@ namespace BitWasp\Bitcoin\Network;
 class NetworkFactory
 {
     /**
-     * @param string $address
-     * @param string $p2sh
-     * @param string $privateKey
-     * @param bool $testnet
-     * @return Network
-     * @throws \Exception
-     */
-    public static function create($address, $p2sh, $privateKey, $testnet = false)
-    {
-        return new Network($address, $p2sh, $privateKey, $testnet);
-    }
-
-    /**
      * @return NetworkInterface
      * @throws \Exception
      */
     public static function bitcoin()
     {
-        $network = self::create('00', '05', '80')
-            ->setHDPubByte('0488b21e')
-            ->setHDPrivByte('0488ade4')
-            ->setNetMagicBytes('d9b4bef9')
-            ->setSegwitBech32Prefix("bc")
-        ;
-
-        return $network;
+        return new Networks\Bitcoin();
     }
 
     /**
@@ -39,14 +19,7 @@ class NetworkFactory
      */
     public static function bitcoinTestnet()
     {
-        $network = self::create('6f', 'c4', 'ef', true)
-            ->setHDPubByte('043587cf')
-            ->setHDPrivByte('04358394')
-            ->setNetMagicBytes('0709110b')
-            ->setSegwitBech32Prefix("tb")
-        ;
-
-        return $network;
+        return new Networks\BitcoinTestnet();
     }
 
     /**
@@ -55,169 +28,70 @@ class NetworkFactory
      */
     public static function bitcoinRegtest()
     {
-        $network = self::create('6f', 'c4', 'ef', true)
-            ->setHDPubByte('043587cf')
-            ->setHDPrivByte('04358394')
-            ->setNetMagicBytes('dab5bffa')
-            ->setSegwitBech32Prefix("tb")
-        ;
-
-        return $network;
+        return new Networks\BitcoinRegtest();
     }
 
     /**
-     * @return NetworkInterface
-     */
-    public static function bitcoinSegnet()
-    {
-        $network = self::create('1e', '32', '9e', true)
-            ->setHDPubByte('043587cf')
-            ->setHDPrivByte('04358394')
-            ->setNetMagicBytes('0709110b');
-
-        return $network;
-    }
-
-    /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\Litecoin
      */
     public static function litecoin()
     {
-        $network = self::create('30', '05', 'b0')
-            ->setHDPubByte('019da462')
-            ->setHDPrivByte('019d9cfe')
-            ->setNetMagicBytes('dbb6c0fb');
-
-        return $network;
+        return new Networks\Litecoin();
     }
 
     /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\LitecoinTestnet
      */
     public static function litecoinTestnet()
     {
-        $network = self::create('6f', 'c4', 'ef', true)
-            ->setHDPubByte('019da462')
-            ->setHDPrivByte('019d9cfe')
-            ->setNetMagicBytes('dcb7c1fc');
-
-        return $network;
+        return new Networks\LitecoinTestnet();
     }
 
     /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\Viacoin
      */
     public static function viacoin()
     {
-        $network = self::create('47', '21', 'c7')
-            ->setHDPubByte('0488b21e')
-            ->setHDPrivByte('0488ade4')
-            ->setNetMagicBytes('cbc6680f')
-        ;
-
-        return $network;
+        return new Networks\Viacoin();
     }
 
     /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\ViacoinTestnet
      */
     public static function viacoinTestnet()
     {
-        $network = self::create('7f', 'c4', 'ff', true)
-            ->setHDPubByte('043587cf')
-            ->setHDPrivByte('04358394')
-            ->setNetMagicBytes('92efc5a9')
-        ;
-
-        return $network;
+        return new Networks\ViacoinTestnet();
     }
 
     /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\Dogecoin
      */
     public static function dogecoin()
     {
-        $network = self::create('1e', '16', '9e')
-            ->setHDPubByte('02facafd')
-            ->setHDPrivByte('02fac398')
-            ->setNetMagicBytes('c0c0c0c0');
-
-        return $network;
+        return new Networks\Dogecoin();
     }
 
     /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\DogecoinTestnet
      */
     public static function dogecoinTestnet()
     {
-        $network = self::create('71', 'c4', 'f1', true)
-            ->setHDPubByte('043587cf')
-            ->setHDPrivByte('0432a243')
-            ->setNetMagicBytes('c0c0c0c0');
-
-        return $network;
+        return new Networks\DogecoinTestnet();
     }
 
     /**
-     * @return NetworkInterface
-     * @throws \Exception
-     */
-    public static function startcoin()
-    {
-        $network = self::create('7d', 'fd', '05')
-            ->setHDPubByte('0488b21e')
-            ->setHDPrivByte('0488ade4')
-            ->setNetMagicBytes('ffc4badf');
-
-        return $network;
-    }
-
-    /**
-     * @return NetworkInterface
-     * @throws \Exception
-     */
-    public static function startcoinTestnet()
-    {
-        $network = self::create('7f', 'f4', 'c4', true)
-            ->setHDPubByte('043587cf')
-            ->setHDPrivByte('04468394')
-            ->setNetMagicBytes('ffc4b9de');
-
-        return $network;
-    }
-
-    /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\Dash
      */
     public static function dash()
     {
-        $network = self::create('4c', '10', 'cc')
-            ->setHDPubByte('0488b21e')
-            ->setHDPrivByte('0488ade4')
-            ->setNetMagicBytes('bd6b0cbf');
-
-        return $network;
+        return new Networks\Dash();
     }
 
-
     /**
-     * @return NetworkInterface
-     * @throws \Exception
+     * @return Networks\DashTestnet
      */
     public static function dashTestnet()
     {
-        $network = self::create('8b', '13', 'ef', true)
-            ->setHDPubByte('043587cf')
-            ->setHDPrivByte('04358394')
-            ->setNetMagicBytes('ffcae2ce');
-
-        return $network;
+        return new Networks\DashTestnet();
     }
 }

--- a/src/Network/NetworkInterface.php
+++ b/src/Network/NetworkInterface.php
@@ -11,6 +11,19 @@ interface NetworkInterface
      */
     public function getAddressByte();
 
+    /**
+     * Return the string that binds address signed messages to
+     * this network
+     *
+     * @return string
+     */
+    public function getSignedMessageMagic();
+
+    /**
+     * Returns the segwit bech32 prefix
+     *
+     * @return string
+     */
     public function getSegwitBech32Prefix();
 
     /**
@@ -26,13 +39,6 @@ interface NetworkInterface
      * @return string
      */
     public function getPrivByte();
-
-    /**
-     * Check if the network is testnet
-     *
-     * @return bool
-     */
-    public function isTestnet();
 
     /**
      * Return the HD public bytes for this network

--- a/src/Network/Networks/Bitcoin.php
+++ b/src/Network/Networks/Bitcoin.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class Bitcoin extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "00",
+        self::BASE58_ADDRESS_P2SH => "05",
+        self::BASE58_WIF => "80",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bech32PrefixMap
+     */
+    protected $bech32PrefixMap = [
+        self::BECH32_PREFIX_SEGWIT => "bc",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "0488b21e",
+        self::BIP32_PREFIX_XPRV => "0488ade4",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "Bitcoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "d9b4bef9";
+}

--- a/src/Network/Networks/BitcoinRegtest.php
+++ b/src/Network/Networks/BitcoinRegtest.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+class BitcoinRegtest extends BitcoinTestnet
+{
+    protected $p2pMagic = "dab5bffa";
+}

--- a/src/Network/Networks/BitcoinTestnet.php
+++ b/src/Network/Networks/BitcoinTestnet.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class BitcoinTestnet extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "6f",
+        self::BASE58_ADDRESS_P2SH => "c4",
+        self::BASE58_WIF => "ef",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bech32PrefixMap
+     */
+    protected $bech32PrefixMap = [
+        self::BECH32_PREFIX_SEGWIT => "tb",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "043587cf",
+        self::BIP32_PREFIX_XPRV => "04358394",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "Bitcoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "0709110b";
+}

--- a/src/Network/Networks/Dash.php
+++ b/src/Network/Networks/Dash.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class Dash extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "4c",
+        self::BASE58_ADDRESS_P2SH => "10",
+        self::BASE58_WIF => "cc",
+
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "0488b21e",
+        self::BIP32_PREFIX_XPRV => "0488ade4",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "DarkCoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "bd6b0cbf";
+}

--- a/src/Network/Networks/DashTestnet.php
+++ b/src/Network/Networks/DashTestnet.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class DashTestnet extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "8b",
+        self::BASE58_ADDRESS_P2SH => "13",
+        self::BASE58_WIF => "ef",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "043587cf",
+        self::BIP32_PREFIX_XPRV => "04358394",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "DarkCoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "ffcae2ce";
+}

--- a/src/Network/Networks/Dogecoin.php
+++ b/src/Network/Networks/Dogecoin.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class Dogecoin extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "1e",
+        self::BASE58_ADDRESS_P2SH => "16",
+        self::BASE58_WIF => "9e",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "02facafd",
+        self::BIP32_PREFIX_XPRV => "02fac398",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "Dogecoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "c0c0c0c0";
+}

--- a/src/Network/Networks/DogecoinTestnet.php
+++ b/src/Network/Networks/DogecoinTestnet.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class DogecoinTestnet extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "71",
+        self::BASE58_ADDRESS_P2SH => "c4",
+        self::BASE58_WIF => "f1",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "043587cf",
+        self::BIP32_PREFIX_XPRV => "04358394",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "Dogecoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "dcb7c1fc";
+}

--- a/src/Network/Networks/Litecoin.php
+++ b/src/Network/Networks/Litecoin.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class Litecoin extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "30",
+        self::BASE58_ADDRESS_P2SH => "05",
+        self::BASE58_WIF => "b0",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bech32PrefixMap
+     */
+    protected $bech32PrefixMap = [
+        self::BECH32_PREFIX_SEGWIT => "ltc",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "019da462",
+        self::BIP32_PREFIX_XPRV => "019d9cfe",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "Litecoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "dbb6c0fb";
+}

--- a/src/Network/Networks/LitecoinTestnet.php
+++ b/src/Network/Networks/LitecoinTestnet.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class LitecoinTestnet extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "6f",
+        self::BASE58_ADDRESS_P2SH => "c4",
+        self::BASE58_WIF => "ef",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "043587cf",
+        self::BIP32_PREFIX_XPRV => "04358394",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "Litecoin Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    protected $p2pMagic = "f1c8d2fd";
+}

--- a/src/Network/Networks/Viacoin.php
+++ b/src/Network/Networks/Viacoin.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class Viacoin extends Network
+{
+    /**
+     * @var array map of base58 address type to byte
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "47",
+        self::BASE58_ADDRESS_P2SH => "21",
+        self::BASE58_WIF => "c7",
+    ];
+
+    /**
+     * @var array map of bip32 type to bytes
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "0488b21e",
+        self::BIP32_PREFIX_XPRV => "0488ade4",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * @var string - message prefix for bitcoin signed messages
+     */
+    protected $signedMessagePrefix = "Viacoin Signed Message";
+
+    /**
+     * @var string - 4 bytes for p2p magic
+     */
+    protected $p2pMagic = "cbc6680f";
+}

--- a/src/Network/Networks/ViacoinTestnet.php
+++ b/src/Network/Networks/ViacoinTestnet.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class ViacoinTestnet extends Network
+{
+    /**
+     * @var array map of base58 address type to byte
+     */
+    protected $base58PrefixMap = [
+        self::BASE58_ADDRESS_P2PKH => "7f",
+        self::BASE58_ADDRESS_P2SH => "c4",
+        self::BASE58_WIF => "ff",
+    ];
+
+    /**
+     * @var array map of bip32 type to bytes
+     */
+    protected $bip32PrefixMap = [
+        self::BIP32_PREFIX_XPUB => "043587cf",
+        self::BIP32_PREFIX_XPRV => "04358394",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * @var string - message prefix for bitcoin signed messages
+     */
+    protected $signedMessagePrefix = "Viacoin Signed Message";
+
+    /**
+     * @var string - 4 bytes for p2p magic
+     */
+    protected $p2pMagic = "92efc5a9";
+}

--- a/tests/Key/Deterministic/HierarchicalKeyTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeyTest.php
@@ -10,8 +10,9 @@ use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Math\Math;
-use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Network\BitcoinNetwork;
 use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Network\Networks\BitcoinTestnet;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
@@ -21,7 +22,7 @@ class HierarchicalKeyTest extends AbstractTestCase
 {
 
     /**
-     * @var Network
+     * @var BitcoinNetwork
      */
     protected $network;
 
@@ -196,26 +197,13 @@ class HierarchicalKeyTest extends AbstractTestCase
     }
 
     /**
-     * This tests that a network always must have the HD priv/pub bytes
-     * @expectedException \Exception
-     */
-    public function testCreateWithInvalidNetworkHDBytes()
-    {
-        $network = new Network('ff', 'ff', 'ff');
-        $key = 'xpub661MyMwAqRbcEZ5ScgSxFiTbNQaUwtEzrbMrUqW5VXfZ47PFGgPq46fbhkpYCkxZQRDxhFy53Nip1VJCofd7auHCrPCmP72NV4YWu2HB7ir';
-        HierarchicalKeyFactory::fromExtended($key, $network);
-    }
-
-    /**
      * This tests if the key being decoded has bytes which match the network.
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage  HD key magic bytes do not match network magic bytes
      */
     public function testCreateWithInvalidNetwork()
     {
-        $network = NetworkFactory::create('ff', 'ff', 'ff')
-            ->setHDPrivByte('ffffffff')
-            ->setHDPubByte('ffffffff');
+        $network = new BitcoinTestnet();
 
         $key = 'xpub661MyMwAqRbcEZ5ScgSxFiTbNQaUwtEzrbMrUqW5VXfZ47PFGgPq46fbhkpYCkxZQRDxhFy53Nip1VJCofd7auHCrPCmP72NV4YWu2HB7ir';
         HierarchicalKeyFactory::fromExtended($key, $network);

--- a/tests/Network/Base58PrefixTest.php
+++ b/tests/Network/Base58PrefixTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network;
+
+use BitWasp\Bitcoin\Exceptions\MissingBase58Prefix;
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class Base58PrefixTest extends AbstractTestCase
+{
+    public function testHasKnownBase58Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'hasBase58Prefix');
+        $method->setAccessible(true);
+        $hasPrefix = $method->invoke(new Bitcoin(), Network::BASE58_ADDRESS_P2PKH);
+        $this->assertTrue($hasPrefix);
+    }
+
+    public function testHasUnknownBase58Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'hasBase58Prefix');
+        $method->setAccessible(true);
+        $hasPrefix = $method->invoke(new Bitcoin(), "don't know this one");
+        $this->assertFalse($hasPrefix);
+    }
+
+    public function testGetKnownBase58Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'getBase58Prefix');
+        $method->setAccessible(true);
+        $prefix = $method->invoke(new Bitcoin(), Network::BASE58_ADDRESS_P2PKH);
+        $this->assertSame('00', $prefix);
+    }
+
+    public function testGetUnknownBase58Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'getBase58Prefix');
+        $method->setAccessible(true);
+
+        $this->expectException(MissingBase58Prefix::class);
+
+        $method->invoke(new Bitcoin(), "unknown!");
+    }
+
+    public function testGetBase58TypeByte()
+    {
+        $network = new Bitcoin();
+        $method = new \ReflectionProperty(Bitcoin::class, 'base58PrefixMap');
+        $method->setAccessible(true);
+
+        $map = $value = $method->getValue($network);
+        $this->assertEquals($map[Network::BASE58_ADDRESS_P2SH], $network->getP2shByte());
+        $this->assertEquals($map[Network::BASE58_ADDRESS_P2PKH], $network->getAddressByte());
+    }
+}

--- a/tests/Network/Bech32PrefixTest.php
+++ b/tests/Network/Bech32PrefixTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network;
+
+use BitWasp\Bitcoin\Exceptions\MissingBech32Prefix;
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class Bech32PrefixTest extends AbstractTestCase
+{
+    public function testHasKnownBech32Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'hasBech32Prefix');
+        $method->setAccessible(true);
+        $hasPrefix = $method->invoke(new Bitcoin(), Network::BECH32_PREFIX_SEGWIT);
+        $this->assertTrue($hasPrefix);
+    }
+
+    public function testHasUnknownBech32Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'hasBech32Prefix');
+        $method->setAccessible(true);
+        $hasPrefix = $method->invoke(new Bitcoin(), "don't know this one");
+        $this->assertFalse($hasPrefix);
+    }
+
+    public function testGetKnownBech32Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'getBech32Prefix');
+        $method->setAccessible(true);
+        $prefix = $method->invoke(new Bitcoin(), Network::BECH32_PREFIX_SEGWIT);
+        $this->assertSame('bc', $prefix);
+    }
+
+    public function testGetUnknownBech32Byte()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, 'getBech32Prefix');
+        $method->setAccessible(true);
+
+        $this->expectException(MissingBech32Prefix::class);
+
+        $method->invoke(new Bitcoin(), "unknown!");
+    }
+
+    public function testGetBech32TypeByte()
+    {
+        $network = new Bitcoin();
+        $method = new \ReflectionProperty(Bitcoin::class, 'bech32PrefixMap');
+        $method->setAccessible(true);
+
+        $map = $value = $method->getValue($network);
+        $this->assertEquals($map[Network::BECH32_PREFIX_SEGWIT], $network->getSegwitBech32Prefix());
+    }
+}

--- a/tests/Network/Bip32PrefixTest.php
+++ b/tests/Network/Bip32PrefixTest.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network;
+
+use BitWasp\Bitcoin\Exceptions\MissingBip32Prefix;
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class Bip32PrefixTest extends AbstractTestCase
+{
+    public function testHasKnownBip32Prefix()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, "hasBip32Prefix");
+        $method->setAccessible(true);
+        $hasPrefix = $method->invoke(new Bitcoin(), Network::BIP32_PREFIX_XPUB);
+        $this->assertTrue($hasPrefix);
+    }
+
+    public function testHasUnknownBip32Prefix()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, "hasBip32Prefix");
+        $method->setAccessible(true);
+        $hasPrefix = $method->invoke(new Bitcoin(), "unknown-prefix");
+        $this->assertFalse($hasPrefix);
+    }
+
+    public function testGetKnownBip32Prefix()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, "getBip32Prefix");
+        $method->setAccessible(true);
+        $prefix = $method->invoke(new Bitcoin(), Network::BIP32_PREFIX_XPUB);
+        $this->assertSame("0488b21e", $prefix);
+    }
+
+    public function testGetUnknownBip32Prefix()
+    {
+        $method = new \ReflectionMethod(Bitcoin::class, "getBip32Prefix");
+        $method->setAccessible(true);
+
+        $this->expectException(MissingBip32Prefix::class);
+
+        $method->invoke(new Bitcoin(), "unknown-prefix");
+    }
+
+    public function testGetBip32TypeByte()
+    {
+        $network = new Bitcoin();
+        $method = new \ReflectionProperty(Bitcoin::class, 'bip32PrefixMap');
+        $method->setAccessible(true);
+
+        $map = $value = $method->getValue($network);
+        $this->assertEquals($map[Network::BIP32_PREFIX_XPUB], $network->getHDPubByte());
+        $this->assertEquals($map[Network::BIP32_PREFIX_XPRV], $network->getHDPrivByte());
+    }
+}

--- a/tests/Network/NetworkFactoryTest.php
+++ b/tests/Network/NetworkFactoryTest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network;
+
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Network\Networks\BitcoinRegtest;
+use BitWasp\Bitcoin\Network\Networks\BitcoinTestnet;
+use BitWasp\Bitcoin\Network\Networks\Dash;
+use BitWasp\Bitcoin\Network\Networks\DashTestnet;
+use BitWasp\Bitcoin\Network\Networks\Dogecoin;
+use BitWasp\Bitcoin\Network\Networks\DogecoinTestnet;
+use BitWasp\Bitcoin\Network\Networks\Litecoin;
+use BitWasp\Bitcoin\Network\Networks\LitecoinTestnet;
+use BitWasp\Bitcoin\Network\Networks\Viacoin;
+use BitWasp\Bitcoin\Network\Networks\ViacoinTestnet;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class NetworkFactoryTest extends AbstractTestCase
+{
+    public function getFactoryMethodAndClass()
+    {
+        return [
+            ['bitcoin', Bitcoin::class],
+            ['bitcoinTestnet', BitcoinTestnet::class],
+            ['bitcoinRegtest', BitcoinRegtest::class],
+            ['dash', Dash::class],
+            ['dashTestnet', DashTestnet::class],
+            ['dogecoin', Dogecoin::class],
+            ['dogecoinTestnet', DogecoinTestnet::class],
+            ['litecoin', Litecoin::class],
+            ['litecoinTestnet', LitecoinTestnet::class],
+            ['viacoin', Viacoin::class],
+            ['viacoinTestnet', ViacoinTestnet::class],
+        ];
+    }
+
+    /**
+     * @param $method
+     * @param $expectedClass
+     * @dataProvider getFactoryMethodAndClass
+     */
+    public function testNetworkFactory($method, $expectedClass)
+    {
+        $this->assertInstanceOf($expectedClass, call_user_func([NetworkFactory::class, $method]));
+    }
+}

--- a/tests/Network/NetworkTest.php
+++ b/tests/Network/NetworkTest.php
@@ -5,270 +5,43 @@ namespace BitWasp\Bitcoin\Tests\Network;
 use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
 use BitWasp\Bitcoin\Address\ScriptHashAddress;
 use BitWasp\Bitcoin\Network\NetworkFactory;
-use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
 use BitWasp\Buffertools\Buffer;
 
 class NetworkTest extends AbstractTestCase
 {
-    /**
-     *
-     */
-    public function testCreatesInstance()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $this->assertInstanceOf(NetworkInterface::class, $network);
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage address byte must be 1 hexadecimal byte
-     */
-    public function testCreateInstanceFailsNotHex()
-    {
-        NetworkFactory::create('hi', '00', '00', true);
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage p2sh byte must be 1 hexadecimal byte
-     */
-    public function testCreateInstanceFailsP2shNotHex()
-    {
-        NetworkFactory::create('00', 'hi', '00', true);
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage priv byte must be 1 hexadecimal byte
-     */
-    public function testCreateInstanceFailsPrivNotHex()
-    {
-        NetworkFactory::create('00', '00', 'hi', true);
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage Testnet parameter must be a boolean
-     */
-    public function testCreateInstanceFailsNotBool()
-    {
-        NetworkFactory::create('aa', '00', 'ab', 'nogood');
-    }
-
-    public function testDefaultTestnetFlag()
-    {
-        $network = NetworkFactory::create('00', '05', '80');
-        $this->assertFalse($network->isTestnet());
-    }
-
-    public function testGetAddressByte()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $this->assertSame('00', $network->getAddressByte());
-    }
-
-    public function testGetP2shByte()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $this->assertSame('05', $network->getP2shByte());
-    }
-
-    /**
-     * @expectedException \Exception
-     */
-    public function testGetNetBytesFailure()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $network->getNetMagicBytes();
-    }
-
-    public function testGetPrivByte()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $this->assertSame('80', $network->getPrivByte());
-    }
-
-    public function testCreateTestnet()
-    {
-        $network = $this->getTestNetwork();
-        $this->assertInstanceOf(NetworkInterface::class, $network);
-        $this->assertInternalType('bool', $network->isTestnet());
-        $this->assertTrue($network->isTestnet());
-    }
-
-    public function testCreateLivenet()
-    {
-        $network = $this->getLiveNetwork();
-        $this->assertInstanceOf(NetworkInterface::class, $network);
-        $this->assertInternalType('bool', $network->isTestnet());
-        $this->assertFalse($network->isTestnet());
-    }
-
-    /**
-     * @return \BitWasp\Bitcoin\Network\NetworkInterface
-     */
-    private function getTestNetwork()
-    {
-        return NetworkFactory::bitcoinTestnet();
-    }
-
-    /**
-     * @return \BitWasp\Bitcoin\Network\NetworkInterface
-     */
-    private function getLiveNetwork()
-    {
-        return NetworkFactory::bitcoin();
-    }
-
     public function testFactoryPresets()
     {
         $p2sh = new ScriptHashAddress(Buffer::hex('3399bc19f2b20473d417e31472c92947b59f95f8'));
         $p2pk = new PayToPubKeyHashAddress(Buffer::hex('06f1b66ffe49df7fce684df16c62f59dc9adbd3f'));
 
-        $this->assertEquals(NetworkFactory::bitcoin()->getAddressByte(), '00');
-        $this->assertEquals(NetworkFactory::bitcoin()->getP2shByte(), '05');
-        $this->assertEquals(NetworkFactory::bitcoin()->getPrivByte(), '80');
-        $this->assertEquals(NetworkFactory::bitcoin()->isTestnet(), false);
-        $this->assertEquals(NetworkFactory::bitcoin()->getHDPrivByte(), '0488ade4');
-        $this->assertEquals(NetworkFactory::bitcoin()->getHDPubByte(), '0488b21e');
-        $this->assertEquals(NetworkFactory::bitcoin()->getNetMagicBytes(), 'd9b4bef9');
         $this->assertEquals('36PrZ1KHYMpqSyAQXSG8VwbUiq2EogxLo2', $p2sh->getAddress(NetworkFactory::bitcoin()));
         $this->assertEquals('1dice8EMZmqKvrGE4Qc9bUFf9PX3xaYDp', $p2pk->getAddress(NetworkFactory::bitcoin()));
-        // Testnet
-        $this->assertEquals(NetworkFactory::bitcoinTestnet()->getAddressByte(), '6f');
-        $this->assertEquals(NetworkFactory::bitcoinTestnet()->getP2shByte(), 'c4');
-        $this->assertEquals(NetworkFactory::bitcoinTestnet()->getPrivByte(), 'ef');
-        $this->assertEquals(NetworkFactory::bitcoinTestnet()->isTestnet(), true);
-        $this->assertEquals(NetworkFactory::bitcoinTestnet()->getHDPrivByte(), '04358394');
-        $this->assertEquals(NetworkFactory::bitcoinTestnet()->getHDPubByte(), '043587cf');
-        $this->assertEquals(NetworkFactory::bitcoinTestnet()->getNetMagicBytes(), '0709110b');
-        // Regtest
-        $this->assertEquals(NetworkFactory::bitcoinRegtest()->getAddressByte(), NetworkFactory::bitcoinTestnet()->getAddressByte());
-        $this->assertEquals(NetworkFactory::bitcoinRegtest()->getP2shByte(), NetworkFactory::bitcoinTestnet()->getP2shByte());
-        $this->assertEquals(NetworkFactory::bitcoinRegtest()->getPrivByte(), NetworkFactory::bitcoinTestnet()->getPrivByte());
-        $this->assertEquals(NetworkFactory::bitcoinRegtest()->getHDPrivByte(), NetworkFactory::bitcoinTestnet()->getHDPrivByte());
-        $this->assertEquals(NetworkFactory::bitcoinRegtest()->getHDPubByte(), NetworkFactory::bitcoinTestnet()->getHDPubByte());
-        $this->assertEquals(NetworkFactory::bitcoinRegtest()->isTestnet(), NetworkFactory::bitcoinTestnet()->isTestnet());
-        $this->assertEquals(NetworkFactory::bitcoinRegtest()->getNetMagicBytes(), 'dab5bffa');
 
         $this->assertEquals('2Mwx4ckFK9pLBeknxCZt17tajwBEQXxNaWV', $p2sh->getAddress(NetworkFactory::bitcoinTestnet()));
         $this->assertEquals('mg9fuhDDAbD673KswdNyyWgaX8zDxJT8QY', $p2pk->getAddress(NetworkFactory::bitcoinTestnet()));
 
-        $this->assertEquals(NetworkFactory::litecoin()->getAddressByte(), '30');
-        $this->assertEquals(NetworkFactory::litecoin()->getP2shByte(), '05');
-        $this->assertEquals(NetworkFactory::litecoin()->getPrivByte(), 'b0');
-        $this->assertEquals(NetworkFactory::litecoin()->isTestnet(), false);
-        $this->assertEquals(NetworkFactory::litecoin()->getHDPrivByte(), '019d9cfe');
-        $this->assertEquals(NetworkFactory::litecoin()->getHDPubByte(), '019da462');
-        $this->assertEquals(NetworkFactory::litecoin()->getNetMagicBytes(), 'dbb6c0fb');
-
         $this->assertEquals('36PrZ1KHYMpqSyAQXSG8VwbUiq2EogxLo2', $p2sh->getAddress(NetworkFactory::litecoin()));
         $this->assertEquals('LKrfsrS4SE1tajYRQCPuRcY1sMkoFf1BN3', $p2pk->getAddress(NetworkFactory::litecoin()));
 
-        $this->assertEquals(NetworkFactory::viacoin()->getAddressByte(), '47');
-        $this->assertEquals(NetworkFactory::viacoin()->getP2shByte(), '21');
-        $this->assertEquals(NetworkFactory::viacoin()->getPrivByte(), 'c7');
-        $this->assertEquals(NetworkFactory::viacoin()->isTestnet(), false);
-        $this->assertEquals(NetworkFactory::viacoin()->getHDPrivByte(), '0488ade4');
-        $this->assertEquals(NetworkFactory::viacoin()->getHDPubByte(), '0488b21e');
-        $this->assertEquals(NetworkFactory::viacoin()->getNetMagicBytes(), 'cbc6680f');
         $this->assertEquals('EMrk83fMRQoNM74qDBb45TDWLxEehWXA7u', $p2sh->getAddress(NetworkFactory::viacoin()));
         $this->assertEquals('VadYXMHgmNg3PhkQxr4EaVo7LxgVZvhAdc', $p2pk->getAddress(NetworkFactory::viacoin()));
 
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->getAddressByte(), '7f');
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->getP2shByte(), 'c4');
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->getPrivByte(), 'ff');
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->isTestnet(), true);
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->getHDPrivByte(), '04358394');
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->getHDPubByte(), '043587cf');
-        $this->assertEquals(NetworkFactory::viacoinTestnet()->getNetMagicBytes(), '92efc5a9');
         $this->assertEquals('2Mwx4ckFK9pLBeknxCZt17tajwBEQXxNaWV', $p2sh->getAddress(NetworkFactory::viacoinTestnet()));
         $this->assertEquals('t7ZKfRypXUd7ByZGLLi5jX3AbD7KQvDj4a', $p2pk->getAddress(NetworkFactory::viacoinTestnet()));
 
-        $this->assertInstanceOf(NetworkInterface::class, NetworkFactory::litecoinTestnet());
-
-        $this->assertEquals(NetworkFactory::dogecoin()->getAddressByte(), '1e');
-        $this->assertEquals(NetworkFactory::dogecoin()->getP2shByte(), '16');
-        $this->assertEquals(NetworkFactory::dogecoin()->getPrivByte(), '9e');
-        $this->assertEquals(NetworkFactory::dogecoin()->isTestnet(), false);
-        $this->assertEquals(NetworkFactory::dogecoin()->getHDPrivByte(), '02fac398');
-        $this->assertEquals(NetworkFactory::dogecoin()->getHDPubByte(), '02facafd');
-        $this->assertEquals(NetworkFactory::dogecoin()->getNetMagicBytes(), 'c0c0c0c0');
-
         $this->assertEquals('9w97HrPBcRhjMLXswZvYk5DrRQQGvT2UeH', $p2sh->getAddress(NetworkFactory::dogecoin()));
         $this->assertEquals('D5mp9u4seyg7rw2rxeQAhMdrYH7pPs5gNu', $p2pk->getAddress(NetworkFactory::dogecoin()));
-
-        $this->assertEquals(NetworkFactory::dogecoinTestnet()->getAddressByte(), '71');
-        $this->assertEquals(NetworkFactory::dogecoinTestnet()->getP2shByte(), 'c4');
-        $this->assertEquals(NetworkFactory::dogecoinTestnet()->getPrivByte(), 'f1');
-        $this->assertEquals(NetworkFactory::dogecoinTestnet()->isTestnet(), true);
-        $this->assertEquals(NetworkFactory::dogecoinTestnet()->getHDPrivByte(), '0432a243');
-        $this->assertEquals(NetworkFactory::dogecoinTestnet()->getHDPubByte(), '043587cf');
-        $this->assertEquals(NetworkFactory::dogecoinTestnet()->getNetMagicBytes(), 'c0c0c0c0');
 
         $this->assertEquals('2Mwx4ckFK9pLBeknxCZt17tajwBEQXxNaWV', $p2sh->getAddress(NetworkFactory::dogecoinTestnet()));
         $this->assertEquals('nUpssuonax8qjuc3zU3cwmE9n9W7QXJjgW', $p2pk->getAddress(NetworkFactory::dogecoinTestnet()));
 
         // Dash
-        $this->assertEquals(NetworkFactory::dash()->getAddressByte(), '4c');
-        $this->assertEquals(NetworkFactory::dash()->getP2shByte(), '10');
-        $this->assertEquals(NetworkFactory::dash()->getPrivByte(), 'cc');
-        $this->assertEquals(NetworkFactory::dash()->isTestnet(), false);
-        $this->assertEquals(NetworkFactory::dash()->getHDPrivByte(), '0488ade4');
-        $this->assertEquals(NetworkFactory::dash()->getHDPubByte(), '0488b21e');
-        $this->assertEquals(NetworkFactory::dash()->getNetMagicBytes(), 'bd6b0cbf');
         $this->assertEquals('7X7VPCbTMLvUSjhMo3vdqKb8eNrccxgkJ1', $p2sh->getAddress(NetworkFactory::dash()));
         $this->assertEquals('XbKZStn8KGzRUsSr5wiq18A3VUyD7pdKXX', $p2pk->getAddress(NetworkFactory::dash()));
 
         // Dash testnet
-        $this->assertEquals(NetworkFactory::dashTestnet()->getAddressByte(), '8b');
-        $this->assertEquals(NetworkFactory::dashTestnet()->getP2shByte(), '13');
-        $this->assertEquals(NetworkFactory::dashTestnet()->getPrivByte(), 'ef');
-        $this->assertEquals(NetworkFactory::dashTestnet()->isTestnet(), true);
-        $this->assertEquals(NetworkFactory::dashTestnet()->getHDPrivByte(), '04358394');
-        $this->assertEquals(NetworkFactory::dashTestnet()->getHDPubByte(), '043587cf');
-        $this->assertEquals(NetworkFactory::dashTestnet()->getNetMagicBytes(), 'ffcae2ce');
         $this->assertEquals('8j8JLXVKUtK6u37csJvbHhQVXtdSmwYhAb', $p2sh->getAddress(NetworkFactory::dashTestnet()));
         $this->assertEquals('xwcZUjZH3eBd1BEJdNhuZ2Jc9GCduoV5cV', $p2pk->getAddress(NetworkFactory::dashTestnet()));
-    }
-
-    public function testGetHDPrivByte()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $network->setHDPrivByte('0488B21E');
-        $this->assertSame('0488B21E', $network->getHDPrivByte());
-    }
-
-
-    public function testSetHDPrivByte()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $network->setHDPrivByte('0488B21E');
-        $this->assertSame('0488B21E', $network->getHDPrivByte());
-    }
-
-    /**
-     * @expectedException \Exception
-     * @expectedExceptionMessage No HD xpub byte was set
-     */
-    public function testGetHDPubByteException()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $network->getHDPubByte();
-    }
-
-    public function testGetHDPubByte()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $network->setHDPubByte('0488B21E');
-        $this->assertSame('0488B21E', $network->getHDPubByte());
-    }
-
-    public function testSetHDPubByte()
-    {
-        $network = NetworkFactory::create('00', '05', '80', true);
-        $network->setHDPubByte('0488B21E');
-        $this->assertSame('0488B21E', $network->getHDPubByte());
     }
 }

--- a/tests/Network/Networks/BitcoinRegtestTest.php
+++ b/tests/Network/Networks/BitcoinRegtestTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\BitcoinRegtest;
+use BitWasp\Bitcoin\Network\Networks\BitcoinTestnet;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class BitcoinRegtestTest extends AbstractTestCase
+{
+    public function testLikeTestnet()
+    {
+        $testnet = new BitcoinTestnet();
+        $regtest = new BitcoinRegtest();
+        $this->assertEquals($testnet->getAddressByte(), $regtest->getAddressByte());
+        $this->assertEquals($testnet->getP2shByte(), $regtest->getP2shByte());
+        $this->assertEquals($testnet->getPrivByte(), $regtest->getPrivByte());
+        $this->assertEquals($testnet->getHDPrivByte(), $regtest->getHDPrivByte());
+        $this->assertEquals($testnet->getHDPubByte(), $regtest->getHDPubByte());
+        $this->assertEquals('dab5bffa', $regtest->getNetMagicBytes());
+    }
+}

--- a/tests/Network/Networks/BitcoinTest.php
+++ b/tests/Network/Networks/BitcoinTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class BitcoinTest extends AbstractTestCase
+{
+    public function testBitcoinNetwork()
+    {
+        $network = new Bitcoin();
+        $this->assertEquals('00', $network->getAddressByte());
+        $this->assertEquals('05', $network->getP2shByte());
+        $this->assertEquals('80', $network->getPrivByte());
+        $this->assertEquals('0488ade4', $network->getHDPrivByte());
+        $this->assertEquals('0488b21e', $network->getHDPubByte());
+        $this->assertEquals('d9b4bef9', $network->getNetMagicBytes());
+        $this->assertEquals("bc", $network->getSegwitBech32Prefix());
+        $this->assertEquals("Bitcoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/BitcoinTestnetTest.php
+++ b/tests/Network/Networks/BitcoinTestnetTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\BitcoinTestnet;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class BitcoinTestnetTest extends AbstractTestCase
+{
+    public function testBitcoinTestnetNetwork()
+    {
+        $network = new BitcoinTestnet();
+        $this->assertEquals('6f', $network->getAddressByte());
+        $this->assertEquals('c4', $network->getP2shByte());
+        $this->assertEquals('ef', $network->getPrivByte());
+        $this->assertEquals('04358394', $network->getHDPrivByte());
+        $this->assertEquals('043587cf', $network->getHDPubByte());
+        $this->assertEquals('0709110b', $network->getNetMagicBytes());
+        $this->assertEquals('tb', $network->getSegwitBech32Prefix());
+        $this->assertEquals("Bitcoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/DashTest.php
+++ b/tests/Network/Networks/DashTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\Dash;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class DashTest extends AbstractTestCase
+{
+    public function testDashNetwork()
+    {
+        $network = new Dash();
+        $this->assertEquals('4c', $network->getAddressByte());
+        $this->assertEquals('10', $network->getP2shByte());
+        $this->assertEquals('cc', $network->getPrivByte());
+        $this->assertEquals('0488ade4', $network->getHDPrivByte());
+        $this->assertEquals('0488b21e', $network->getHDPubByte());
+        $this->assertEquals('bd6b0cbf', $network->getNetMagicBytes());
+        $this->assertEquals("DarkCoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/DashTestnetTest.php
+++ b/tests/Network/Networks/DashTestnetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\DashTestnet;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class DashTestnetTest extends AbstractTestCase
+{
+    public function testDashTestnetNetwork()
+    {
+        $network = new DashTestnet();
+        $this->assertEquals('8b', $network->getAddressByte());
+        $this->assertEquals('13', $network->getP2shByte());
+        $this->assertEquals('ef', $network->getPrivByte());
+        $this->assertEquals('04358394', $network->getHDPrivByte());
+        $this->assertEquals('043587cf', $network->getHDPubByte());
+        $this->assertEquals('ffcae2ce', $network->getNetMagicBytes());
+        $this->assertEquals("DarkCoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/DogecoinTest.php
+++ b/tests/Network/Networks/DogecoinTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\Dogecoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class DogecoinTest extends AbstractTestCase
+{
+    public function testDogecoinNetwork()
+    {
+        $network = new Dogecoin();
+        $this->assertEquals('1e', $network->getAddressByte());
+        $this->assertEquals('16', $network->getP2shByte());
+        $this->assertEquals('9e', $network->getPrivByte());
+        $this->assertEquals('02fac398', $network->getHDPrivByte());
+        $this->assertEquals('02facafd', $network->getHDPubByte());
+        $this->assertEquals('c0c0c0c0', $network->getNetMagicBytes());
+        $this->assertEquals("Dogecoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/DogecoinTestnetTest.php
+++ b/tests/Network/Networks/DogecoinTestnetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\DogecoinTestnet;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class DogecoinTestnetTest extends AbstractTestCase
+{
+    public function testDogecoinTestnetNetwork()
+    {
+        $network = new DogecoinTestnet();
+        $this->assertEquals('71', $network->getAddressByte());
+        $this->assertEquals('c4', $network->getP2shByte());
+        $this->assertEquals('f1', $network->getPrivByte());
+        $this->assertEquals('04358394', $network->getHDPrivByte());
+        $this->assertEquals('043587cf', $network->getHDPubByte());
+        $this->assertEquals('dcb7c1fc', $network->getNetMagicBytes());
+        $this->assertEquals("Dogecoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/LitecoinTest.php
+++ b/tests/Network/Networks/LitecoinTest.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\Litecoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class LitecoinTest extends AbstractTestCase
+{
+    public function testLitecoinNetwork()
+    {
+        $network = new Litecoin();
+        $this->assertEquals('30', $network->getAddressByte());
+        $this->assertEquals('05', $network->getP2shByte());
+        $this->assertEquals('b0', $network->getPrivByte());
+        $this->assertEquals('019d9cfe', $network->getHDPrivByte());
+        $this->assertEquals('019da462', $network->getHDPubByte());
+        $this->assertEquals('dbb6c0fb', $network->getNetMagicBytes());
+        $this->assertEquals('ltc', $network->getSegwitBech32Prefix());
+        $this->assertEquals("Litecoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/LitecoinTestnetTest.php
+++ b/tests/Network/Networks/LitecoinTestnetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\LitecoinTestnet;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class LitecoinTestnetTest extends AbstractTestCase
+{
+    public function testLitecoinTestnetNetwork()
+    {
+        $network = new LitecoinTestnet();
+        $this->assertEquals('6f', $network->getAddressByte());
+        $this->assertEquals('c4', $network->getP2shByte());
+        $this->assertEquals('ef', $network->getPrivByte());
+        $this->assertEquals('04358394', $network->getHDPrivByte());
+        $this->assertEquals('043587cf', $network->getHDPubByte());
+        $this->assertEquals('f1c8d2fd', $network->getNetMagicBytes());
+        $this->assertEquals("Litecoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/ViacoinTest.php
+++ b/tests/Network/Networks/ViacoinTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\Viacoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class ViacoinTest extends AbstractTestCase
+{
+    public function testViacoin()
+    {
+        $network = new Viacoin();
+        $this->assertEquals('47', $network->getAddressByte());
+        $this->assertEquals('21', $network->getP2shByte());
+        $this->assertEquals('c7', $network->getPrivByte());
+        $this->assertEquals('0488ade4', $network->getHDPrivByte());
+        $this->assertEquals('0488b21e', $network->getHDPubByte());
+        $this->assertEquals('cbc6680f', $network->getNetMagicBytes());
+        $this->assertEquals("Viacoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/Networks/ViacoinTestnetTest.php
+++ b/tests/Network/Networks/ViacoinTestnetTest.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Networks\ViacoinTestnet;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class ViacoinTestnetTest extends AbstractTestCase
+{
+    public function testViacoinTestnetNetwork()
+    {
+        $network = new ViacoinTestnet();
+        $this->assertEquals('7f', $network->getAddressByte());
+        $this->assertEquals('c4', $network->getP2shByte());
+        $this->assertEquals('ff', $network->getPrivByte());
+        $this->assertEquals('04358394', $network->getHDPrivByte());
+        $this->assertEquals('043587cf', $network->getHDPubByte());
+        $this->assertEquals('92efc5a9', $network->getNetMagicBytes());
+        $this->assertEquals("Viacoin Signed Message", $network->getSignedMessageMagic());
+    }
+}

--- a/tests/Network/P2PMagicTest.php
+++ b/tests/Network/P2PMagicTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network;
+
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class P2PMagicTest extends AbstractTestCase
+{
+    public function testGetP2PMagic()
+    {
+        $bitcoin = new Bitcoin();
+        $this->assertEquals("d9b4bef9", $bitcoin->getNetMagicBytes());
+    }
+}

--- a/tests/Network/SignedMessageMagicTest.php
+++ b/tests/Network/SignedMessageMagicTest.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Network;
+
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class SignedMessageMagicTest extends AbstractTestCase
+{
+    public function testGetSignedMessageMagic()
+    {
+        $bitcoin = new Bitcoin();
+        $this->assertEquals("Bitcoin Signed Message", $bitcoin->getSignedMessageMagic());
+    }
+}


### PR DESCRIPTION
Moves network configuration into named classes, and organizes their tests. Allows users to extend Network to add new networks with some useful errors if some prefix is missing.

Also removes `isTestnet`, not sure it's actually useful..