### PR TITLE
Run one set of unit tests for extension tests

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -18,7 +18,7 @@ tools:
         excluded_dirs: [vendor, build, tests]
     external_code_coverage:
         timeout: 4100
-        runs: 4
+        runs: 1
 
 changetracking:
     bug_patterns: ["\bfix(?:es|ed)?\b"]

--- a/.travis.yml
+++ b/.travis.yml
@@ -91,9 +91,6 @@ before_script:
 
 script:
   - if [ "$PHPUNIT" = "true" ]; then make phpunit-ci; fi
-  - if [ "$PHPUNIT_EXT" = "true" ]; then EXT_PHP=" -dextension=secp256k1.so " make phpunit-ci; fi
-  - if [ "$PHPUNIT_EXT" = "true" ]; then EXT_PHP=" -dextension=bitcoinconsensus.so " make phpunit-ci; fi
-  - if [ "$PHPUNIT_EXT" = "true" ]; then EXT_PHP=" -dextension=bitcoinconsensus.so -dextension=secp256k1.so " make phpunit-ci; fi
   - if [ "$CODE_STYLE" = "true" ]; then make phpcs && echo "Code style OK"; fi
   - if [ "$EXAMPLES" = "true" ]; then make test-examples && echo "Examples OK"; fi
   - if [ "$RPC_TEST" = "true" ]; then export BITCOIND_PATH="$HOME/bitcoin/bitcoin-$BITCOIN_VERSION/bin/bitcoind"; fi

--- a/examples/trezor.bip32.php
+++ b/examples/trezor.bip32.php
@@ -9,7 +9,8 @@ use BitWasp\Bitcoin\Script\ScriptFactory;
 
 require __DIR__ . "/../vendor/autoload.php";
 
-function toAddress(HierarchicalKey $key, $purpose) {
+function toAddress(HierarchicalKey $key, $purpose)
+{
     switch ($purpose) {
         case 44:
             $script = ScriptFactory::scriptPubKey()->p2pkh($key->getPublicKey()->getPubKeyHash());

--- a/src/Crypto/EcAdapter/EcSerializer.php
+++ b/src/Crypto/EcAdapter/EcSerializer.php
@@ -110,17 +110,20 @@ class EcSerializer
      */
     public static function getSerializer($interface, $useCache = true, EcAdapterInterface $adapter = null)
     {
-        $adapter = $adapter ?: Bitcoin::getEcAdapter();
+        if (null === $adapter) {
+            $adapter = Bitcoin::getEcAdapter();
+        }
 
-        if (isset(self::$cache[$interface])) {
-            return self::$cache[$interface];
+        $key = get_class($adapter) . ":" . $interface;
+        if (array_key_exists($key, self::$cache)) {
+            return self::$cache[$key];
         }
 
         $classPath = self::getAdapterImplPath($adapter) . self::getImplRelPath($interface);
         $class = new $classPath($adapter);
 
         if ($useCache && self::$useCache) {
-            self::$cache[$interface] = $class;
+            self::$cache[$key] = $class;
         }
 
         return $class;

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PrivateKey.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Key/PrivateKey.php
@@ -149,7 +149,7 @@ class PrivateKey extends Key implements PrivateKeyInterface, \Mdanter\Ecc\Crypto
     {
         $network = $network ?: Bitcoin::getNetwork();
         $serializer = new WifPrivateKeySerializer(
-            $this->ecAdapter->getMath(),
+            $this->ecAdapter,
             new PrivateKeySerializer($this->ecAdapter)
         );
 

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
@@ -174,7 +174,7 @@ class PrivateKey extends Key implements PrivateKeyInterface
     public function toWif(NetworkInterface $network = null)
     {
         $network = $network ?: Bitcoin::getNetwork();
-        $wifSerializer = new WifPrivateKeySerializer($this->ecAdapter->getMath(), new PrivateKeySerializer($this->ecAdapter));
+        $wifSerializer = new WifPrivateKeySerializer($this->ecAdapter, new PrivateKeySerializer($this->ecAdapter));
         return $wifSerializer->serialize($network, $this);
     }
 

--- a/src/Key/PrivateKeyFactory.php
+++ b/src/Key/PrivateKeyFactory.php
@@ -83,16 +83,19 @@ class PrivateKeyFactory
     /**
      * @param string $wif
      * @param EcAdapterInterface|null $ecAdapter
-     * @param NetworkInterface $network
-     * @return \BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface
+     * @param NetworkInterface|null $network
+     * @return PrivateKeyInterface
      * @throws InvalidPrivateKey
+     * @throws \BitWasp\Bitcoin\Exceptions\Base58ChecksumFailure
      */
     public static function fromWif($wif, EcAdapterInterface $ecAdapter = null, NetworkInterface $network = null)
     {
-        $ecAdapter = $ecAdapter ?: Bitcoin::getEcAdapter();
-        $network = $network ?: Bitcoin::getNetwork();
+        if (null === $ecAdapter) {
+            $ecAdapter = Bitcoin::getEcAdapter();
+        }
+
         $serializer = EcSerializer::getSerializer(PrivateKeySerializerInterface::class, true, $ecAdapter);
-        $wifSerializer = new WifPrivateKeySerializer($ecAdapter->getMath(), $serializer);
+        $wifSerializer = new WifPrivateKeySerializer($ecAdapter, $serializer);
 
         return $wifSerializer->parse($wif, $network);
     }

--- a/tests/AbstractTestCase.php
+++ b/tests/AbstractTestCase.php
@@ -127,10 +127,10 @@ abstract class AbstractTestCase extends \PHPUnit_Framework_TestCase
         $math = new Math;
         $generator = EccFactory::getSecgCurves()->generator256k1();
         $adapters = [];
-
-        $adapters[] = [(extension_loaded('secp256k1')
-            ? EcAdapterFactory::getSecp256k1($math, $generator)
-            : EcAdapterFactory::getPhpEcc($math, $generator))];
+        $adapters[] = [EcAdapterFactory::getPhpEcc($math, $generator)];
+        if (extension_loaded('secp256k1')) {
+            $adapters[] = [EcAdapterFactory::getSecp256k1($math, $generator)];
+        }
 
         return $adapters;
     }

--- a/tests/Key/Deterministic/HierarchicalKeyTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeyTest.php
@@ -5,7 +5,6 @@ namespace BitWasp\Bitcoin\Tests\Key\Deterministic;
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
-use BitWasp\Bitcoin\Crypto\Random\Random;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKey;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
@@ -131,32 +130,38 @@ class HierarchicalKeyTest extends AbstractTestCase
         }
     }
 
-    public function testDerivePath()
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $ecAdapter
+     * @throws \Exception
+     */
+    public function testDerivePath(EcAdapterInterface $ecAdapter)
     {
+        $network = NetworkFactory::bitcoin();
         $entropy = Buffer::hex("000102030405060708090a0b0c0d0e0f");
-        $masterKey = HierarchicalKeyFactory::fromEntropy($entropy);
-        $this->assertEquals("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi", $masterKey->toExtendedKey());
+        $masterKey = HierarchicalKeyFactory::fromEntropy($entropy, $ecAdapter);
+        $this->assertEquals("xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi", $masterKey->toExtendedKey($network));
 
         $firstChildKey = $masterKey->derivePath("0");
-        $this->assertEquals("xprv9uHRZZhbkedL37eZEnyrNsQPFZYRAvjy5rt6M1nbEkLSo378x1CQQLo2xxBvREwiK6kqf7GRNvsNEchwibzXaV6i5GcsgyjBeRguXhKsi4R", $firstChildKey->toExtendedKey());
+        $this->assertEquals("xprv9uHRZZhbkedL37eZEnyrNsQPFZYRAvjy5rt6M1nbEkLSo378x1CQQLo2xxBvREwiK6kqf7GRNvsNEchwibzXaV6i5GcsgyjBeRguXhKsi4R", $firstChildKey->toExtendedKey($network));
 
         $bip44ChildKey = $masterKey->derivePath("44'/0'/0'/0/0");
-        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey());
+        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey($network));
 
         // get the "m/44'/0'/0'/0/0" derivation, in 2 steps
         $bip44ChildKey = $masterKey->derivePath("44'/0'");
         $bip44ChildKey = $bip44ChildKey->derivePath("0'/0/0");
-        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey());
+        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey($network));
 
         // get the "m/44'/0'/0'/0/0" derivation, in 2 steps
         $bip44ChildKey = $masterKey->derivePath("44'/0'/0'");
         $bip44ChildKey = $bip44ChildKey->derivePath("0/0");
-        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey());
+        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey($network));
 
         // get the "m/44'/0'/0'/0/0" derivation, in 2 steps
         $bip44ChildKey = $masterKey->derivePath("44'/0'/0'/0");
         $bip44ChildKey = $bip44ChildKey->derivePath("0");
-        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey());
+        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey($network));
 
         // get the "m/44'/0'/0'/0/0" derivation, in single steps
         $bip44ChildKey = $masterKey->derivePath("44'");
@@ -164,7 +169,7 @@ class HierarchicalKeyTest extends AbstractTestCase
         $bip44ChildKey = $bip44ChildKey->derivePath("0'");
         $bip44ChildKey = $bip44ChildKey->derivePath("0");
         $bip44ChildKey = $bip44ChildKey->derivePath("0");
-        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey());
+        $this->assertEquals("xprvA4A9CuBXhdBtCaLxwrw64Jaran4n1rgzeS5mjH47Ds8V67uZS8tTkG8jV3BZi83QqYXPcN4v8EjK2Aof4YcEeqLt688mV57gF4j6QZWdP9U", $bip44ChildKey->toExtendedKey($network));
     }
 
     /**

--- a/tests/Key/Deterministic/MultisigHDTest.php
+++ b/tests/Key/Deterministic/MultisigHDTest.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Tests\Key\Deterministic;
 
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeySequence;
 use BitWasp\Bitcoin\Key\Deterministic\MultisigHD;
@@ -57,10 +58,24 @@ class MultisigHDTest extends AbstractTestCase
         $this->assertEquals($keys, $hd->getKeys(), 'keys should match input when not sorting');
     }
 
-    public function testGetRedeemScript()
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $ecAdapter
+     */
+    public function testGetRedeemScript(EcAdapterInterface $ecAdapter)
     {
-        $keys[0] = HierarchicalKeyFactory::fromExtended('xpub661MyMwAqRbcGG5afwSiBJ37bLbnzj9VuCdKzcQgihyuRYbiA1PnhuzWzMg2H9xT7JMHWGowEfx93cxzL7KUsX9Q2hrG2ayhKf93x1uXUsV');
-        $keys[1] = HierarchicalKeyFactory::fromExtended('xpub661MyMwAqRbcG2X4GYsMkLw3Rputa3aG865sQUG1mK6B4UGCyGLePHejDxiSYqWGBDUzUagLqzHq8cemTYYjHop8DRtkfqt6TAxMEznufcz');
+        $keys[0] = HierarchicalKeyFactory::fromExtended(
+            'xpub661MyMwAqRbcGG5afwSiBJ37bLbnzj9VuCdKzcQgihyuRYbiA1PnhuzWzMg2H9xT7JMHWGowEfx93cxzL7KUsX9Q2hrG2ayhKf93x1uXUsV',
+            null,
+            $ecAdapter
+        );
+
+        $keys[1] = HierarchicalKeyFactory::fromExtended(
+            'xpub661MyMwAqRbcG2X4GYsMkLw3Rputa3aG865sQUG1mK6B4UGCyGLePHejDxiSYqWGBDUzUagLqzHq8cemTYYjHop8DRtkfqt6TAxMEznufcz',
+            null,
+            $ecAdapter
+        );
+
         $sequences = new HierarchicalKeySequence();
         $hd = new MultisigHD(2, 'm', $keys, $sequences, true);
         $script = $hd->getRedeemScript();
@@ -71,14 +86,19 @@ class MultisigHDTest extends AbstractTestCase
         $this->assertEquals($expected, $script->getHex());
     }
 
-    public function testDeriveChild()
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $ecAdapter
+     * @throws \Exception
+     */
+    public function testDeriveChild(EcAdapterInterface $ecAdapter)
     {
         $hd = new MultisigHD(
             2,
             'm',
             [
-                HierarchicalKeyFactory::fromEntropy(Buffer::hex('01')),
-                HierarchicalKeyFactory::fromEntropy(Buffer::hex('02'))
+                HierarchicalKeyFactory::fromEntropy(Buffer::hex('01'), $ecAdapter),
+                HierarchicalKeyFactory::fromEntropy(Buffer::hex('02'), $ecAdapter)
             ],
             new HierarchicalKeySequence(),
             true
@@ -95,14 +115,19 @@ class MultisigHDTest extends AbstractTestCase
         $this->assertEquals('3GX7j2puUbkyMiWu3YYYEczJQ1ZPS9vdam', $address->getAddress());
     }
 
-    public function testDerivePath()
+    /**
+     * @throws \Exception
+     * @param EcAdapterInterface $ecAdapter
+     * @dataProvider getEcAdapters
+     */
+    public function testDerivePath(EcAdapterInterface $ecAdapter)
     {
         $hd = new MultisigHD(
             2,
             'm',
             [
-                HierarchicalKeyFactory::fromEntropy(Buffer::hex('01')),
-                HierarchicalKeyFactory::fromEntropy(Buffer::hex('02'))
+                HierarchicalKeyFactory::fromEntropy(Buffer::hex('01'), $ecAdapter),
+                HierarchicalKeyFactory::fromEntropy(Buffer::hex('02'), $ecAdapter)
             ],
             new HierarchicalKeySequence(),
             true

--- a/tests/Key/PrivateKeyTest.php
+++ b/tests/Key/PrivateKeyTest.php
@@ -149,10 +149,11 @@ class PrivateKeyTest extends AbstractTestCase
     }
 
     /**
+     * @dataProvider getEcAdapters
      * @expectedException \BitWasp\Bitcoin\Exceptions\Base58ChecksumFailure
      */
-    public function testInvalidWif()
+    public function testInvalidWif(EcAdapterInterface $ecAdapter)
     {
-        PrivateKeyFactory::fromWif('5akdgashdgkjads');
+        PrivateKeyFactory::fromWif('5akdgashdgkjads', $ecAdapter);
     }
 }

--- a/tests/Key/PublicKeyTest.php
+++ b/tests/Key/PublicKeyTest.php
@@ -107,10 +107,13 @@ class PublicKeyTest extends AbstractTestCase
         $results = [];
 
         foreach ($json->test as $test) {
-            $results[] = [
-                $test->key,
-                $test->hash
-            ];
+            foreach ($this->getEcAdapters() as $ecAdapterFixture) {
+                $results[] = [
+                    $ecAdapterFixture[0],
+                    $test->key,
+                    $test->hash
+                ];
+            }
         }
         
         return $results;
@@ -121,11 +124,11 @@ class PublicKeyTest extends AbstractTestCase
      * @param string $eKey - hex public key
      * @param string $eHash - hex sha256ripemd160 of public key
      */
-    public function testPubKeyHash($eKey, $eHash)
+    public function testPubKeyHash(EcAdapterInterface $ecAdapter, $eKey, $eHash)
     {
         $this->assertSame(
             $eHash,
-            PublicKeyFactory::fromHex($eKey)
+            PublicKeyFactory::fromHex($eKey, $ecAdapter)
                 ->getPubKeyHash()
                 ->getHex()
         );

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -44,7 +44,7 @@ class InterpreterTest extends AbstractTestCase
     public function testScript($flags, ScriptInterface $scriptSig, ScriptInterface $scriptPubKey, $result, $tx)
     {
         $ec = Bitcoin::getEcAdapter();
-        $i = new Interpreter($ec, $tx);
+        $i = new Interpreter($ec);
 
         $stack = new Stack();
         $checker = new Checker($ec, new Transaction(), 0, 0);
@@ -58,7 +58,7 @@ class InterpreterTest extends AbstractTestCase
     {
         $ec = Bitcoin::getEcAdapter();
         $f = 0;
-        $i = new Interpreter($ec, new Transaction);
+        $i = new Interpreter($ec);
         $script = ScriptFactory::create()->op('OP_RETURN')->getScript();
 
         $this->assertFalse($i->verify($script, new Script, $f, new Checker($ec, new Transaction(), 0, 0)));
@@ -80,7 +80,7 @@ class InterpreterTest extends AbstractTestCase
         $f = 0;
         $ec = Bitcoin::getEcAdapter();
 
-        $i = new Interpreter(Bitcoin::getEcAdapter(), new Transaction);
+        $i = new Interpreter(Bitcoin::getEcAdapter());
         $empty = new Script();
         $this->assertFalse($i->verify($empty, $empty, $f, new Checker($ec, new Transaction(), 0, 0)));
     }
@@ -93,7 +93,7 @@ class InterpreterTest extends AbstractTestCase
         $ec = Bitcoin::getEcAdapter();
 
         $f = 0;
-        $i = new Interpreter(Bitcoin::getEcAdapter(), new Transaction);
+        $i = new Interpreter(Bitcoin::getEcAdapter());
         $this->assertFalse($i->verify($true, $false, $f, new Checker($ec, new Transaction(), 0, 0)));
     }
 
@@ -106,7 +106,7 @@ class InterpreterTest extends AbstractTestCase
         $scriptSig = new Script();
 
         $f = InterpreterInterface::VERIFY_P2SH;
-        $i = new Interpreter(Bitcoin::getEcAdapter(), new Transaction);
+        $i = new Interpreter(Bitcoin::getEcAdapter());
         $this->assertFalse($i->verify($scriptSig, $output, $f, new Checker($ec, new Transaction(), 0, 0)));
     }
 
@@ -118,7 +118,7 @@ class InterpreterTest extends AbstractTestCase
         $scriptSig = ScriptFactory::create()->op('OP_0')->push($p2sh->getBuffer())->getScript();
 
         $f = InterpreterInterface::VERIFY_P2SH;
-        $i = new Interpreter($ec, new Transaction);
+        $i = new Interpreter($ec);
         $this->assertFalse($i->verify($scriptSig, $scriptPubKey, $f, new Checker($ec, new Transaction(), 0, 0)));
     }
 
@@ -130,7 +130,7 @@ class InterpreterTest extends AbstractTestCase
         $scriptPubKey = ScriptFactory::scriptPubKey()->payToScriptHash(Hash::sha256ripe160($p2sh->getBuffer()));
 
         $f = InterpreterInterface::VERIFY_P2SH;
-        $i = new Interpreter($ec, new Transaction);
+        $i = new Interpreter($ec);
         $this->assertFalse($i->verify($scriptSig, $scriptPubKey, $f, new Checker($ec, new Transaction(), 0, 0)));
     }
 

--- a/tests/Script/Interpreter/NumberTest.php
+++ b/tests/Script/Interpreter/NumberTest.php
@@ -8,7 +8,9 @@ use BitWasp\Buffertools\Buffer;
 
 class NumberTest extends AbstractTestCase
 {
-
+    /**
+     * @return array
+     */
     public function getVectors()
     {
         return [
@@ -28,6 +30,7 @@ class NumberTest extends AbstractTestCase
 
     /**
      * @param int|string $int
+     * @param int $expectedSize
      * @param string $expectedHex
      * @dataProvider getVectors
      */
@@ -40,7 +43,9 @@ class NumberTest extends AbstractTestCase
     }
 
     /**
+     * @throws \Exception
      * @param int|string $int
+     * @param int $expectedSize
      * @param string $expectedHex
      * @dataProvider getVectors
      */

--- a/tests/Script/Interpreter/ScriptTest.php
+++ b/tests/Script/Interpreter/ScriptTest.php
@@ -2,199 +2,33 @@
 
 namespace BitWasp\Bitcoin\Tests\Script\Interpreter;
 
-use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Script\Interpreter\Checker;
 use BitWasp\Bitcoin\Script\Interpreter\Interpreter;
-use BitWasp\Bitcoin\Script\Opcodes;
-use BitWasp\Bitcoin\Script\Script;
-use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
-use BitWasp\Bitcoin\Script\ScriptWitness;
 use BitWasp\Bitcoin\Script\ScriptWitnessInterface;
-use BitWasp\Bitcoin\Tests\AbstractTestCase;
-use BitWasp\Bitcoin\Transaction\OutPoint;
-use BitWasp\Bitcoin\Transaction\Transaction;
-use BitWasp\Bitcoin\Transaction\TransactionInput;
-use BitWasp\Bitcoin\Transaction\TransactionInterface;
-use BitWasp\Bitcoin\Transaction\TransactionOutput;
-use BitWasp\Buffertools\Buffer;
+use BitWasp\Bitcoin\Tests\Script\ScriptCheckTestBase;
 
 /**
  * This is essentially a port of Bitcoin Core's test suite.
  * When updating:
  *   cp bitcoin/src/test/data/script_tests.json bitcoin-php/tests/Data/script_tests.json
  */
-class ScriptTest extends AbstractTestCase
+class ScriptTest extends ScriptCheckTestBase
 {
-    /**
-     * @param ScriptInterface $scriptPubKey
-     * @param int $amount
-     * @return Transaction
-     */
-    public function buildCreditingTransaction(ScriptInterface $scriptPubKey, $amount = 0)
-    {
-        return new Transaction(
-            1,
-            [
-                new TransactionInput(
-                    new OutPoint(new Buffer("\x00", 32), 0xffffffff),
-                    ScriptFactory::sequence([Opcodes::OP_0, Opcodes::OP_0]),
-                    TransactionInput::SEQUENCE_FINAL
-                )
-            ],
-            [
-                new TransactionOutput($amount, $scriptPubKey)
-            ],
-            [],
-            0
-        );
-    }
-
-    /**
-     * @param TransactionInterface $tx
-     * @param ScriptInterface $scriptSig
-     * @param ScriptWitnessInterface|null $scriptWitness
-     * @return Transaction
-     */
-    public function buildSpendTransaction(TransactionInterface $tx, ScriptInterface $scriptSig, ScriptWitnessInterface $scriptWitness = null)
-    {
-        return new Transaction(
-            1,
-            [
-                new TransactionInput(
-                    $tx->makeOutPoint(0),
-                    $scriptSig,
-                    TransactionInput::SEQUENCE_FINAL
-                )
-            ],
-            [
-                new TransactionOutput($tx->getOutput(0)->getValue(), new Script())
-            ],
-            $scriptWitness == null ? [] : [$scriptWitness],
-            0
-        );
-    }
-
-    /**
-     * @param string $data
-     * @return Script|ScriptInterface
-     */
-    public function parseTestScript($data)
-    {
-        if (is_array($data)) {
-            return ScriptFactory::sequence($data);
-        } else if (is_string($data)) {
-            return ScriptFactory::fromHex($data);
-        }
-
-        throw new \RuntimeException('Invalid data for test case: supports array (interpreted as sequence), or string (interpreted as hex)');
-    }
-
-    /**
-     * @param Opcodes $opcodes
-     * @return array
-     */
-    public function calcMapOpNames(Opcodes $opcodes)
-    {
-        $mapOpNames = [];
-        for ($op = 0; $op <= Opcodes::OP_NOP10; $op++) {
-            if ($op < Opcodes::OP_NOP && $op != Opcodes::OP_RESERVED) {
-                continue;
-            }
-
-            $name = $opcodes->getOp($op);
-            if ($name === "OP_UNKNOWN") {
-                continue;
-            }
-
-            $mapOpNames[$name] = $op;
-            $mapOpNames[substr($name, 3)] = $op;
-        }
-
-        return $mapOpNames;
-    }
-
-    /**
-     * @param array $mapOpNames
-     * @param string $string
-     * @return ScriptInterface
-     */
-    public function calcScriptFromString($mapOpNames, $string)
-    {
-        $builder = ScriptFactory::create();
-        $split = explode(" ", $string);
-        foreach ($split as $item) {
-            if ($item === 'NOP3') {
-                $item = 'OP_CHECKSEQUENCEVERIFY';
-            }
-
-            if (strlen($item) == '') {
-            } else if (preg_match("/^[0-9]*$/", $item) || substr($item, 0, 1) === "-" && preg_match("/^[0-9]*$/", substr($item, 1))) {
-                $builder->int($item);
-            } else if (substr($item, 0, 2) === "0x") {
-                $scriptConcat = new Script(Buffer::hex(substr($item, 2)));
-                $builder->concat($scriptConcat);
-            } else if (strlen($item) >= 2 && substr($item, 0, 1) === "'" && substr($item, -1) === "'") {
-                $buffer = new Buffer(substr($item, 1, strlen($item) - 2));
-                $builder->push($buffer);
-            } else if (isset($mapOpNames[$item])) {
-                $builder->sequence([$mapOpNames[$item]]);
-            } else {
-                throw new \RuntimeException('Script parse error: element "' . $item . '"');
-            }
-        }
-
-        return $builder->getScript();
-    }
 
     /**
      * @return array
      */
-    public function prepareTests()
+    public function prepareInterpreterTests()
     {
-        $ecAdapter = Bitcoin::getEcAdapter();
-        $opcodes = new Opcodes();
-        $mapOpNames = $this->calcMapOpNames($opcodes);
-        $object = json_decode($this->dataFile("script_tests.json"), true);
-        $testCount = count($object);
         $vectors = [];
-        for ($idx = 0; $idx < $testCount; $idx++) {
-            $test = $object[$idx];
-            $strTest = end($test);
-            $witnessStack = [];
-            $amount = 0;
-            $pos = 0;
-            if (count($test) > 0 && is_array($test[$pos])) {
-                for ($i = 0; $i < count($test[$pos]) - 1; $i++) {
-                    $witnessStack[] = Buffer::hex($test[$pos][$i]);
-                }
-
-                $amt = number_format($test[$pos][$i], 8, '.', '');
-                $sat = bcmul($amt, 10**8);
-                $amount = $sat;
-                $pos++;
+        foreach ($this->prepareTestData() as $fixture) {
+            list ($flags, $returns, $scriptWitness, $scriptSig, $scriptPubKey, $amount, $strTest) = $fixture;
+            foreach ($this->getEcAdapters() as $ecAdapterFixture) {
+                list ($ecAdapter) = $ecAdapterFixture;
+                $vectors[] = [$ecAdapter, new Interpreter($ecAdapter), $flags, $returns, $scriptWitness, $scriptSig, $scriptPubKey, $amount, $strTest];
             }
-
-            if (count($test) < 4 + $pos) {
-                if (count($test) != 1) {
-                    throw new \RuntimeException('bad test');
-                }
-
-                continue;
-            }
-
-            $scriptWitness = new ScriptWitness($witnessStack);
-            $scriptSigString = $test[$pos++];
-            $scriptSig = $this->calcScriptFromString($mapOpNames, $scriptSigString);
-
-            $scriptPubKeyString = $test[$pos++];
-            $scriptPubKey = $this->calcScriptFromString($mapOpNames, $scriptPubKeyString);
-
-            $flags = $this->getScriptFlagsFromString($test[$pos++]);
-            $returns = ($test[$pos++]) === 'OK' ? true : false;
-
-            $vectors[] = [$ecAdapter, new Interpreter($ecAdapter), $flags, $returns, $scriptWitness, $scriptSig, $scriptPubKey, $amount, $strTest];
         }
 
         return $vectors;
@@ -209,7 +43,7 @@ class ScriptTest extends AbstractTestCase
      * @param ScriptInterface $scriptSig
      * @param ScriptInterface $scriptPubKey
      * @param int $amount
-     * @dataProvider prepareTests
+     * @dataProvider prepareInterpreterTests
      */
     public function testScript(EcAdapterInterface $ecAdapter, Interpreter $interpreter, $flags, $expectedResult, ScriptWitnessInterface $scriptWitness, ScriptInterface $scriptSig, ScriptInterface $scriptPubKey, $amount, $strTest)
     {

--- a/tests/Script/P2shScriptTest.php
+++ b/tests/Script/P2shScriptTest.php
@@ -10,7 +10,6 @@ use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
-use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Script\WitnessScript;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
 use BitWasp\Buffertools\Buffer;

--- a/tests/Script/ScriptCheckTestBase.php
+++ b/tests/Script/ScriptCheckTestBase.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Script;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Script\Consensus\BitcoinConsensus;
+use BitWasp\Bitcoin\Script\Consensus\NativeConsensus;
+use BitWasp\Bitcoin\Script\Opcodes;
+use BitWasp\Bitcoin\Script\Script;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Script\ScriptWitness;
+use BitWasp\Bitcoin\Script\ScriptWitnessInterface;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Bitcoin\Transaction\OutPoint;
+use BitWasp\Bitcoin\Transaction\Transaction;
+use BitWasp\Bitcoin\Transaction\TransactionInput;
+use BitWasp\Bitcoin\Transaction\TransactionInterface;
+use BitWasp\Bitcoin\Transaction\TransactionOutput;
+use BitWasp\Buffertools\Buffer;
+
+abstract class ScriptCheckTestBase extends AbstractTestCase
+{
+    /**
+     * @param ScriptInterface $scriptPubKey
+     * @param int $amount
+     * @return Transaction
+     */
+    public function buildCreditingTransaction(ScriptInterface $scriptPubKey, $amount = 0)
+    {
+        return new Transaction(
+            1,
+            [
+                new TransactionInput(
+                    new OutPoint(new Buffer("\x00", 32), 0xffffffff),
+                    ScriptFactory::sequence([Opcodes::OP_0, Opcodes::OP_0]),
+                    TransactionInput::SEQUENCE_FINAL
+                )
+            ],
+            [
+                new TransactionOutput($amount, $scriptPubKey)
+            ],
+            [],
+            0
+        );
+    }
+
+    /**
+     * @param TransactionInterface $tx
+     * @param ScriptInterface $scriptSig
+     * @param ScriptWitnessInterface|null $scriptWitness
+     * @return Transaction
+     */
+    public function buildSpendTransaction(TransactionInterface $tx, ScriptInterface $scriptSig, ScriptWitnessInterface $scriptWitness = null)
+    {
+        return new Transaction(
+            1,
+            [
+                new TransactionInput(
+                    $tx->makeOutPoint(0),
+                    $scriptSig,
+                    TransactionInput::SEQUENCE_FINAL
+                )
+            ],
+            [
+                new TransactionOutput($tx->getOutput(0)->getValue(), new Script())
+            ],
+            $scriptWitness == null ? [] : [$scriptWitness],
+            0
+        );
+    }
+
+    /**
+     * @param string $data
+     * @return Script|ScriptInterface
+     */
+    public function parseTestScript($data)
+    {
+        if (is_array($data)) {
+            return ScriptFactory::sequence($data);
+        } else if (is_string($data)) {
+            return ScriptFactory::fromHex($data);
+        }
+
+        throw new \RuntimeException('Invalid data for test case: supports array (interpreted as sequence), or string (interpreted as hex)');
+    }
+
+    /**
+     * @param Opcodes $opcodes
+     * @return array
+     */
+    public function calcMapOpNames(Opcodes $opcodes)
+    {
+        $mapOpNames = [];
+        for ($op = 0; $op <= Opcodes::OP_NOP10; $op++) {
+            if ($op < Opcodes::OP_NOP && $op != Opcodes::OP_RESERVED) {
+                continue;
+            }
+
+            $name = $opcodes->getOp($op);
+            if ($name === "OP_UNKNOWN") {
+                continue;
+            }
+
+            $mapOpNames[$name] = $op;
+            $mapOpNames[substr($name, 3)] = $op;
+        }
+
+        return $mapOpNames;
+    }
+
+    /**
+     * @param array $mapOpNames
+     * @param string $string
+     * @return ScriptInterface
+     */
+    public function calcScriptFromString($mapOpNames, $string)
+    {
+        $builder = ScriptFactory::create();
+        $split = explode(" ", $string);
+        foreach ($split as $item) {
+            if ($item === 'NOP3') {
+                $item = 'OP_CHECKSEQUENCEVERIFY';
+            }
+
+            if (strlen($item) == '') {
+            } else if (preg_match("/^[0-9]*$/", $item) || substr($item, 0, 1) === "-" && preg_match("/^[0-9]*$/", substr($item, 1))) {
+                $builder->int($item);
+            } else if (substr($item, 0, 2) === "0x") {
+                $scriptConcat = new Script(Buffer::hex(substr($item, 2)));
+                $builder->concat($scriptConcat);
+            } else if (strlen($item) >= 2 && substr($item, 0, 1) === "'" && substr($item, -1) === "'") {
+                $buffer = new Buffer(substr($item, 1, strlen($item) - 2));
+                $builder->push($buffer);
+            } else if (isset($mapOpNames[$item])) {
+                $builder->sequence([$mapOpNames[$item]]);
+            } else {
+                throw new \RuntimeException('Script parse error: element "' . $item . '"');
+            }
+        }
+
+        return $builder->getScript();
+    }
+
+    /**
+     * @return array
+     */
+    public function prepareTestData()
+    {
+        $opcodes = new Opcodes();
+        $mapOpNames = $this->calcMapOpNames($opcodes);
+        $object = json_decode($this->dataFile("script_tests.json"), true);
+        $testCount = count($object);
+        $vectors = [];
+        for ($idx = 0; $idx < $testCount; $idx++) {
+            $test = $object[$idx];
+            $strTest = end($test);
+            $witnessStack = [];
+            $amount = 0;
+            $pos = 0;
+            if (count($test) > 0 && is_array($test[$pos])) {
+                for ($i = 0; $i < count($test[$pos]) - 1; $i++) {
+                    $witnessStack[] = Buffer::hex($test[$pos][$i]);
+                }
+
+                $amt = number_format($test[$pos][$i], 8, '.', '');
+                $sat = bcmul($amt, 10**8);
+                $amount = $sat;
+                $pos++;
+            }
+
+            if (count($test) < 4 + $pos) {
+                if (count($test) != 1) {
+                    throw new \RuntimeException('bad test');
+                }
+
+                continue;
+            }
+
+            $scriptWitness = new ScriptWitness($witnessStack);
+            $scriptSigString = $test[$pos++];
+            $scriptSig = $this->calcScriptFromString($mapOpNames, $scriptSigString);
+
+            $scriptPubKeyString = $test[$pos++];
+            $scriptPubKey = $this->calcScriptFromString($mapOpNames, $scriptPubKeyString);
+
+            $flags = $this->getScriptFlagsFromString($test[$pos++]);
+            $returns = ($test[$pos++]) === 'OK' ? true : false;
+
+            $vectors[] = [$flags, $returns, $scriptWitness, $scriptSig, $scriptPubKey, $amount, $strTest];
+        }
+
+        return $vectors;
+    }
+
+    /**
+     * @param array $ecAdapterFixtures - array<array<EcAdapterInterface>>
+     * @return array - array<array<ConsensusInterface,EcAdapterInterface>>
+     */
+    public function getConsensusAdapters(array $ecAdapterFixtures)
+    {
+        $adapters = [];
+        foreach ($ecAdapterFixtures as $ecAdapterFixture) {
+            list ($ecAdapter) = $ecAdapterFixture;
+            $adapters[] = [new NativeConsensus($ecAdapter)];
+            if (extension_loaded('bitcoinconsensus')) {
+                $adapters[] = [new BitcoinConsensus()];
+            }
+        }
+
+        return $adapters;
+    }
+}

--- a/tests/Serializer/Key/PrivateKey/WifPrivateKeySerializerTest.php
+++ b/tests/Serializer/Key/PrivateKey/WifPrivateKeySerializerTest.php
@@ -17,21 +17,23 @@ class WifPrivateKeySerializerTest extends AbstractBip39Case
     /**
      * @param EcAdapterInterface $ecAdapter
      * @dataProvider getEcAdapters
-     * @expectedException \BitWasp\Bitcoin\Exceptions\InvalidPrivateKey
-     * @expectedExceptionMessage Private key should be always be 32 or 33 bytes (depending on if it's compressed)
      */
     public function testSerializer(EcAdapterInterface $ecAdapter)
     {
         $network = NetworkFactory::bitcoin();
 
         $hexSerializer = EcSerializer::getSerializer(PrivateKeySerializerInterface::class, true, $ecAdapter);
-        $wifSerializer = new WifPrivateKeySerializer($ecAdapter->getMath(), $hexSerializer);
+        $wifSerializer = new WifPrivateKeySerializer($ecAdapter, $hexSerializer);
 
-        $valid = PrivateKeyFactory::create();
+        $valid = PrivateKeyFactory::create(false, $ecAdapter);
         $this->assertEquals($valid, $wifSerializer->parse($wifSerializer->serialize($network, $valid), $network));
 
         $invalid = Buffer::hex('8041414141414141414141414141414141');
         $b58 = Base58::encodeCheck($invalid);
+
+        $this->expectException(\BitWasp\Bitcoin\Exceptions\InvalidPrivateKey::class);
+        $this->expectExceptionMessage("Private key should be always be 32 or 33 bytes (depending on if it's compressed)");
+
         $wifSerializer->parse($b58);
     }
 }

--- a/tests/SignedMessage/SignedMessageTest.php
+++ b/tests/SignedMessage/SignedMessageTest.php
@@ -55,10 +55,10 @@ IBpGR29vEbbl4kmpK0fcDsT75GPeH2dg5O199D3iIkS3VcDoQahJMGJEDozXot8JGULWjN9Llq79aF+F
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Message must begin with -----BEGIN BITCOIN SIGNED MESSAGE-----
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $ecAdapter
      */
-    public function testInvalidMessage1()
+    public function testInvalidMessage1(EcAdapterInterface $ecAdapter)
     {
         $invalid = '-----BEGIN SIGNED MESSAGE-----
 hi
@@ -67,16 +67,20 @@ IBpGR29vEbbl4kmpK0fcDsT75GPeH2dg5O199D3iIkS3VcDoQahJMGJEDozXot8JGULWjN9Llq79aF+F
         -----END BITCOIN SIGNED MESSAGE-----';
 
         $serializer = new SignedMessageSerializer(
-            EcSerializer::getSerializer(CompactSignatureSerializerInterface::class, true, $this->safeEcAdapter())
+            EcSerializer::getSerializer(CompactSignatureSerializerInterface::class, true, $ecAdapter)
         );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Message must begin with -----BEGIN BITCOIN SIGNED MESSAGE-----");
+
         $serializer->parse($invalid);
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Message must end with -----END BITCOIN SIGNED MESSAGE-----
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $ecAdapter
      */
-    public function testInvalidMessage2()
+    public function testInvalidMessage2(EcAdapterInterface $ecAdapter)
     {
         $invalid = '-----BEGIN BITCOIN SIGNED MESSAGE-----
 hi
@@ -85,16 +89,20 @@ IBpGR29vEbbl4kmpK0fcDsT75GPeH2dg5O199D3iIkS3VcDoQahJMGJEDozXot8JGULWjN9Llq79aF+F
         ';
 
         $serializer = new SignedMessageSerializer(
-            EcSerializer::getSerializer(CompactSignatureSerializerInterface::class, true, $this->safeEcAdapter())
+            EcSerializer::getSerializer(CompactSignatureSerializerInterface::class, true, $ecAdapter)
         );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Message must end with -----END BITCOIN SIGNED MESSAGE-----");
+
         $serializer->parse($invalid);
     }
 
     /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Unable to find start of signature
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $ecAdapter
      */
-    public function testInvalidMessage3()
+    public function testInvalidMessage3(EcAdapterInterface $ecAdapter)
     {
         $invalid = '-----BEGIN BITCOIN SIGNED MESSAGE-----
 hi
@@ -103,8 +111,12 @@ IBpGR29vEbbl4kmpK0fcDsT75GPeH2dg5O199D3iIkS3VcDoQahJMGJEDozXot8JGULWjN9Llq79aF+F
         -----END BITCOIN SIGNED MESSAGE-----';
 
         $serializer = new SignedMessageSerializer(
-            EcSerializer::getSerializer(CompactSignatureSerializerInterface::class, true, $this->safeEcAdapter())
+            EcSerializer::getSerializer(CompactSignatureSerializerInterface::class, true, $ecAdapter)
         );
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("Unable to find start of signature");
+
         $serializer->parse($invalid);
     }
 }

--- a/tests/UriTest.php
+++ b/tests/UriTest.php
@@ -39,8 +39,6 @@ class UriTest extends AbstractTestCase
         $this->assertEquals('bitcoin:'.$string."?amount=1", $uri->uri());
     }
 
-
-
     public function testLabel()
     {
         $string = '1FeDtFhARLxjKUPPkQqEBL78tisenc9znS';


### PR DESCRIPTION
The previous approach of running the entire test suite for as many combinations of extensions was a bit much for travis.. We exceeded the maximum test duration today because of it. 

Had to break WifPrivateKeySerializer's constructor to do it because it only had Math before, not an EcAdapter, so would return instances derived from the default EcAdapter, not the one we were testing..