### PR TITLE
Allow custom Checker implementations

### DIFF
--- a/src/Exceptions/SignerException.php
+++ b/src/Exceptions/SignerException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class SignerException extends \Exception
+{
+
+}

--- a/src/Script/Interpreter/BitcoinCashChecker.php
+++ b/src/Script/Interpreter/BitcoinCashChecker.php
@@ -11,8 +11,13 @@ use BitWasp\Bitcoin\Transaction\SignatureHash\V1Hasher;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
 
-class BitcoinCashChecker extends Checker
+class BitcoinCashChecker extends CheckerBase
 {
+    /**
+     * @var array
+     */
+    protected $sigHashCache = [];
+
     /**
      * @var int
      */
@@ -24,7 +29,7 @@ class BitcoinCashChecker extends Checker
      * @param int $sigVersion
      * @return BufferInterface
      */
-    public function getSigHash(ScriptInterface $script, int $sigHashType, int $sigVersion)
+    public function getSigHash(ScriptInterface $script, int $sigHashType, int $sigVersion): BufferInterface
     {
         if ($sigVersion !== 0) {
             throw new \RuntimeException("SigVersion must be 0");
@@ -35,11 +40,7 @@ class BitcoinCashChecker extends Checker
             if ($sigHashType & SigHash::BITCOINCASH) {
                 $hasher = new V1Hasher($this->transaction, $this->amount);
             } else {
-                if ($this->hasherV0) {
-                    $hasher = $this->hasherV0;
-                } else {
-                    $hasher = $this->hasherV0 = new Hasher($this->transaction);
-                }
+                $hasher = new Hasher($this->transaction);
             }
 
             $hash = $hasher->calculate($script, $this->nInput, $sigHashType);

--- a/src/Script/Interpreter/Checker.php
+++ b/src/Script/Interpreter/Checker.php
@@ -4,198 +4,19 @@ declare(strict_types=1);
 
 namespace BitWasp\Bitcoin\Script\Interpreter;
 
-use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
-use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PublicKey;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
-use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Signature\DerSignatureSerializerInterface;
-use BitWasp\Bitcoin\Exceptions\ScriptRuntimeException;
-use BitWasp\Bitcoin\Exceptions\SignatureNotCanonical;
-use BitWasp\Bitcoin\Locktime;
 use BitWasp\Bitcoin\Script\ScriptInterface;
-use BitWasp\Bitcoin\Serializer\Signature\TransactionSignatureSerializer;
-use BitWasp\Bitcoin\Signature\TransactionSignature;
 use BitWasp\Bitcoin\Transaction\SignatureHash\Hasher;
 use BitWasp\Bitcoin\Transaction\SignatureHash\SigHash;
 use BitWasp\Bitcoin\Transaction\SignatureHash\V1Hasher;
-use BitWasp\Bitcoin\Transaction\TransactionInput;
-use BitWasp\Bitcoin\Transaction\TransactionInputInterface;
-use BitWasp\Bitcoin\Transaction\TransactionInterface;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
 
-class Checker
+class Checker extends CheckerBase
 {
-    /**
-     * @var EcAdapterInterface
-     */
-    protected $adapter;
-
-    /**
-     * @var TransactionInterface
-     */
-    protected $transaction;
-
-    /**
-     * @var int
-     */
-    protected $nInput;
-
-    /**
-     * @var int|string
-     */
-    protected $amount;
-
-    /**
-     * @var Hasher
-     */
-    protected $hasherV0;
-
     /**
      * @var array
      */
     protected $sigHashCache = [];
-
-    /**
-     * @var array
-     */
-    protected $sigCache = [];
-
-    /**
-     * @var TransactionSignatureSerializer
-     */
-    private $sigSerializer;
-
-    /**
-     * @var PublicKeySerializerInterface
-     */
-    private $pubKeySerializer;
-
-    /**
-     * @var int
-     */
-    protected $sigHashOptionalBits = SigHash::ANYONECANPAY;
-
-    /**
-     * Checker constructor.
-     * @param EcAdapterInterface $ecAdapter
-     * @param TransactionInterface $transaction
-     * @param int $nInput
-     * @param int $amount
-     * @param TransactionSignatureSerializer|null $sigSerializer
-     * @param PublicKeySerializerInterface|null $pubKeySerializer
-     */
-    public function __construct(EcAdapterInterface $ecAdapter, TransactionInterface $transaction, int $nInput, int $amount, TransactionSignatureSerializer $sigSerializer = null, PublicKeySerializerInterface $pubKeySerializer = null)
-    {
-        $this->sigSerializer = $sigSerializer ?: new TransactionSignatureSerializer(EcSerializer::getSerializer(DerSignatureSerializerInterface::class, true, $ecAdapter));
-        $this->pubKeySerializer = $pubKeySerializer ?: EcSerializer::getSerializer(PublicKeySerializerInterface::class, true, $ecAdapter);
-        $this->adapter = $ecAdapter;
-        $this->transaction = $transaction;
-        $this->nInput = $nInput;
-        $this->amount = $amount;
-    }
-
-    /**
-     * @param BufferInterface $signature
-     * @return bool
-     */
-    public function isValidSignatureEncoding(BufferInterface $signature)
-    {
-        try {
-            TransactionSignature::isDERSignature($signature);
-            return true;
-        } catch (SignatureNotCanonical $e) {
-            /* In any case, we will return false outside this block */
-        }
-
-        return false;
-    }
-
-    /**
-     * @param BufferInterface $signature
-     * @return bool
-     * @throws ScriptRuntimeException
-     * @throws \Exception
-     */
-    public function isLowDerSignature(BufferInterface $signature): bool
-    {
-        if (!$this->isValidSignatureEncoding($signature)) {
-            throw new ScriptRuntimeException(Interpreter::VERIFY_DERSIG, 'Signature with incorrect encoding');
-        }
-
-        $binary = $signature->getBinary();
-        $nLenR = ord($binary[3]);
-        $nLenS = ord($binary[5 + $nLenR]);
-        $s = $signature->slice(6 + $nLenR, $nLenS)->getGmp();
-
-        return $this->adapter->validateSignatureElement($s, true);
-    }
-
-    /**
-     * @param int $hashType
-     * @return bool
-     */
-    public function isDefinedHashtype($hashType): bool
-    {
-        $nHashType = $hashType & (~($this->sigHashOptionalBits));
-
-        return !(($nHashType < SigHash::ALL) || ($nHashType > SigHash::SINGLE));
-    }
-
-    /**
-     * Determine whether the sighash byte appended to the signature encodes
-     * a valid sighash type.
-     *
-     * @param BufferInterface $signature
-     * @return bool
-     */
-    public function isDefinedHashtypeSignature(BufferInterface $signature): bool
-    {
-        if ($signature->getSize() === 0) {
-            return false;
-        }
-
-        $binary = $signature->getBinary();
-        return $this->isDefinedHashtype(ord(substr($binary, -1)));
-    }
-
-    /**
-     * @param BufferInterface $signature
-     * @param int $flags
-     * @return $this
-     * @throws \BitWasp\Bitcoin\Exceptions\ScriptRuntimeException
-     */
-    public function checkSignatureEncoding(BufferInterface $signature, int $flags)
-    {
-        if ($signature->getSize() === 0) {
-            return $this;
-        }
-
-        if (($flags & (Interpreter::VERIFY_DERSIG | Interpreter::VERIFY_LOW_S | Interpreter::VERIFY_STRICTENC)) !== 0 && !$this->isValidSignatureEncoding($signature)) {
-            throw new ScriptRuntimeException(Interpreter::VERIFY_DERSIG, 'Signature with incorrect encoding');
-        } else if (($flags & Interpreter::VERIFY_LOW_S) !== 0 && !$this->isLowDerSignature($signature)) {
-            throw new ScriptRuntimeException(Interpreter::VERIFY_LOW_S, 'Signature s element was not low');
-        } else if (($flags & Interpreter::VERIFY_STRICTENC) !== 0 && !$this->isDefinedHashtypeSignature($signature)) {
-            throw new ScriptRuntimeException(Interpreter::VERIFY_STRICTENC, 'Signature with invalid hashtype');
-        }
-
-        return $this;
-    }
-
-    /**
-     * @param BufferInterface $publicKey
-     * @param int $flags
-     * @return $this
-     * @throws \Exception
-     */
-    public function checkPublicKeyEncoding(BufferInterface $publicKey, int $flags)
-    {
-        if (($flags & Interpreter::VERIFY_STRICTENC) !== 0 && !PublicKey::isCompressedOrUncompressed($publicKey)) {
-            throw new ScriptRuntimeException(Interpreter::VERIFY_STRICTENC, 'Public key with incorrect encoding');
-        }
-
-        return $this;
-    }
 
     /**
      * @param ScriptInterface $script
@@ -203,18 +24,14 @@ class Checker
      * @param int $sigVersion
      * @return BufferInterface
      */
-    public function getSigHash(ScriptInterface $script, int $sigHashType, int $sigVersion)
+    public function getSigHash(ScriptInterface $script, int $sigHashType, int $sigVersion): BufferInterface
     {
         $cacheCheck = $sigVersion . $sigHashType . $script->getBuffer()->getBinary();
         if (!isset($this->sigHashCache[$cacheCheck])) {
             if (SigHash::V1 === $sigVersion) {
                 $hasher = new V1Hasher($this->transaction, $this->amount);
             } else {
-                if ($this->hasherV0) {
-                    $hasher = $this->hasherV0;
-                } else {
-                    $hasher = $this->hasherV0 = new Hasher($this->transaction);
-                }
+                $hasher = new Hasher($this->transaction);
             }
 
             $hash = $hasher->calculate($script, $this->nInput, $sigHashType);
@@ -224,97 +41,5 @@ class Checker
         }
 
         return $hash;
-    }
-
-    /**
-     * @param ScriptInterface $script
-     * @param BufferInterface $sigBuf
-     * @param BufferInterface $keyBuf
-     * @param int $sigVersion
-     * @param int $flags
-     * @return bool
-     * @throws ScriptRuntimeException
-     */
-    public function checkSig(ScriptInterface $script, BufferInterface $sigBuf, BufferInterface $keyBuf, int $sigVersion, int $flags)
-    {
-        $this
-            ->checkSignatureEncoding($sigBuf, $flags)
-            ->checkPublicKeyEncoding($keyBuf, $flags);
-
-        try {
-            $cacheCheck = $flags . $sigVersion . $keyBuf->getBinary() . $sigBuf->getBinary();
-            if (!isset($this->sigCache[$cacheCheck])) {
-                $txSignature = $this->sigSerializer->parse($sigBuf);
-                $publicKey = $this->pubKeySerializer->parse($keyBuf);
-
-                $hash = $this->getSigHash($script, $txSignature->getHashType(), $sigVersion);
-                $result = $this->sigCache[$cacheCheck] = $publicKey->verify($hash, $txSignature->getSignature());
-            } else {
-                $result = $this->sigCache[$cacheCheck];
-            }
-
-            return $result;
-        } catch (\Exception $e) {
-            return false;
-        }
-    }
-
-    /**
-     * @param \BitWasp\Bitcoin\Script\Interpreter\Number $scriptLockTime
-     * @return bool
-     */
-    public function checkLockTime(\BitWasp\Bitcoin\Script\Interpreter\Number $scriptLockTime): bool
-    {
-        $input = $this->transaction->getInput($this->nInput);
-        $nLockTime = $scriptLockTime->getInt();
-        $txLockTime = $this->transaction->getLockTime();
-
-        if (!(($txLockTime < Locktime::BLOCK_MAX && $nLockTime < Locktime::BLOCK_MAX) ||
-            ($txLockTime >= Locktime::BLOCK_MAX && $nLockTime >= Locktime::BLOCK_MAX))
-        ) {
-            return false;
-        }
-
-        if ($nLockTime > $txLockTime) {
-            return false;
-        }
-
-        if ($input->isFinal()) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
-     * @param \BitWasp\Bitcoin\Script\Interpreter\Number $sequence
-     * @return bool
-     */
-    public function checkSequence(\BitWasp\Bitcoin\Script\Interpreter\Number $sequence): bool
-    {
-        $txSequence = $this->transaction->getInput($this->nInput)->getSequence();
-        if ($this->transaction->getVersion() < 2) {
-            return false;
-        }
-
-        if (($txSequence & TransactionInputInterface::SEQUENCE_LOCKTIME_DISABLE_FLAG) !== 0) {
-            return false;
-        }
-
-        $mask = TransactionInputInterface::SEQUENCE_LOCKTIME_TYPE_FLAG | TransactionInputInterface::SEQUENCE_LOCKTIME_MASK;
-
-        $txToSequenceMasked = $txSequence & $mask;
-        $nSequenceMasked = $sequence->getInt() & $mask;
-        if (!(($txToSequenceMasked < TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG && $nSequenceMasked < TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG) ||
-            ($txToSequenceMasked >= TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG && $nSequenceMasked >= TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG))
-        ) {
-            return false;
-        }
-
-        if ($nSequenceMasked > $txToSequenceMasked) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/src/Script/Interpreter/CheckerBase.php
+++ b/src/Script/Interpreter/CheckerBase.php
@@ -1,0 +1,286 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitWasp\Bitcoin\Script\Interpreter;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PublicKey;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Signature\DerSignatureSerializerInterface;
+use BitWasp\Bitcoin\Exceptions\ScriptRuntimeException;
+use BitWasp\Bitcoin\Exceptions\SignatureNotCanonical;
+use BitWasp\Bitcoin\Locktime;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Serializer\Signature\TransactionSignatureSerializer;
+use BitWasp\Bitcoin\Signature\TransactionSignature;
+use BitWasp\Bitcoin\Transaction\SignatureHash\SigHash;
+use BitWasp\Bitcoin\Transaction\TransactionInput;
+use BitWasp\Bitcoin\Transaction\TransactionInputInterface;
+use BitWasp\Bitcoin\Transaction\TransactionInterface;
+use BitWasp\Buffertools\BufferInterface;
+
+abstract class CheckerBase
+{
+    /**
+     * @var EcAdapterInterface
+     */
+    protected $adapter;
+
+    /**
+     * @var TransactionInterface
+     */
+    protected $transaction;
+
+    /**
+     * @var int
+     */
+    protected $nInput;
+
+    /**
+     * @var int|string
+     */
+    protected $amount;
+
+    /**
+     * @var array
+     */
+    protected $sigCache = [];
+
+    /**
+     * @var TransactionSignatureSerializer
+     */
+    private $sigSerializer;
+
+    /**
+     * @var PublicKeySerializerInterface
+     */
+    private $pubKeySerializer;
+
+    /**
+     * @var int
+     */
+    protected $sigHashOptionalBits = SigHash::ANYONECANPAY;
+
+    /**
+     * Checker constructor.
+     * @param EcAdapterInterface $ecAdapter
+     * @param TransactionInterface $transaction
+     * @param int $nInput
+     * @param int $amount
+     * @param TransactionSignatureSerializer|null $sigSerializer
+     * @param PublicKeySerializerInterface|null $pubKeySerializer
+     */
+    public function __construct(EcAdapterInterface $ecAdapter, TransactionInterface $transaction, int $nInput, int $amount, TransactionSignatureSerializer $sigSerializer = null, PublicKeySerializerInterface $pubKeySerializer = null)
+    {
+        $this->sigSerializer = $sigSerializer ?: new TransactionSignatureSerializer(EcSerializer::getSerializer(DerSignatureSerializerInterface::class, true, $ecAdapter));
+        $this->pubKeySerializer = $pubKeySerializer ?: EcSerializer::getSerializer(PublicKeySerializerInterface::class, true, $ecAdapter);
+        $this->adapter = $ecAdapter;
+        $this->transaction = $transaction;
+        $this->nInput = $nInput;
+        $this->amount = $amount;
+    }
+
+    /**
+     * @param ScriptInterface $script
+     * @param int $hashType
+     * @param int $sigVersion
+     * @return BufferInterface
+     */
+    abstract public function getSigHash(ScriptInterface $script, int $hashType, int $sigVersion): BufferInterface;
+
+    /**
+     * @param BufferInterface $signature
+     * @return bool
+     */
+    public function isValidSignatureEncoding(BufferInterface $signature): bool
+    {
+        try {
+            TransactionSignature::isDERSignature($signature);
+            return true;
+        } catch (SignatureNotCanonical $e) {
+            /* In any case, we will return false outside this block */
+        }
+
+        return false;
+    }
+
+    /**
+     * @param BufferInterface $signature
+     * @return bool
+     * @throws ScriptRuntimeException
+     * @throws \Exception
+     */
+    public function isLowDerSignature(BufferInterface $signature): bool
+    {
+        if (!$this->isValidSignatureEncoding($signature)) {
+            throw new ScriptRuntimeException(Interpreter::VERIFY_DERSIG, 'Signature with incorrect encoding');
+        }
+
+        $binary = $signature->getBinary();
+        $nLenR = ord($binary[3]);
+        $nLenS = ord($binary[5 + $nLenR]);
+        $s = $signature->slice(6 + $nLenR, $nLenS)->getGmp();
+
+        return $this->adapter->validateSignatureElement($s, true);
+    }
+
+    /**
+     * @param int $hashType
+     * @return bool
+     */
+    public function isDefinedHashtype(int $hashType): bool
+    {
+        $nHashType = $hashType & (~($this->sigHashOptionalBits));
+
+        return !(($nHashType < SigHash::ALL) || ($nHashType > SigHash::SINGLE));
+    }
+
+    /**
+     * Determine whether the sighash byte appended to the signature encodes
+     * a valid sighash type.
+     *
+     * @param BufferInterface $signature
+     * @return bool
+     */
+    public function isDefinedHashtypeSignature(BufferInterface $signature): bool
+    {
+        if ($signature->getSize() === 0) {
+            return false;
+        }
+
+        $binary = $signature->getBinary();
+        return $this->isDefinedHashtype(ord(substr($binary, -1)));
+    }
+
+    /**
+     * @param BufferInterface $signature
+     * @param int $flags
+     * @return $this
+     * @throws \BitWasp\Bitcoin\Exceptions\ScriptRuntimeException
+     */
+    public function checkSignatureEncoding(BufferInterface $signature, int $flags)
+    {
+        if ($signature->getSize() === 0) {
+            return $this;
+        }
+
+        if (($flags & (Interpreter::VERIFY_DERSIG | Interpreter::VERIFY_LOW_S | Interpreter::VERIFY_STRICTENC)) !== 0 && !$this->isValidSignatureEncoding($signature)) {
+            throw new ScriptRuntimeException(Interpreter::VERIFY_DERSIG, 'Signature with incorrect encoding');
+        } else if (($flags & Interpreter::VERIFY_LOW_S) !== 0 && !$this->isLowDerSignature($signature)) {
+            throw new ScriptRuntimeException(Interpreter::VERIFY_LOW_S, 'Signature s element was not low');
+        } else if (($flags & Interpreter::VERIFY_STRICTENC) !== 0 && !$this->isDefinedHashtypeSignature($signature)) {
+            throw new ScriptRuntimeException(Interpreter::VERIFY_STRICTENC, 'Signature with invalid hashtype');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param BufferInterface $publicKey
+     * @param int $flags
+     * @return $this
+     * @throws \Exception
+     */
+    public function checkPublicKeyEncoding(BufferInterface $publicKey, int $flags)
+    {
+        if (($flags & Interpreter::VERIFY_STRICTENC) !== 0 && !PublicKey::isCompressedOrUncompressed($publicKey)) {
+            throw new ScriptRuntimeException(Interpreter::VERIFY_STRICTENC, 'Public key with incorrect encoding');
+        }
+
+        return $this;
+    }
+
+    /**
+     * @param ScriptInterface $script
+     * @param BufferInterface $sigBuf
+     * @param BufferInterface $keyBuf
+     * @param int $sigVersion
+     * @param int $flags
+     * @return bool
+     * @throws ScriptRuntimeException
+     */
+    public function checkSig(ScriptInterface $script, BufferInterface $sigBuf, BufferInterface $keyBuf, int $sigVersion, int $flags)
+    {
+        $this
+            ->checkSignatureEncoding($sigBuf, $flags)
+            ->checkPublicKeyEncoding($keyBuf, $flags);
+
+        try {
+            $cacheCheck = "{$script->getBinary()}{$sigVersion}{$keyBuf->getBinary()}{$sigBuf->getBinary()}";
+            if (!isset($this->sigCache[$cacheCheck])) {
+                $txSignature = $this->sigSerializer->parse($sigBuf);
+                $publicKey = $this->pubKeySerializer->parse($keyBuf);
+
+                $hash = $this->getSigHash($script, $txSignature->getHashType(), $sigVersion);
+                $result = $this->sigCache[$cacheCheck] = $publicKey->verify($hash, $txSignature->getSignature());
+            } else {
+                $result = $this->sigCache[$cacheCheck];
+            }
+
+            return $result;
+        } catch (\Exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * @param \BitWasp\Bitcoin\Script\Interpreter\Number $scriptLockTime
+     * @return bool
+     */
+    public function checkLockTime(\BitWasp\Bitcoin\Script\Interpreter\Number $scriptLockTime): bool
+    {
+        $input = $this->transaction->getInput($this->nInput);
+        $nLockTime = $scriptLockTime->getInt();
+        $txLockTime = $this->transaction->getLockTime();
+
+        if (!(($txLockTime < Locktime::BLOCK_MAX && $nLockTime < Locktime::BLOCK_MAX) ||
+            ($txLockTime >= Locktime::BLOCK_MAX && $nLockTime >= Locktime::BLOCK_MAX))
+        ) {
+            return false;
+        }
+
+        if ($nLockTime > $txLockTime) {
+            return false;
+        }
+
+        if ($input->isFinal()) {
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * @param \BitWasp\Bitcoin\Script\Interpreter\Number $sequence
+     * @return bool
+     */
+    public function checkSequence(\BitWasp\Bitcoin\Script\Interpreter\Number $sequence): bool
+    {
+        $txSequence = $this->transaction->getInput($this->nInput)->getSequence();
+        if ($this->transaction->getVersion() < 2) {
+            return false;
+        }
+
+        if (($txSequence & TransactionInputInterface::SEQUENCE_LOCKTIME_DISABLE_FLAG) !== 0) {
+            return false;
+        }
+
+        $mask = TransactionInputInterface::SEQUENCE_LOCKTIME_TYPE_FLAG | TransactionInputInterface::SEQUENCE_LOCKTIME_MASK;
+
+        $txToSequenceMasked = $txSequence & $mask;
+        $nSequenceMasked = $sequence->getInt() & $mask;
+        if (!(($txToSequenceMasked < TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG && $nSequenceMasked < TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG) ||
+            ($txToSequenceMasked >= TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG && $nSequenceMasked >= TransactionInput::SEQUENCE_LOCKTIME_TYPE_FLAG))
+        ) {
+            return false;
+        }
+
+        if ($nSequenceMasked > $txToSequenceMasked) {
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/src/Transaction/Factory/Checker/BitcoinCashCheckerCreator.php
+++ b/src/Transaction/Factory/Checker/BitcoinCashCheckerCreator.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitWasp\Bitcoin\Transaction\Factory\Checker;
+
+use BitWasp\Bitcoin\Script\Interpreter\CheckerBase;
+use BitWasp\Bitcoin\Script\Interpreter\BitcoinCashChecker;
+use BitWasp\Bitcoin\Script\Interpreter\Checker;
+use BitWasp\Bitcoin\Transaction\TransactionInterface;
+use BitWasp\Bitcoin\Transaction\TransactionOutputInterface;
+
+class BitcoinCashCheckerCreator extends CheckerCreator
+{
+    /**
+     * @param TransactionInterface $tx
+     * @param int $nInput
+     * @param TransactionOutputInterface $txOut
+     * @return Checker
+     */
+    public function create(TransactionInterface $tx, int $nInput, TransactionOutputInterface $txOut): CheckerBase
+    {
+        return new BitcoinCashChecker($this->ecAdapter, $tx, $nInput, $txOut->getValue(), $this->txSigSerializer, $this->pubKeySerializer);
+    }
+}

--- a/src/Transaction/Factory/Checker/CheckerCreator.php
+++ b/src/Transaction/Factory/Checker/CheckerCreator.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitWasp\Bitcoin\Transaction\Factory\Checker;
+
+use BitWasp\Bitcoin\Script\Interpreter\CheckerBase;
+use BitWasp\Bitcoin\Script\Interpreter\Checker;
+use BitWasp\Bitcoin\Transaction\TransactionInterface;
+use BitWasp\Bitcoin\Transaction\TransactionOutputInterface;
+
+class CheckerCreator extends CheckerCreatorBase
+{
+    /**
+     * @param TransactionInterface $tx
+     * @param int $nInput
+     * @param TransactionOutputInterface $txOut
+     * @return CheckerBase
+     */
+    public function create(TransactionInterface $tx, int $nInput, TransactionOutputInterface $txOut): CheckerBase
+    {
+        return new Checker($this->ecAdapter, $tx, $nInput, $txOut->getValue(), $this->txSigSerializer, $this->pubKeySerializer);
+    }
+}

--- a/src/Transaction/Factory/Checker/CheckerCreatorBase.php
+++ b/src/Transaction/Factory/Checker/CheckerCreatorBase.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitWasp\Bitcoin\Transaction\Factory\Checker;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
+use BitWasp\Bitcoin\Script\Interpreter\CheckerBase;
+use BitWasp\Bitcoin\Serializer\Signature\TransactionSignatureSerializer;
+use BitWasp\Bitcoin\Transaction\TransactionInterface;
+use BitWasp\Bitcoin\Transaction\TransactionOutputInterface;
+
+abstract class CheckerCreatorBase
+{
+    /**
+     * @var EcAdapterInterface
+     */
+    protected $ecAdapter;
+
+    /**
+     * @var TransactionSignatureSerializer
+     */
+    protected $txSigSerializer;
+
+    /**
+     * @var PublicKeySerializerInterface
+     */
+    protected $pubKeySerializer;
+
+    /**
+     * CheckerCreator constructor.
+     * @param EcAdapterInterface $ecAdapter
+     * @param TransactionSignatureSerializer $txSigSerializer
+     * @param PublicKeySerializerInterface $pubKeySerializer
+     */
+    public function __construct(
+        EcAdapterInterface $ecAdapter,
+        TransactionSignatureSerializer $txSigSerializer,
+        PublicKeySerializerInterface $pubKeySerializer
+    ) {
+        $this->ecAdapter = $ecAdapter;
+        $this->txSigSerializer = $txSigSerializer;
+        $this->pubKeySerializer = $pubKeySerializer;
+    }
+
+    /**
+     * @param TransactionInterface $tx
+     * @param int $nInput
+     * @param TransactionOutputInterface $txOut
+     * @return CheckerBase
+     */
+    abstract public function create(TransactionInterface $tx, int $nInput, TransactionOutputInterface $txOut): CheckerBase;
+}

--- a/src/Transaction/SignatureHash/Hasher.php
+++ b/src/Transaction/SignatureHash/Hasher.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace BitWasp\Bitcoin\Transaction\SignatureHash;
 
-use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Script\ScriptInterface;
 use BitWasp\Buffertools\Buffer;

--- a/tests/Data/signer_fixtures.json
+++ b/tests/Data/signer_fixtures.json
@@ -1458,7 +1458,7 @@
     {
       "description": "P2PKH: detects a bad signature",
       "exception": {
-        "type": "\\RuntimeException",
+        "type": "\\BitWasp\\Bitcoin\\Exceptions\\SignerException",
         "message": "Existing signatures are invalid!"
       },
       "txOut": {
@@ -1476,7 +1476,7 @@
     {
       "description": "P2PK: detects a bad signature",
       "exception": {
-        "type": "\\RuntimeException",
+        "type": "\\BitWasp\\Bitcoin\\Exceptions\\SignerException",
         "message": "Existing signatures are invalid!"
       },
       "txOut": {
@@ -1494,7 +1494,7 @@
     {
       "description": "Multisig: detects a bad signature",
       "exception": {
-        "type": "\\RuntimeException",
+        "type": "\\BitWasp\\Bitcoin\\Exceptions\\SignerException",
         "message": "Existing signatures are invalid!"
       },
       "txOut": {

--- a/tests/Transaction/Factory/InputSignerTest.php
+++ b/tests/Transaction/Factory/InputSignerTest.php
@@ -6,6 +6,7 @@ namespace BitWasp\Bitcoin\Tests\Transaction\Factory;
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Script\Interpreter\Checker;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptWitness;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
@@ -86,8 +87,9 @@ class InputSignerTest extends AbstractTestCase
      */
     public function testInvalidSolveSignData($description, EcAdapterInterface $ecAdapter, TransactionInterface $tx, TransactionOutput $txOut, SignData $signData, $exception, $exceptionMsg)
     {
+        $checker = new Checker($ecAdapter, $tx, 0, $txOut->getValue());
         try {
-            (new InputSigner($ecAdapter, $tx, 0, $txOut, $signData))
+            (new InputSigner($ecAdapter, $tx, 0, $txOut, $signData, $checker))
                 ->extract();
         } catch (\Exception $caught) {
             $this->assertInstanceOf($exception, $caught);


### PR DESCRIPTION
Creates an abstract class to serve as a base type for Checker. Also adds a base type for CheckerCreator, which can be set on a Signer before any inputs have been accessed. A custom CheckerCreator can create the right Checker instance, meaning we can take the logic for handling bitcoin cash out of this library to be maintained elsewhere.