### PR TITLE
Bip39Mnemonic code style

### DIFF
--- a/src/Mnemonic/Bip39/Bip39Mnemonic.php
+++ b/src/Mnemonic/Bip39/Bip39Mnemonic.php
@@ -68,7 +68,7 @@ class Bip39Mnemonic implements MnemonicInterface
 
     /**
      * @param BufferInterface $entropy
-     * @return string[]
+     * @return string[] - array of words from the word list
      */
     public function entropyToWords(BufferInterface $entropy): array
     {
@@ -113,6 +113,7 @@ class Bip39Mnemonic implements MnemonicInterface
     {
         $words = explode(' ', $mnemonic);
 
+        // Mnemonic sizes are multiples of 3 words
         if (count($words) % 3 !== 0) {
             throw new \InvalidArgumentException('Invalid mnemonic');
         }
@@ -130,11 +131,12 @@ class Bip39Mnemonic implements MnemonicInterface
             throw new \InvalidArgumentException('Invalid mnemonic, too long');
         }
 
+        // Every 32 bits of ENT adds a 1 CS bit.
         $CS = strlen($bits) / 33;
         $ENT = strlen($bits) - $CS;
 
-        $csBits = substr($bits, -1 * $CS);
-        $entBits = substr($bits, 0, -1 * $CS);
+        // Checksum bits
+        $csBits = substr($bits, $ENT, $CS);
 
         // Split $ENT bits into 8 bit words to be packed
         assert($ENT % 8 === 0);

--- a/src/Mnemonic/Bip39/Bip39SeedGenerator.php
+++ b/src/Mnemonic/Bip39/Bip39SeedGenerator.php
@@ -39,7 +39,7 @@ class Bip39SeedGenerator
         return Hash::pbkdf2(
             'sha512',
             $this->normalize($mnemonic),
-            $this->normalize("mnemonic" . $passphrase),
+            $this->normalize("mnemonic{$passphrase}"),
             2048,
             64
         );

--- a/src/Mnemonic/Bip39/Wordlist/EnglishWordList.php
+++ b/src/Mnemonic/Bip39/Wordlist/EnglishWordList.php
@@ -41,7 +41,7 @@ class EnglishWordList extends WordList implements Bip39WordListInterface
             $this->wordsFlipped = array_flip($this->getWords());
         }
 
-        if (!isset($this->wordsFlipped[$word])) {
+        if (!array_key_exists($word, $this->wordsFlipped)) {
             throw new \InvalidArgumentException(__CLASS__ . ' does not contain word ' . $word);
         }
 


### PR DESCRIPTION
Some minor code style adjustments for Bip39Mnemonic.

Avoids use of GMP for base conversions, and avoids excessive `substr()` calls in mnemonicToEntropy by using `str_split`