### PR TITLE
HierarchicalKey - make class immutable

### DIFF
--- a/examples/trezor.bip32.php
+++ b/examples/trezor.bip32.php
@@ -43,10 +43,12 @@ echo "M/{$purpose}'/0'/0': ".$purposePriv->toExtendedPublicKey().PHP_EOL;
 echo "Derive (M -> m/{$purpose}'/0'/0'): .... should fail\n";
 
 try {
-    $rootPub = $root->toPublic()->derivePath("{$purpose}'/0'/0'");
+    $rootPub = $root->withoutPrivateKey();
+    $rootPub->derivePath("{$purpose}'/0'/0'");
 } catch (\Exception $e) {
     echo "caught exception, yes this is impossible: " . $e->getMessage().PHP_EOL;
 }
+
 $purposePub = $purposePriv->toExtendedPublicKey();
 
 echo "\n\n -------------- \n\n";

--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -140,7 +140,7 @@ class HierarchicalKey
      *
      * @return BufferInterface
      */
-    public function getChainCode()
+    public function getChainCode(): BufferInterface
     {
         return $this->chainCode;
     }
@@ -148,7 +148,7 @@ class HierarchicalKey
     /**
      * @return PrivateKeyInterface
      */
-    public function getPrivateKey()
+    public function getPrivateKey(): PrivateKeyInterface
     {
         if ($this->key->isPrivate()) {
             return $this->key;
@@ -162,7 +162,7 @@ class HierarchicalKey
      *
      * @return PublicKeyInterface
      */
-    public function getPublicKey()
+    public function getPublicKey(): PublicKeyInterface
     {
         if ($this->isPrivate()) {
             return $this->getPrivateKey()->getPublicKey();
@@ -186,7 +186,7 @@ class HierarchicalKey
      *
      * @return bool
      */
-    public function isPrivate()
+    public function isPrivate(): bool
     {
         return $this->key->isPrivate();
     }
@@ -196,7 +196,7 @@ class HierarchicalKey
      *
      * @return bool
      */
-    public function isHardened()
+    public function isHardened(): bool
     {
         return ($this->sequence >> 31) === 1;
     }
@@ -208,7 +208,7 @@ class HierarchicalKey
      * @return BufferInterface
      * @throws \Exception
      */
-    public function getHmacSeed(int $sequence)
+    public function getHmacSeed(int $sequence): BufferInterface
     {
         if ($sequence < 0 || $sequence > IntRange::U32_MAX) {
             throw new \InvalidArgumentException("Sequence is outside valid range, must be >= 0 && <= (2^31)-1");
@@ -234,7 +234,7 @@ class HierarchicalKey
      * @return HierarchicalKey
      * @throws \Exception
      */
-    public function deriveChild(int $sequence)
+    public function deriveChild(int $sequence): HierarchicalKey
     {
         $nextDepth = $this->depth + 1;
         if ($nextDepth > 255) {
@@ -266,7 +266,7 @@ class HierarchicalKey
      * @param array|\stdClass|\Traversable $list
      * @return HierarchicalKey
      */
-    public function deriveFromList($list)
+    public function deriveFromList($list): HierarchicalKey
     {
         if (!is_array($list) && !$list instanceof \Traversable && !$list instanceof \stdClass) {
             throw new \InvalidArgumentException('List must be an array or \Traversable');
@@ -287,7 +287,7 @@ class HierarchicalKey
      * @return HierarchicalKey
      * @throws \Exception
      */
-    public function derivePath($path)
+    public function derivePath(string $path): HierarchicalKey
     {
         $sequences = new HierarchicalKeySequence();
         return $this->deriveFromList($sequences->decodePath($path));
@@ -298,7 +298,7 @@ class HierarchicalKey
      * @param NetworkInterface $network
      * @return string
      */
-    public function toExtendedKey(NetworkInterface $network = null)
+    public function toExtendedKey(NetworkInterface $network = null): string
     {
         $network = $network ?: Bitcoin::getNetwork();
 
@@ -314,7 +314,7 @@ class HierarchicalKey
      * @param NetworkInterface $network
      * @return string
      */
-    public function toExtendedPrivateKey(NetworkInterface $network = null)
+    public function toExtendedPrivateKey(NetworkInterface $network = null): string
     {
         if (!$this->isPrivate()) {
             throw new \LogicException('Cannot create extended private key from public');

--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -16,8 +16,6 @@ use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
 use BitWasp\Bitcoin\Util\IntRange;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
-use BitWasp\Buffertools\Buffertools;
-use BitWasp\Buffertools\Parser;
 
 class HierarchicalKey
 {
@@ -176,13 +174,11 @@ class HierarchicalKey
     /**
      * @return HierarchicalKey
      */
-    public function toPublic()
+    public function withoutPrivateKey(): HierarchicalKey
     {
-        if ($this->isPrivate()) {
-            $this->key = $this->getPrivateKey()->getPublicKey();
-        }
-
-        return $this;
+        $clone = clone $this;
+        $clone->key = $clone->getPublicKey();
+        return $clone;
     }
 
     /**
@@ -333,9 +329,11 @@ class HierarchicalKey
      * @param NetworkInterface $network
      * @return string
      */
-    public function toExtendedPublicKey(NetworkInterface $network = null)
+    public function toExtendedPublicKey(NetworkInterface $network = null): string
     {
-        $clone = clone($this);
-        return $clone->toPublic()->toExtendedKey($network);
+        return $this
+            ->withoutPrivateKey()
+            ->toExtendedKey($network)
+        ;
     }
 }

--- a/src/Key/Deterministic/MultisigHD.php
+++ b/src/Key/Deterministic/MultisigHD.php
@@ -8,6 +8,7 @@ use BitWasp\Bitcoin\Address\ScriptHashAddress;
 use BitWasp\Bitcoin\Script\P2shScript;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Buffertools\BufferInterface;
 use BitWasp\Buffertools\Buffertools;
 
 class MultisigHD
@@ -80,9 +81,9 @@ class MultisigHD
      * @param HierarchicalKey[] $keys
      * @return HierarchicalKey[]
      */
-    private function sortHierarchicalKeys(array $keys)
+    private function sortHierarchicalKeys(array $keys): array
     {
-        return Buffertools::sort($keys, function (HierarchicalKey $key) {
+        return Buffertools::sort($keys, function (HierarchicalKey $key): BufferInterface {
             return $key->getPublicKey()->getBuffer();
         });
     }
@@ -127,7 +128,7 @@ class MultisigHD
     /**
      * @return ScriptHashAddress
      */
-    public function getAddress()
+    public function getAddress(): ScriptHashAddress
     {
         return $this->redeemScript->getAddress();
     }


### PR DESCRIPTION
Replace `HierarchicalKey::toPublic()`, which mutates the object, with the function `HierarchicalKey;:withoutPrivateKey()` which returns a distinct object without the public key.