### PR TITLE
OutputScriptFactory: remove payToAddress

### DIFF
--- a/src/PaymentProtocol/RequestBuilder.php
+++ b/src/PaymentProtocol/RequestBuilder.php
@@ -8,7 +8,6 @@ use BitWasp\Bitcoin\Address\AddressInterface;
 use BitWasp\Bitcoin\PaymentProtocol\Protobufs\Output;
 use BitWasp\Bitcoin\PaymentProtocol\Protobufs\PaymentDetails;
 use BitWasp\Bitcoin\PaymentProtocol\Protobufs\PaymentRequest;
-use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
 use BitWasp\Bitcoin\Transaction\TransactionOutputInterface;
 
@@ -112,7 +111,7 @@ class RequestBuilder
      */
     public function addAddressPayment(AddressInterface $address, int $value)
     {
-        $script = ScriptFactory::scriptPubKey()->payToAddress($address);
+        $script = $address->getScriptPubKey();
         $output = new TransactionOutput($value, $script);
         return $this->addOutput($output);
     }

--- a/src/Script/Factory/OutputScriptFactory.php
+++ b/src/Script/Factory/OutputScriptFactory.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace BitWasp\Bitcoin\Script\Factory;
 
-use BitWasp\Bitcoin\Address\AddressInterface;
-use BitWasp\Bitcoin\Address\ScriptHashAddress;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PublicKey;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
 use BitWasp\Bitcoin\Script\Opcodes;
@@ -17,17 +15,6 @@ use BitWasp\Buffertools\Buffertools;
 
 class OutputScriptFactory
 {
-    /**
-     * @param AddressInterface $address
-     * @return ScriptInterface
-     */
-    public function payToAddress(AddressInterface $address): ScriptInterface
-    {
-        return $address instanceof ScriptHashAddress
-            ? ScriptFactory::sequence([Opcodes::OP_HASH160, $address->getHash(), Opcodes::OP_EQUAL])
-            : ScriptFactory::sequence([Opcodes::OP_DUP, Opcodes::OP_HASH160, $address->getHash(), Opcodes::OP_EQUALVERIFY, Opcodes::OP_CHECKSIG]);
-    }
-
     /**
      * @param PublicKeyInterface $publicKey
      * @return ScriptInterface
@@ -120,9 +107,9 @@ class OutputScriptFactory
      * @param bool|true $sort
      * @return ScriptInterface
      */
-    public function multisig(int $m, array $keys = [], $sort = true): ScriptInterface
+    public function multisig(int $m, array $keys = [], bool $sort = true): ScriptInterface
     {
-        return self::multisigKeyBuffers($m, array_map(function (PublicKeyInterface $key) {
+        return self::multisigKeyBuffers($m, array_map(function (PublicKeyInterface $key): BufferInterface {
             return $key->getBuffer();
         }, $keys), $sort);
     }
@@ -130,10 +117,10 @@ class OutputScriptFactory
     /**
      * @param int $m
      * @param BufferInterface[] $keys
-     * @param bool|true $sort
+     * @param bool $sort
      * @return ScriptInterface
      */
-    public function multisigKeyBuffers(int $m, array $keys = [], $sort = true): ScriptInterface
+    public function multisigKeyBuffers(int $m, array $keys = [], bool $sort = true): ScriptInterface
     {
         $n = count($keys);
         if ($m < 0) {
@@ -155,7 +142,7 @@ class OutputScriptFactory
         $new = ScriptFactory::create();
         $new->int($m);
         foreach ($keys as $key) {
-            if ($key->getSize() != PublicKey::LENGTH_COMPRESSED && $key->getSize() != PublicKey::LENGTH_UNCOMPRESSED) {
+            if ($key->getSize() !== PublicKey::LENGTH_COMPRESSED && $key->getSize() !== PublicKey::LENGTH_UNCOMPRESSED) {
                 throw new \RuntimeException("Invalid length for public key buffer");
             }
 

--- a/src/Transaction/Factory/TxBuilder.php
+++ b/src/Transaction/Factory/TxBuilder.php
@@ -265,7 +265,7 @@ class TxBuilder
         // Create Script from address, then create an output.
         $this->output(
             $value,
-            ScriptFactory::scriptPubKey()->payToAddress($address)
+            $address->getScriptPubKey()
         );
 
         return $this;

--- a/tests/PaymentProtocol/RequestBuilderTest.php
+++ b/tests/PaymentProtocol/RequestBuilderTest.php
@@ -58,7 +58,7 @@ class RequestBuilderTest extends Bip70Test
         $builder->setTime(1);
         $pubkey = PublicKeyFactory::fromHex('0496b538e853519c726a2c91e61ec11600ae1390813a627c66fb8be7947be63c52da7589379515d4e0a604f8141781e62294721166bf621e73a82cbf2342c858ee');
         $address = new PayToPubKeyHashAddress($pubkey->getPubKeyHash());
-        $script = ScriptFactory::scriptPubKey()->payToAddress($address);
+        $script = $address->getScriptPubKey();
 
         $builder->addAddressPayment($address, 50);
 

--- a/tests/Script/Factory/OutputScriptFactoryTest.php
+++ b/tests/Script/Factory/OutputScriptFactoryTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace BitWasp\Bitcoin\Tests\Script\Factory;
 
-use BitWasp\Bitcoin\Address\PayToPubKeyHashAddress;
-use BitWasp\Bitcoin\Address\ScriptHashAddress;
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Adapter\EcAdapter;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Key\PublicKey;
@@ -22,31 +20,6 @@ use Mdanter\Ecc\Primitives\Point;
 
 class OutputScriptFactoryTest extends AbstractTestCase
 {
-    public function testPayToAddress()
-    {
-        $publicKey = PublicKeyFactory::fromHex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb');
-        $p2pkh = new PayToPubKeyHashAddress($publicKey->getPubKeyHash());
-        $p2pkhScript = ScriptFactory::scriptPubKey()->payToAddress($p2pkh);
-        $parsedScript = $p2pkhScript->getScriptParser()->decode();
-
-        $classifier = new OutputClassifier();
-        $this->assertEquals(Opcodes::OP_DUP, $parsedScript[0]->getOp());
-        $this->assertEquals(Opcodes::OP_HASH160, $parsedScript[1]->getOp());
-        $this->assertTrue($p2pkh->getHash()->equals($parsedScript[2]->getData()));
-        $this->assertEquals(Opcodes::OP_EQUALVERIFY, $parsedScript[3]->getOp());
-        $this->assertEquals(Opcodes::OP_CHECKSIG, $parsedScript[4]->getOp());
-        $this->assertEquals(ScriptType::P2PKH, $classifier->classify($p2pkhScript));
-
-        $multisig = ScriptFactory::scriptPubKey()->multisig(1, [$publicKey]);
-        $p2sh = new ScriptHashAddress($multisig->getScriptHash());
-        $p2shScript = ScriptFactory::scriptPubKey()->payToAddress($p2sh);
-        $parsedScript = $p2shScript->getScriptParser()->decode();
-        $this->assertEquals(Opcodes::OP_HASH160, $parsedScript[0]->getOp());
-        $this->assertTrue($p2sh->getHash()->equals($parsedScript[1]->getData()));
-        $this->assertEquals(Opcodes::OP_EQUAL, $parsedScript[2]->getOp());
-        $this->assertEquals(ScriptType::P2SH, $classifier->classify($p2shScript));
-    }
-
     public function testPayToPubKey()
     {
         $x = gmp_init('61365198687444549113797742543489768233362236615628880309411002867851217134145', 10);

--- a/tests/Transaction/Factory/TxBuilderTest.php
+++ b/tests/Transaction/Factory/TxBuilderTest.php
@@ -94,7 +94,8 @@ class TxBuilderTest extends AbstractTestCase
         $tx = $builder->get();
 
         $output = $tx->getOutput(0);
-        $this->assertEquals(ScriptFactory::scriptPubKey()->payToAddress($address)->getBinary(), $output->getScript()->getBinary());
+        $script = $address->getScriptPubKey();
+        $this->assertEquals($script->getBinary(), $output->getScript()->getBinary());
         $this->assertEquals($value, $output->getValue());
     }
 
@@ -149,7 +150,7 @@ class TxBuilderTest extends AbstractTestCase
      */
     public function testPayToAddress2(AddressInterface $address)
     {
-        $expectedScript = ScriptFactory::scriptPubKey()->payToAddress($address);
+        $expectedScript = $address->getScriptPubKey();
 
         $builder = new TxBuilder();
         $builder->payToAddress(50, $address);


### PR DESCRIPTION
Need to remove this one before it causes any problems, Address objects by contract can create their own scriptPubkeys, but it can be easy to forget to update the likes of OutputScriptFactory::payToAddress, it was never updated when we added a new address type..