### PR TITLE
Script remove serializable support

### DIFF
--- a/examples/script.simple.php
+++ b/examples/script.simple.php
@@ -5,12 +5,13 @@ require_once __DIR__ . "/../vendor/autoload.php";
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Script\Interpreter\Checker;
 use BitWasp\Bitcoin\Script\Interpreter\Interpreter;
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Transaction\Transaction;
 
 $ecAdapter = Bitcoin::getEcAdapter();
 $scriptSig = ScriptFactory::create()->int(1)->int(1)->getScript();
-$scriptPubKey = ScriptFactory::create()->op('OP_ADD')->int(2)->op('OP_EQUAL')->getScript();
+$scriptPubKey = ScriptFactory::create()->opcode(Opcodes::OP_ADD)->int(2)->opcode(Opcodes::OP_EQUAL)->getScript();
 echo "Formed script: " . $scriptSig->getHex() . " " . $scriptPubKey->getHex() . "\n";
 
 $flags = 0;

--- a/src/Script/Factory/OutputScriptFactory.php
+++ b/src/Script/Factory/OutputScriptFactory.php
@@ -122,7 +122,7 @@ class OutputScriptFactory
      */
     public function multisig(int $m, array $keys = [], $sort = true): ScriptInterface
     {
-        return self::multisigKeyBuffers($m, array_map(function (PublicKeyInterface $key) {
+        return self::multisigKeyBuffers($m, array_map(function (PublicKeyInterface $key): BufferInterface {
             return $key->getBuffer();
         }, $keys), $sort);
     }
@@ -162,7 +162,7 @@ class OutputScriptFactory
             $new->push($key);
         }
 
-        return $new->int($n)->op('OP_CHECKMULTISIG')->getScript();
+        return $new->int($n)->opcode(Opcodes::OP_CHECKMULTISIG)->getScript();
     }
 
     /**

--- a/src/Script/Factory/ScriptCreator.php
+++ b/src/Script/Factory/ScriptCreator.php
@@ -9,7 +9,6 @@ use BitWasp\Bitcoin\Script\Interpreter\Number;
 use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptInterface;
-use BitWasp\Bitcoin\Serializable;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
 
@@ -133,16 +132,6 @@ class ScriptCreator
             $this->push(Number::int($n)->getBuffer());
         }
 
-        return $this;
-    }
-
-    /**
-     * @param Serializable $object
-     * @return $this
-     */
-    public function pushSerializable(Serializable $object)
-    {
-        $this->push($object->getBuffer());
         return $this;
     }
 

--- a/src/Script/Interpreter/Number.php
+++ b/src/Script/Interpreter/Number.php
@@ -147,12 +147,7 @@ class Number extends Serializable
             $result[count($result) - 1] |= 0x80;
         }
 
-        $s = '';
-        foreach ($result as $i) {
-            $s .= chr($i);
-        }
-
-        return new Buffer($s);
+        return new Buffer(pack("C*", ...$result));
     }
 
     /**

--- a/src/Script/Opcodes.php
+++ b/src/Script/Opcodes.php
@@ -86,8 +86,8 @@ class Opcodes implements \ArrayAccess
     const OP_MUL = 149;
     const OP_DIV = 150;
     const OP_MOD = 151;
-    const OP_LSHIFT = 152;
-    const OP_RSHIFT = 153;
+    const OP_LSHIFT = 152; /* Disabled */
+    const OP_RSHIFT = 153; /* Disabled */
     const OP_BOOLAND = 154;
     const OP_BOOLOR = 155;
     const OP_NUMEQUAL = 156;
@@ -220,8 +220,8 @@ class Opcodes implements \ArrayAccess
         self::OP_MUL => 'OP_MUL',
         self::OP_DIV => 'OP_DIV',
         self::OP_MOD => 'OP_MOD',
-        self::OP_LSHIFT => 'OP_LSHIFT',
-        self::OP_RSHIFT => 'OP_RSHIFT',
+        self::OP_LSHIFT => 'OP_LSHIFT', /* Disabled */
+        self::OP_RSHIFT => 'OP_RSHIFT', /* Disabled */
         self::OP_BOOLAND => 'OP_BOOLAND',
         self::OP_BOOLOR => 'OP_BOOLOR',
         self::OP_NUMEQUAL => 'OP_NUMEQUAL',

--- a/src/Script/ScriptInfo/Multisig.php
+++ b/src/Script/ScriptInfo/Multisig.php
@@ -128,8 +128,7 @@ class Multisig
      * @param bool $allowVerify
      * @return Multisig
      */
-    public static function fromScript(ScriptInterface $script, PublicKeySerializerInterface $pubKeySerializer = null, bool
-    $allowVerify = false)
+    public static function fromScript(ScriptInterface $script, PublicKeySerializerInterface $pubKeySerializer = null, bool $allowVerify = false)
     {
         return static::fromDecodedScript($script->getScriptParser()->decode(), $pubKeySerializer, $allowVerify);
     }

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -15,6 +15,7 @@ use BitWasp\Bitcoin\Exceptions\UnrecognizedAddressException;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkFactory;
 use BitWasp\Bitcoin\Network\NetworkInterface;
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\WitnessProgram;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
@@ -180,7 +181,7 @@ class AddressTest extends AbstractTestCase
      */
     public function testFromOutputScript()
     {
-        $unknownScript = ScriptFactory::create()->op('OP_0')->op('OP_1')->getScript();
+        $unknownScript = ScriptFactory::create()->opcode(Opcodes::OP_0, Opcodes::OP_1)->getScript();
         $addressCreator = new AddressCreator();
         $addressCreator->fromOutputScript($unknownScript);
     }

--- a/tests/Script/Factory/OutputScriptFactoryTest.php
+++ b/tests/Script/Factory/OutputScriptFactoryTest.php
@@ -106,14 +106,13 @@ class OutputScriptFactoryTest extends AbstractTestCase
 
     public function testClassifyMultisig()
     {
-        $script = ScriptFactory::create()
-            ->op('OP_2')
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->op('OP_3')
-            ->op('OP_CHECKMULTISIG')
-            ->getScript();
+        $keyBufs = [
+            Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+            Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+            Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+        ];
+
+        $script = ScriptFactory::scriptPubKey()->multisigKeyBuffers(2, $keyBufs);
 
         $classifier = new OutputClassifier();
         $this->assertEquals(ScriptType::MULTISIG, $classifier->classify($script));
@@ -122,14 +121,13 @@ class OutputScriptFactoryTest extends AbstractTestCase
     public function testPayToScriptHash()
     {
         // Script::payToScriptHash should produce a ScriptHash type script, from a different script
-        $script = ScriptFactory::create()
-            ->op('OP_2')
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->op('OP_3')
-            ->op('OP_CHECKMULTISIG')
-            ->getScript();
+        $keyBufs = [
+            Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+            Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+            Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+        ];
+
+        $script = ScriptFactory::scriptPubKey()->multisigKeyBuffers(2, $keyBufs);
 
         $scriptHash = ScriptFactory::scriptPubKey()->payToScriptHash(Hash::sha256ripe160($script->getBuffer()));
         $parsed = $scriptHash->getScriptParser()->decode();
@@ -147,7 +145,7 @@ class OutputScriptFactoryTest extends AbstractTestCase
         $hash = Hash::sha256d(new Buffer($witnessMerkleRoot->getBinary() . $reservedVal->getBinary()));
 
         $expected = ScriptFactory::create()
-            ->op('OP_RETURN')
+            ->opcode(Opcodes::OP_RETURN)
             ->push(new Buffer("\xaa\x21\xa9\xed" . $hash->getBinary()))
             ->getScript();
 

--- a/tests/Script/Interpreter/InterpreterTest.php
+++ b/tests/Script/Interpreter/InterpreterTest.php
@@ -10,6 +10,7 @@ use BitWasp\Bitcoin\Script\Interpreter\Checker;
 use BitWasp\Bitcoin\Script\Interpreter\Interpreter;
 use BitWasp\Bitcoin\Script\Interpreter\InterpreterInterface;
 use BitWasp\Bitcoin\Script\Interpreter\Stack;
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Script\ScriptInterface;
@@ -59,7 +60,7 @@ class InterpreterTest extends AbstractTestCase
         $ec = Bitcoin::getEcAdapter();
         $f = 0;
         $i = new Interpreter($ec);
-        $script = ScriptFactory::create()->op('OP_RETURN')->getScript();
+        $script = ScriptFactory::create()->opcode(Opcodes::OP_RETURN)->getScript();
 
         $this->assertFalse($i->verify($script, new Script, $f, new Checker($ec, new Transaction(), 0, 0)));
     }
@@ -69,9 +70,9 @@ class InterpreterTest extends AbstractTestCase
         $f = 0;
         $ec = Bitcoin::getEcAdapter();
 
-        $i = new Interpreter($ec, new Transaction);
+        $i = new Interpreter($ec);
         $true = new Script(Buffer::hex('0101'));
-        $false = ScriptFactory::create()->op('OP_RETURN')->getScript();
+        $false = ScriptFactory::create()->opcode(Opcodes::OP_RETURN)->getScript();
         $this->assertFalse($i->verify($true, $false, $f, new Checker($ec, new Transaction(), 0, 0)));
     }
 
@@ -113,9 +114,9 @@ class InterpreterTest extends AbstractTestCase
     public function testInvalidPayToScriptHash()
     {
         $ec = Bitcoin::getEcAdapter();
-        $p2sh = ScriptFactory::create()->op('OP_RETURN')->getScript();
+        $p2sh = ScriptFactory::create()->opcode(Opcodes::OP_RETURN)->getScript();
         $scriptPubKey = ScriptFactory::scriptPubKey()->payToScriptHash(Hash::sha256ripe160($p2sh->getBuffer()));
-        $scriptSig = ScriptFactory::create()->op('OP_0')->push($p2sh->getBuffer())->getScript();
+        $scriptSig = ScriptFactory::create()->opcode(Opcodes::OP_0)->push($p2sh->getBuffer())->getScript();
 
         $f = InterpreterInterface::VERIFY_P2SH;
         $i = new Interpreter($ec);
@@ -125,8 +126,8 @@ class InterpreterTest extends AbstractTestCase
     public function testVerifyScriptsigMustBePushOnly()
     {
         $ec = Bitcoin::getEcAdapter();
-        $p2sh = ScriptFactory::create()->op('OP_1')->push(Buffer::hex('41414141'))->op('OP_DEPTH')->getScript();
-        $scriptSig = ScriptFactory::create()->op('OP_DEPTH')->push($p2sh->getBuffer())->getScript();
+        $p2sh = ScriptFactory::create()->opcode(Opcodes::OP_1)->push(Buffer::hex('41414141'))->opcode(Opcodes::OP_DEPTH)->getScript();
+        $scriptSig = ScriptFactory::create()->opcode(Opcodes::OP_DEPTH)->push($p2sh->getBuffer())->getScript();
         $scriptPubKey = ScriptFactory::scriptPubKey()->payToScriptHash(Hash::sha256ripe160($p2sh->getBuffer()));
 
         $f = InterpreterInterface::VERIFY_P2SH;

--- a/tests/Script/Parser/ParserTest.php
+++ b/tests/Script/Parser/ParserTest.php
@@ -88,7 +88,7 @@ class ParserTest extends AbstractTestCase
     public function testParse()
     {
         $buf = Buffer::hex('0f9947c2b0fdd82ef3153232ee23d5c0bed84a02');
-        $script = ScriptFactory::create()->op('OP_HASH160')->push($buf)->op('OP_EQUAL')->getScript();
+        $script = ScriptFactory::create()->opcode(Opcodes::OP_HASH160)->push($buf)->opcode(Opcodes::OP_EQUAL)->getScript();
         $parse = $script->getScriptParser()->decode();
         $this->assertFalse($parse[0]->isPush());
         $this->assertSame($parse[0]->getOp(), Opcodes::OP_HASH160);
@@ -102,7 +102,7 @@ class ParserTest extends AbstractTestCase
 
     public function testParseNullByte()
     {
-        $script = ScriptFactory::create()->op('OP_0')->getScript();
+        $script = ScriptFactory::create()->opcode(Opcodes::OP_0)->getScript();
         $parse = $script->getScriptParser()->decode();
         $data = $parse[0];
         $this->assertEquals(Opcodes::OP_0, $data->getOp());
@@ -199,7 +199,7 @@ class ParserTest extends AbstractTestCase
     public function testDataSize()
     {
         $buffer = new Buffer('', 40);
-        $script = ScriptFactory::create()->push($buffer)->op('OP_HASH160')->getScript();
+        $script = ScriptFactory::create()->push($buffer)->opcode(Opcodes::OP_HASH160)->getScript();
         $parsed = $script->getScriptParser();
 
         for ($i = 0; $i < 1; $i++) {

--- a/tests/Script/ScriptCountSigOpsTest.php
+++ b/tests/Script/ScriptCountSigOpsTest.php
@@ -6,6 +6,7 @@ namespace BitWasp\Bitcoin\Tests\Script;
 
 use BitWasp\Bitcoin\Crypto\Hash;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Script\ScriptFactory;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
@@ -15,8 +16,8 @@ class ScriptCountSigOpsTest extends AbstractTestCase
 {
     public function getCountTestVectors()
     {
-        $s1 = ScriptFactory::create()->op('OP_1')->push(new Buffer())->push(new Buffer())->op('OP_2')->op('OP_CHECKMULTISIG')->getScript();
-        $s2 = ScriptFactory::create($s1->getBuffer())->op('OP_IF')->op('OP_CHECKSIG')->op('OP_ENDIF')->getScript();
+        $s1 = ScriptFactory::create()->opcode(Opcodes::OP_1)->push(new Buffer())->push(new Buffer())->opcode(Opcodes::OP_2, Opcodes::OP_CHECKMULTISIG)->getScript();
+        $s2 = ScriptFactory::create($s1->getBuffer())->opcode(Opcodes::OP_IF, Opcodes::OP_CHECKSIG, Opcodes::OP_ENDIF)->getScript();
 
         return [
             [
@@ -50,17 +51,16 @@ class ScriptCountSigOpsTest extends AbstractTestCase
     public function testP2sh()
     {
         $innerScript = ScriptFactory::create()
-            ->op('OP_1')
-            ->push(new Buffer())
-            ->push(new Buffer())
-            ->op('OP_2')
-            ->op('OP_CHECKMULTISIG')
+            ->opcode(Opcodes::OP_1)
+            ->data(new Buffer(), new Buffer())
+            ->opcode(Opcodes::OP_2)
+            ->opcode(Opcodes::OP_CHECKMULTISIG)
             ->getScript();
 
         $innerBuf = $innerScript->getBuffer();
 
         $p2sh = ScriptFactory::scriptPubKey()->payToScriptHash(Hash::sha256ripe160($innerScript->getBuffer()));
-        $scriptSig = ScriptFactory::create()->op('OP_0')->push($innerBuf)->getScript();
+        $scriptSig = ScriptFactory::create()->opcode(Opcodes::OP_0)->push($innerBuf)->getScript();
         $count = $p2sh->countP2shSigOps($scriptSig);
 
         $this->assertEquals(2, $count);
@@ -82,9 +82,8 @@ class ScriptCountSigOpsTest extends AbstractTestCase
         $this->assertEquals(0, $scriptPubKey->countSigOps(false));
 
         $scriptSig = ScriptFactory::create()
-            ->op('OP_1')
-            ->push(new Buffer())
-            ->push(new Buffer())
+            ->opcode(Opcodes::OP_1)
+            ->data(new Buffer(), new Buffer())
             ->push($p2shScript->getBuffer())
             ->getScript();
 
@@ -104,14 +103,18 @@ class ScriptCountSigOpsTest extends AbstractTestCase
 
     public function testWhenNotP2sh()
     {
-        $p2pkh = ScriptFactory::create()->op('OP_DUP')->op('OP_HASH160')->push(new Buffer())->op('OP_EQUALVERIFY')->op('OP_CHECKSIG')->getScript();
+        $p2pkh = ScriptFactory::create()
+            ->opcode(Opcodes::OP_DUP, Opcodes::OP_HASH160)
+            ->push(new Buffer())
+            ->opcode(Opcodes::OP_EQUALVERIFY, Opcodes::OP_CHECKSIG)->getScript();
+
         $empty = new Script();
         $this->assertEquals(1, $p2pkh->countP2shSigOps($empty));
 
         $p2shPubKey = ScriptFactory::scriptPubKey()->payToScriptHash(Hash::sha256ripe160($empty->getBuffer()));
         $this->assertEquals(0, $p2shPubKey->countP2shSigOps($empty));
 
-        $p2shScript = ScriptFactory::create()->op('OP_HASH160')->getScript();
+        $p2shScript = ScriptFactory::create()->opcode(Opcodes::OP_HASH160)->getScript();
         $p2shPubKey1 = ScriptFactory::scriptPubKey()->payToScriptHash(Hash::sha256ripe160($p2shScript->getBuffer()));
         $this->assertEquals(0, $p2shPubKey1->countP2shSigOps($p2shScript));
     }

--- a/tests/Script/ScriptTest.php
+++ b/tests/Script/ScriptTest.php
@@ -157,12 +157,13 @@ class ScriptTest extends AbstractTestCase
     public function testGetScriptHash()
     {
         $script = $script = ScriptFactory::create()
-            ->op('OP_2')
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->push(Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'))
-            ->op('OP_3')
-            ->op('OP_CHECKMULTISIG')
+            ->opcode(Opcodes::OP_2)
+            ->data(
+                Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+                Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb'),
+                Buffer::hex('02cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb')
+            )
+            ->opcode(Opcodes::OP_3, Opcodes::OP_CHECKMULTISIG)
             ->getScript();
 
         $rs = new Script(Buffer::hex('522102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb2102cffc9fcdc2a4e6f5dd91aee9d8d79828c1c93e7a76949a451aab8be6a0c44feb53ae'));
@@ -189,12 +190,12 @@ class ScriptTest extends AbstractTestCase
     public function getPushOnlyVectors()
     {
         return [
-            [ScriptFactory::create()->push(new Buffer())->push(new Buffer())->op('OP_0')->getScript(), true],
-            [ScriptFactory::create()->op('OP_1')->getScript(), true],
-            [ScriptFactory::create()->op('OP_0')->getScript(), true],
-            [ScriptFactory::create()->op('OP_16')->op('OP_RESERVED')->getScript(), true],
-            [ScriptFactory::create()->op('OP_16')->op('OP_RESERVED')->getScript(), true],
-            [ScriptFactory::create()->op('OP_NOP')->getScript(), false],
+            [ScriptFactory::create()->data(new Buffer(), new Buffer())->opcode(Opcodes::OP_0)->getScript(), true],
+            [ScriptFactory::create()->opcode(Opcodes::OP_1)->getScript(), true],
+            [ScriptFactory::create()->opcode(Opcodes::OP_0)->getScript(), true],
+            [ScriptFactory::create()->opcode(Opcodes::OP_16, Opcodes::OP_RESERVED)->getScript(), true],
+            [ScriptFactory::create()->opcode(Opcodes::OP_16, Opcodes::OP_RESERVED)->getScript(), true],
+            [ScriptFactory::create()->opcode(Opcodes::OP_NOP)->getScript(), false],
 
         ];
     }


### PR DESCRIPTION
Started out just removing pushSerializable (serialize it with getBuffer or use the serializer directly!)

Turned into adding variadic arguments for methods in ScriptCreator so multiple, but still typed, parameters can be passed. 

op(string ... $opcodes); // stringy name eg "OP_DUP"
opcode(int ... $opcodes); // opcode symbol Opcodes::OP_DUP
data(BufferInterface ... $dataList); // 
