### PR TITLE
[0.0.34] Reuse opcodes instance

### DIFF
--- a/src/Block/BlockFactory.php
+++ b/src/Block/BlockFactory.php
@@ -4,8 +4,13 @@ namespace BitWasp\Bitcoin\Block;
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Math\Math;
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Serializer\Block\BlockHeaderSerializer;
 use BitWasp\Bitcoin\Serializer\Block\BlockSerializer;
+use BitWasp\Bitcoin\Serializer\Script\ScriptWitnessSerializer;
+use BitWasp\Bitcoin\Serializer\Transaction\OutPointSerializer;
+use BitWasp\Bitcoin\Serializer\Transaction\TransactionInputSerializer;
+use BitWasp\Bitcoin\Serializer\Transaction\TransactionOutputSerializer;
 use BitWasp\Bitcoin\Serializer\Transaction\TransactionSerializer;
 
 class BlockFactory
@@ -17,10 +22,15 @@ class BlockFactory
      */
     public static function fromHex($string, Math $math = null)
     {
+        $opcodes = new Opcodes();
         return (new BlockSerializer(
             $math ?: Bitcoin::getMath(),
             new BlockHeaderSerializer(),
-            new TransactionSerializer()
+            new TransactionSerializer(
+                new TransactionInputSerializer(new OutPointSerializer(), $opcodes),
+                new TransactionOutputSerializer($opcodes),
+                new ScriptWitnessSerializer()
+            )
         ))
             ->parse($string);
     }

--- a/src/Serializer/Transaction/TransactionInputSerializer.php
+++ b/src/Serializer/Transaction/TransactionInputSerializer.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Serializer\Transaction;
 
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Serializer\Types;
 use BitWasp\Bitcoin\Transaction\TransactionInput;
@@ -28,14 +29,21 @@ class TransactionInputSerializer
     private $uint32le;
 
     /**
+     * @var Opcodes
+     */
+    private $opcodes;
+
+    /**
      * TransactionInputSerializer constructor.
      * @param OutPointSerializerInterface $outPointSerializer
+     * @param Opcodes|null $opcodes
      */
-    public function __construct(OutPointSerializerInterface $outPointSerializer)
+    public function __construct(OutPointSerializerInterface $outPointSerializer, Opcodes $opcodes = null)
     {
         $this->outpointSerializer = $outPointSerializer;
         $this->varstring = Types::varstring();
         $this->uint32le = Types::uint32le();
+        $this->opcodes = $opcodes ?: new Opcodes();
     }
 
     /**
@@ -60,7 +68,7 @@ class TransactionInputSerializer
     {
         return new TransactionInput(
             $this->outpointSerializer->fromParser($parser),
-            new Script($this->varstring->read($parser)),
+            new Script($this->varstring->read($parser), $this->opcodes),
             $this->uint32le->read($parser)
         );
     }

--- a/src/Serializer/Transaction/TransactionOutputSerializer.php
+++ b/src/Serializer/Transaction/TransactionOutputSerializer.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Serializer\Transaction;
 
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Script\Script;
 use BitWasp\Bitcoin\Serializer\Types;
 use BitWasp\Bitcoin\Transaction\TransactionOutput;
@@ -22,10 +23,20 @@ class TransactionOutputSerializer
      */
     private $varstring;
 
-    public function __construct()
+    /**
+     * @var Opcodes
+     */
+    private $opcodes;
+
+    /**
+     * TransactionOutputSerializer constructor.
+     * @param Opcodes|null $opcodes
+     */
+    public function __construct(Opcodes $opcodes = null)
     {
         $this->uint64le = Types::uint64le();
         $this->varstring = Types::varstring();
+        $this->opcodes = $opcodes ?: new Opcodes();
     }
 
     /**
@@ -49,7 +60,7 @@ class TransactionOutputSerializer
     {
         return new TransactionOutput(
             $this->uint64le->read($parser),
-            new Script($this->varstring->read($parser))
+            new Script($this->varstring->read($parser), $this->opcodes)
         );
     }
 

--- a/src/Serializer/Transaction/TransactionSerializer.php
+++ b/src/Serializer/Transaction/TransactionSerializer.php
@@ -2,6 +2,7 @@
 
 namespace BitWasp\Bitcoin\Serializer\Transaction;
 
+use BitWasp\Bitcoin\Script\Opcodes;
 use BitWasp\Bitcoin\Serializer\Script\ScriptWitnessSerializer;
 use BitWasp\Bitcoin\Serializer\Types;
 use BitWasp\Bitcoin\Transaction\Transaction;
@@ -49,9 +50,23 @@ class TransactionSerializer implements TransactionSerializerInterface
         $this->uint32le = Types::uint32le();
         $this->varint = Types::varint();
 
-        $this->inputSerializer = $inputSerializer ?: new TransactionInputSerializer(new OutPointSerializer());
-        $this->outputSerializer = $outputSerializer ?: new TransactionOutputSerializer;
-        $this->witnessSerializer = $witnessSerializer ?: new ScriptWitnessSerializer();
+        if ($inputSerializer === null || $outputSerializer === null) {
+            $opcodes = new Opcodes();
+            if (!$inputSerializer) {
+                $inputSerializer = new TransactionInputSerializer(new OutPointSerializer(), $opcodes);
+            }
+            if (!$outputSerializer) {
+                $outputSerializer = new TransactionOutputSerializer($opcodes);
+            }
+        }
+
+        if (!$witnessSerializer) {
+            $witnessSerializer = new ScriptWitnessSerializer();
+        }
+
+        $this->inputSerializer = $inputSerializer;
+        $this->outputSerializer = $outputSerializer;
+        $this->witnessSerializer = $witnessSerializer;
     }
 
     /**


### PR DESCRIPTION
Massively reduces memory by reusing an Opcodes instance over the lifetime of a Block/Transaction serializer