### PR TITLE
[0.0.35] BC Break: change litecoin multisignature prefix to m-addresses

### DIFF
--- a/src/Network/NetworkFactory.php
+++ b/src/Network/NetworkFactory.php
@@ -84,7 +84,7 @@ class NetworkFactory
      */
     public static function litecoin()
     {
-        $network = self::create('30', '05', 'b0')
+        $network = self::create('30', '32', 'b0')
             ->setHDPubByte('019da462')
             ->setHDPrivByte('019d9cfe')
             ->setNetMagicBytes('dbb6c0fb');

--- a/tests/Network/NetworkTest.php
+++ b/tests/Network/NetworkTest.php
@@ -156,14 +156,14 @@ class NetworkTest extends AbstractTestCase
         $this->assertEquals('mg9fuhDDAbD673KswdNyyWgaX8zDxJT8QY', $p2pk->getAddress(NetworkFactory::bitcoinTestnet()));
 
         $this->assertEquals(NetworkFactory::litecoin()->getAddressByte(), '30');
-        $this->assertEquals(NetworkFactory::litecoin()->getP2shByte(), '05');
+        $this->assertEquals(NetworkFactory::litecoin()->getP2shByte(), '32');
         $this->assertEquals(NetworkFactory::litecoin()->getPrivByte(), 'b0');
         $this->assertEquals(NetworkFactory::litecoin()->isTestnet(), false);
         $this->assertEquals(NetworkFactory::litecoin()->getHDPrivByte(), '019d9cfe');
         $this->assertEquals(NetworkFactory::litecoin()->getHDPubByte(), '019da462');
         $this->assertEquals(NetworkFactory::litecoin()->getNetMagicBytes(), 'dbb6c0fb');
 
-        $this->assertEquals('36PrZ1KHYMpqSyAQXSG8VwbUiq2EogxLo2', $p2sh->getAddress(NetworkFactory::litecoin()));
+        $this->assertEquals('MCbzrtjFVUgGFUSJdKFUKaqt3Xcgpi6Csx', $p2sh->getAddress(NetworkFactory::litecoin()));
         $this->assertEquals('LKrfsrS4SE1tajYRQCPuRcY1sMkoFf1BN3', $p2pk->getAddress(NetworkFactory::litecoin()));
 
         $this->assertEquals(NetworkFactory::viacoin()->getAddressByte(), '47');


### PR DESCRIPTION
For old addresses, duplicate the old function somewhere in your project and use that! To support both forms, try using the AddressCreator with the first network, then the second.