### PR TITLE
Debugging invalid addresses on travis/nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
     - |
         if [ "$PHPUNIT_EXT" = "true" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then
             git clone https://github.com/Bit-Wasp/secp256k1-php && cd secp256k1-php &&
-            git checkout 1335d166f26f67b1ba4781a7ae4434f58756d98b && cd secp256k1 &&
+            git checkout 60678a95beccd3e093d7fc3c9f36cad46ec0ddd1 && cd secp256k1 &&
             phpize && ./configure &&
             make && sudo make install && cd ../..;
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ install:
         fi
     - |
         if [ "$PHPUNIT_EXT" = "true" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then
-            git clone -b v0.1.2 https://github.com/Bit-Wasp/secp256k1-php &&
-            cd secp256k1-php/secp256k1 &&
+            git clone https://github.com/afk11/secp256k1-php && cd secp256k1-php &&
+            git fetch origin run-php-extension-tests && git checkout run-php-extension-tests && cd secp256k1 &&
             phpize && ./configure &&
             make && sudo make install && cd ../..;
         fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -87,6 +87,7 @@ script:
       elif [ "$PHPUNIT" = "true" ]; then
           make phpunit-ci;
       fi
+
   - if [ "$CODE_STYLE" = "true" ]; then make phpcs && echo "Code style OK"; fi
   - if [ "$EXAMPLES" = "true" ]; then make test-examples && echo "Examples OK"; fi
   - if [ "$RPC_TEST" = "true" ]; then export BITCOIND_PATH="$HOME/bitcoin/bitcoin-$BITCOIN_VERSION/bin/bitcoind"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
     - |
         if [ "$PHPUNIT_EXT" = "true" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then
             git clone https://github.com/Bit-Wasp/secp256k1-php && cd secp256k1-php &&
-            git checkout 55dae0e0cd6c5028eadbfb76c7436d022887d044 && cd secp256k1 &&
+            git checkout 1335d166f26f67b1ba4781a7ae4434f58756d98b && cd secp256k1 &&
             phpize && ./configure &&
             make && sudo make install && cd ../..;
         fi
@@ -81,11 +81,12 @@ before_script:
   - if [ "${COVERAGE}" != "true" ] && [ "$TRAVIS_PHP_VERSION" != "hhvm" ] && [ "$TRAVIS_PHP_VERSION" != "nightly" ]; then phpenv config-rm xdebug.ini && echo "xdebug disabled"; fi
 
 script:
+  - travis/run_secp256k1_tests.sh || exit 1
   - |
       if [ "$PHPUNIT_EXT" = "true" ]; then
-          EXT_PHP='-dextension="secp256k1.so" -dextension="bitcoinconsensus.so"' make phpunit-ci;
+          EXT_PHP='-dextension="secp256k1.so" -dextension="bitcoinconsensus.so"' make phpunit-ci || travis_terminate 1;
       elif [ "$PHPUNIT" = "true" ]; then
-          make phpunit-ci;
+          make phpunit-ci || travis_terminate 1;
       fi
 
   - if [ "$CODE_STYLE" = "true" ]; then make phpcs && echo "Code style OK"; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,8 +59,8 @@ install:
         fi
     - |
         if [ "$PHPUNIT_EXT" = "true" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then
-            git clone https://github.com/afk11/secp256k1-php && cd secp256k1-php &&
-            git fetch origin run-php-extension-tests && git checkout run-php-extension-tests && cd secp256k1 &&
+            git clone https://github.com/Bit-Wasp/secp256k1-php && cd secp256k1-php &&
+            git checkout 55dae0e0cd6c5028eadbfb76c7436d022887d044 && cd secp256k1 &&
             phpize && ./configure &&
             make && sudo make install && cd ../..;
         fi

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
@@ -181,8 +181,13 @@ class PrivateKey extends Key implements PrivateKeyInterface
         $adapter = $this->ecAdapter;
         $math = $adapter->getMath();
         $context = $adapter->getContext();
+
         $privateKey = $this->getBinary(); // mod by reference
+        echo "      privateKey = " . unpack("H*", $privateKey)[1] . PHP_EOL;
+
         $tweak = Buffer::int($math->toString($tweak), 32)->getBinary();
+        echo "      tweak = " . unpack("H*", $tweak)[1] . PHP_EOL;
+
         $ret = \secp256k1_ec_privkey_tweak_add(
             $context,
             $privateKey,
@@ -193,7 +198,9 @@ class PrivateKey extends Key implements PrivateKeyInterface
             throw new \RuntimeException('Secp256k1 privkey tweak add: failed');
         }
 
-        $secret = new Buffer($privateKey);
+        echo "      privateKey.tweaked = " . unpack("H*", $privateKey)[1] . PHP_EOL;
+        echo "      [originValue = " . unpack("H*", $this->getBinary())[1] . "]" . PHP_EOL;
+        $secret = new Buffer($privateKey, 32);
         return $adapter->getPrivateKey($secret->getGmp(), $this->compressed);
     }
 

--- a/src/Key/Deterministic/ElectrumKey.php
+++ b/src/Key/Deterministic/ElectrumKey.php
@@ -96,6 +96,18 @@ class ElectrumKey
     public function deriveChild(int $sequence, bool $change = false): KeyInterface
     {
         $key = is_null($this->masterPrivate) ? $this->masterPublic : $this->masterPrivate;
-        return $key->tweakAdd($this->getSequenceOffset($sequence, $change));
+        $offset = $this->getSequenceOffset($sequence, $change);
+        if ($this->masterPrivate) {
+            echo "derive sequence {$sequence} " . ($change ? "external":"internal") . PHP_EOL;
+            echo "sequenceOffset: " . gmp_strval($offset, 10) . PHP_EOL;
+            echo " + privKey    : " . $this->getMasterPrivateKey()->getHex().PHP_EOL;
+            $child = $key->tweakAdd($offset);
+            echo "     equals   : " . $child->getHex() . PHP_EOL;
+            echo "    pubkey    : " . $child->getPublicKey()->getHex() . PHP_EOL;
+        } else {
+            $child = $key->tweakAdd($offset);
+        }
+
+        return $child;
     }
 }

--- a/tests/Key/Deterministic/ElectrumKeyTest.php
+++ b/tests/Key/Deterministic/ElectrumKeyTest.php
@@ -71,6 +71,18 @@ class ElectrumKeyTest extends AbstractTestCase
             list ($sequence, $eAddr) = $vector;
             $childPriv = $keyPriv->deriveChild($sequence);
             $keyHash = $childPriv->getPubKeyHash();
+
+            if ($eAddr != (new PayToPubKeyHashAddress($keyHash))->getAddress()) {
+                var_dump($mnemonic);
+                var_dump($eSecExp);
+                var_dump($eMPK);
+                var_dump($vector);
+                echo "$eAddr != expected\n";
+                echo (new PayToPubKeyHashAddress($keyHash))->getAddress() . PHP_EOL;
+                echo "childPriv: {$childPriv->getHex()}\n";
+                echo "childPrivKeyHash: {$keyHash->getHex()}\n";
+            }
+
             $this->assertEquals($eAddr, (new PayToPubKeyHashAddress($keyHash))->getAddress());
 
             $childPub = $keyPub->deriveChild($sequence);

--- a/travis/run_secp256k1_tests.sh
+++ b/travis/run_secp256k1_tests.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -e
+if [ "${PHPUNIT_EXT}" = "true" ]; then
+    cd secp256k1-php/secp256k1 && REPORT_EXIT_STATUS=1 make test;
+fi


### PR DESCRIPTION
Initial review: appears only to affect deterministic keys, and only on secp256k1. this narrows things down to secp256k1_ec_privkey_tweak_add. 

Further review took place while working on the secp256k1-php repo, which actually never shown signs of the bug, which sucks. While the intention was to modify the zval in question, we only wanted to modify the variable passed into the function, not every reference to the zval. Added a regression test capturing this scenario.