### PR TITLE
[0.0.35] HierarchicalKey: add getAddress and getScriptAndSignData (Slip132)

### DIFF
--- a/examples/slip132.php
+++ b/examples/slip132.php
@@ -1,0 +1,72 @@
+<?php
+
+use BitWasp\Bitcoin\Address\AddressCreator;
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Mnemonic\Bip39\Bip39SeedGenerator;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$adapter = Bitcoin::getEcAdapter();
+$slip132 = new Slip132(new KeyToScriptHelper($adapter));
+$addrCreator = new AddressCreator();
+
+// We're using bitcoin, and need the slip132 bitcoin registry
+$btc = NetworkFactory::bitcoin();
+$bitcoinPrefixes = new BitcoinRegistry();
+
+// What prefixes do we want to encode/decode? Configure those here
+// Separate out this one, want it in a sec
+$YpubPrefix = $slip132->p2shP2wshP2pkh($bitcoinPrefixes);
+
+// Keys with ALL of these prefixes will be supported.
+// You can chose a subset if desired (for some networks it's
+// a good idea!)
+$config = new GlobalPrefixConfig([
+    new NetworkConfig($btc, [
+        $slip132->p2pkh($bitcoinPrefixes),
+        // $slip132->p2shP2pkh($bitcoinPrefixes),
+        // ^^ that's why this is so configurable.
+        // prefixes can conflict, so you might need
+        // two configs for full support ;)
+
+        $slip132->p2shP2wpkh($bitcoinPrefixes),
+        $YpubPrefix,
+        $slip132->p2wpkh($bitcoinPrefixes),
+        $slip132->p2wshP2pkh($bitcoinPrefixes),
+    ])
+]);
+
+$btcPrefixConfig = $config->getNetworkConfig($btc);
+$serializer = new Base58ExtendedKeySerializer(new ExtendedKeySerializer($adapter, $config));
+
+$bip39 = new Bip39SeedGenerator();
+$seed = $bip39->getSeed("insect issue net wall milk bulb stamp remind tell fee roast mansion angry stable oil");
+
+// This shows how we create such keys. You
+// don't actually need the config until serialize
+// time
+$p2shP2wshP2pkhKey = HierarchicalKeyFactory::fromEntropy($seed, $adapter, $YpubPrefix->getScriptDataFactory());
+$serialized = $serializer->serialize($btc, $p2shP2wshP2pkhKey);
+echo "master key {$serialized}\n";
+
+// This shows how you can parse such a key.
+// Remember the serializer needs the config for this!
+$parsedKey = $serializer->parse($btc, $serialized);
+$accountKey = $parsedKey->derivePath("m/44'/0'/0'"); // Can't really remember the 'purpose' field for this script, assume 44
+$serAccKey = $serializer->serialize($btc, $accountKey);
+echo "account key {$serAccKey}\n";
+
+$addrKey = $accountKey->derivePath("0/0");
+$serAddrKey = $serializer->serialize($btc, $addrKey);
+echo "address key {$serAddrKey}\n";
+echo "addr[0] {$addrKey->getAddress($addrCreator)->getAddress($btc)}\n";
+

--- a/examples/slip132.php
+++ b/examples/slip132.php
@@ -69,4 +69,3 @@ $addrKey = $accountKey->derivePath("0/0");
 $serAddrKey = $serializer->serialize($btc, $addrKey);
 echo "address key {$serAddrKey}\n";
 echo "addr[0] {$addrKey->getAddress($addrCreator)->getAddress($btc)}\n";
-

--- a/examples/trezor.bip32.php
+++ b/examples/trezor.bip32.php
@@ -47,7 +47,8 @@ echo "M/{$purpose}'/0'/0': ".$purposePriv->toExtendedPublicKey().PHP_EOL;
 echo "Derive (M -> m/{$purpose}'/0'/0'): .... should fail\n";
 
 try {
-    $rootPub = $root->toPublic()->derivePath("{$purpose}'/0'/0'");
+    $rootPub = $root->withoutPrivateKey();
+    $rootPub->derivePath("{$purpose}'/0'/0'");
 } catch (\Exception $e) {
     echo "caught exception, yes this is impossible: " . $e->getMessage().PHP_EOL;
 }

--- a/examples/zpub.create.php
+++ b/examples/zpub.create.php
@@ -1,0 +1,75 @@
+<?php
+
+use BitWasp\Bitcoin\Address\AddressCreator;
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$adapter = Bitcoin::getEcAdapter();
+$addrCreator = new AddressCreator();
+
+// We're using bitcoin and want the zpub.
+// Grab bitcoin registry, use that to make our prefix.
+$btc = NetworkFactory::bitcoin();
+$bitcoinPrefixes = new BitcoinRegistry();
+
+// If you want to produce different addresses,
+// set a different prefix/factory here.
+$slip132 = new Slip132(new KeyToScriptHelper($adapter));
+$prefix = $slip132->p2wpkh($bitcoinPrefixes);
+$scriptFactory = $prefix->getScriptDataFactory();
+
+// To create a key and derive addressses, we don't
+// need the GlobalPrefixConfig, or even a ScriptPrefix.
+// We just need a ScriptDataFactory. (see the KeyToScript
+// helpers on how to create custom script factories)
+
+$masterKey = HierarchicalKeyFactory::generateMasterKey($adapter, $scriptFactory);
+
+// First nice part, we have access to the SPK/RS/WS
+$scriptAndSignData = $masterKey->getScriptAndSignData();
+$spk = $scriptAndSignData->getScriptPubKey();
+$signData = $scriptAndSignData->getSignData();
+echo "scriptPubKey: " . $spk->getHex() . PHP_EOL;
+if ($signData->hasRedeemScript()) {
+    echo "redeemScript: " . $signData->getRedeemScript()->getHex().PHP_EOL;
+}
+if ($signData->hasWitnessScript()) {
+    echo "witnessScript: " . $signData->getWitnessScript()->getHex().PHP_EOL;
+}
+
+// Drawing on the spk, we can try and make an address
+$address = $masterKey->getAddress($addrCreator);
+echo "address: " . $address->getAddress($btc) . PHP_EOL;
+
+// Doh - you wanna serialize NOW?
+// Well, the toExtendedKey() method will error because
+// the HK's serializer doesn't know about the GlobalPrefixConfig.
+// So we need to bring our own serializer, configurable
+// with the bare minimum prefixes.
+try {
+    $masterKey->toExtendedKey();
+} catch (\Exception $e) {
+    echo "\nfriendly reminder: {$e->getMessage()}\n\n";
+    // "Cannot serialize non-P2PKH HierarchicalKeys without a GlobalPrefixConfig"
+}
+
+$config = new GlobalPrefixConfig([
+    new NetworkConfig($btc, [
+        $prefix
+    ]),
+]);
+
+$serializer = new Base58ExtendedKeySerializer(new ExtendedKeySerializer($adapter, $config));
+
+$serialized = $serializer->serialize($btc, $masterKey);
+echo "master key: " . $serialized . PHP_EOL;

--- a/examples/zpub.parse.php
+++ b/examples/zpub.parse.php
@@ -1,0 +1,38 @@
+<?php
+
+use BitWasp\Bitcoin\Address\AddressCreator;
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
+
+require __DIR__ . "/../vendor/autoload.php";
+
+$adapter = Bitcoin::getEcAdapter();
+$btc = NetworkFactory::bitcoin();
+
+$slip132 = new Slip132(new KeyToScriptHelper($adapter));
+$bitcoinPrefixes = new BitcoinRegistry();
+$zpubPrefix = $slip132->p2wpkh($bitcoinPrefixes);
+
+$config = new GlobalPrefixConfig([
+    new NetworkConfig($btc, [
+        $zpubPrefix,
+    ])
+]);
+
+$serializer = new Base58ExtendedKeySerializer(
+    new ExtendedKeySerializer($adapter, $config)
+);
+
+$rootKey = $serializer->parse($btc, "zprvAWgYBBk7JR8GiuMByuy3PBgDdCdBk3fBK77VSGEMnWT1gKG7hz5z9Jt1tPCA2itCvzowhWh5yMdGwyLcLmuKmC8RwgPZMcdCfvyVLhmUR2m");
+
+$account0Key = $rootKey->derivePath("84'/0'/0'");
+$firstKey = $account0Key->derivePath("0/0");
+$address = $firstKey->getAddress(new AddressCreator());
+echo $address->getAddress() . PHP_EOL;

--- a/src/Exceptions/DisallowedScriptDataFactoryException.php
+++ b/src/Exceptions/DisallowedScriptDataFactoryException.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class DisallowedScriptDataFactoryException extends \Exception
+{
+
+}

--- a/src/Exceptions/InvalidKeyHashInput.php
+++ b/src/Exceptions/InvalidKeyHashInput.php
@@ -1,0 +1,8 @@
+<?php
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class InvalidKeyHashInput extends \Exception
+{
+
+}

--- a/src/Key/Deterministic/HdPrefix/GlobalPrefixConfig.php
+++ b/src/Key/Deterministic/HdPrefix/GlobalPrefixConfig.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\Deterministic\HdPrefix;
+
+use BitWasp\Bitcoin\Network\NetworkInterface;
+
+class GlobalPrefixConfig
+{
+    /**
+     * @var NetworkConfig[]
+     */
+    private $networkConfigs = [];
+
+    /**
+     * ScriptPrefixConfig constructor.
+     * @param NetworkConfig[] $config
+     */
+    public function __construct(array $config)
+    {
+        foreach ($config as $networkPrefixConfig) {
+            if (!($networkPrefixConfig instanceof NetworkConfig)) {
+                throw new \InvalidArgumentException("expecting array of NetworkPrefixConfig");
+            }
+
+            $networkClass = get_class($networkPrefixConfig->getNetwork());
+            if (array_key_exists($networkClass, $this->networkConfigs)) {
+                throw new \InvalidArgumentException("multiple configs for network");
+            }
+
+            $this->networkConfigs[$networkClass] = $networkPrefixConfig;
+        }
+    }
+
+    /**
+     * @param NetworkInterface $network
+     * @return NetworkConfig
+     */
+    public function getNetworkConfig(NetworkInterface $network)
+    {
+        $class = get_class($network);
+        if (!array_key_exists($class, $this->networkConfigs)) {
+            throw new \InvalidArgumentException("Network not registered with GlobalHdPrefixConfig");
+        }
+
+        return $this->networkConfigs[$class];
+    }
+}

--- a/src/Key/Deterministic/HdPrefix/NetworkConfig.php
+++ b/src/Key/Deterministic/HdPrefix/NetworkConfig.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\Deterministic\HdPrefix;
+
+use BitWasp\Bitcoin\Network\NetworkInterface;
+
+class NetworkConfig
+{
+    /**
+     * @var NetworkInterface
+     */
+    private $network;
+
+    /**
+     * @var ScriptPrefix[]
+     */
+    private $scriptPrefixMap = [];
+
+    /**
+     * @var ScriptPrefix[]
+     */
+    private $scriptTypeMap = [];
+
+    /**
+     * NetworkHdKeyPrefixConfig constructor.
+     * @param NetworkInterface $network
+     * @param ScriptPrefix[] $prefixConfigList
+     */
+    public function __construct(NetworkInterface $network, array $prefixConfigList)
+    {
+        foreach ($prefixConfigList as $config) {
+            if (!($config instanceof ScriptPrefix)) {
+                throw new \InvalidArgumentException("expecting array of NetworkPrefixConfig");
+            }
+            $this->setupConfig($config);
+        }
+
+        $this->network = $network;
+    }
+
+    /**
+     * @param ScriptPrefix $config
+     */
+    private function setupConfig(ScriptPrefix $config)
+    {
+        $this->checkForOverwriting($config);
+
+        $this->scriptPrefixMap[$config->getPrivatePrefix()] = $config;
+        $this->scriptPrefixMap[$config->getPublicPrefix()] = $config;
+        $this->scriptTypeMap[$config->getScriptDataFactory()->getScriptType()] = $config;
+    }
+
+    /**
+     * @param ScriptPrefix $config
+     */
+    private function checkForOverwriting(ScriptPrefix $config)
+    {
+        if (array_key_exists($config->getPublicPrefix(), $this->scriptPrefixMap)) {
+            $this->rejectConflictPrefix($config, $config->getPublicPrefix());
+        }
+
+        if (array_key_exists($config->getPrivatePrefix(), $this->scriptPrefixMap)) {
+            $this->rejectConflictPrefix($config, $config->getPrivatePrefix());
+        }
+
+        if (array_key_exists($config->getScriptDataFactory()->getScriptType(), $this->scriptTypeMap)) {
+            $this->rejectConflictScriptType($config);
+        }
+    }
+
+    /**
+     * @param ScriptPrefix $config
+     * @param string $prefix
+     */
+    private function rejectConflictPrefix(ScriptPrefix $config, $prefix)
+    {
+        $conflict = $this->scriptPrefixMap[$prefix];
+        throw new \RuntimeException(sprintf(
+            "A BIP32 prefix for %s conflicts with the %s BIP32 prefix of %s",
+            $config->getScriptDataFactory()->getScriptType(),
+            $prefix === $config->getPublicPrefix() ? "public" : "private",
+            $conflict->getScriptDataFactory()->getScriptType()
+        ));
+    }
+
+    /**
+     * @param ScriptPrefix $config
+     */
+    private function rejectConflictScriptType(ScriptPrefix $config)
+    {
+        throw new \RuntimeException(sprintf(
+            "The script type %s has a conflict",
+            $config->getScriptDataFactory()->getScriptType()
+        ));
+    }
+
+    /**
+     * @return NetworkInterface
+     */
+    public function getNetwork()
+    {
+        return $this->network;
+    }
+
+    /**
+     * @param string $prefix
+     * @return ScriptPrefix
+     */
+    public function getConfigForPrefix($prefix)
+    {
+        if (!array_key_exists($prefix, $this->scriptPrefixMap)) {
+            throw new \InvalidArgumentException("Prefix not configured for network");
+        }
+
+        return $this->scriptPrefixMap[$prefix];
+    }
+
+    /**
+     * @param string $scriptType
+     * @return ScriptPrefix
+     */
+    public function getConfigForScriptType($scriptType)
+    {
+        if (!array_key_exists($scriptType, $this->scriptTypeMap)) {
+            throw new \InvalidArgumentException("Script type not configured for network");
+        }
+
+        return $this->scriptTypeMap[$scriptType];
+    }
+}

--- a/src/Key/Deterministic/HdPrefix/ScriptPrefix.php
+++ b/src/Key/Deterministic/HdPrefix/ScriptPrefix.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\Deterministic\HdPrefix;
+
+use BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptDataFactory;
+
+class ScriptPrefix
+{
+    /**
+     * @var string
+     */
+    private $privatePrefix;
+
+    /**
+     * @var string
+     */
+    private $publicPrefix;
+
+    /**
+     * @var ScriptDataFactory
+     */
+    private $scriptDataFactory;
+
+    /**
+     * ScriptPrefixConfig constructor.
+     * @param ScriptDataFactory $scriptDataFactory
+     * @param string $privatePrefix
+     * @param string $publicPrefix
+     */
+    public function __construct(ScriptDataFactory $scriptDataFactory, $privatePrefix, $publicPrefix)
+    {
+        if (strlen($privatePrefix) !== 8) {
+            throw new InvalidNetworkParameter("Invalid HD private prefix: wrong length");
+        }
+
+        if (!ctype_xdigit($privatePrefix)) {
+            throw new InvalidNetworkParameter("Invalid HD private prefix: expecting hex");
+        }
+
+        if (strlen($publicPrefix) !== 8) {
+            throw new InvalidNetworkParameter("Invalid HD public prefix: wrong length");
+        }
+
+        if (!ctype_xdigit($publicPrefix)) {
+            throw new InvalidNetworkParameter("Invalid HD public prefix: expecting hex");
+        }
+
+        $this->scriptDataFactory = $scriptDataFactory;
+        $this->publicPrefix = $publicPrefix;
+        $this->privatePrefix = $privatePrefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrivatePrefix()
+    {
+        return $this->privatePrefix;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPublicPrefix()
+    {
+        return $this->publicPrefix;
+    }
+
+    /**
+     * @return ScriptDataFactory
+     */
+    public function getScriptDataFactory()
+    {
+        return $this->scriptDataFactory;
+    }
+}

--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -206,6 +206,7 @@ class HierarchicalKey
     {
         $clone = clone $this;
         $clone->scriptDataFactory = $factory;
+        $clone->scriptAndSignData = null; // we cache, don't forget to clear
         return $clone;
     }
 

--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -199,18 +199,6 @@ class HierarchicalKey
     }
 
     /**
-     * @param ScriptDataFactory $factory
-     * @return HierarchicalKey
-     */
-    public function withScriptFactory(ScriptDataFactory $factory)
-    {
-        $clone = clone $this;
-        $clone->scriptDataFactory = $factory;
-        $clone->scriptAndSignData = null; // we cache, don't forget to clear
-        return $clone;
-    }
-
-    /**
      * @return ScriptDataFactory
      */
     public function getScriptDataFactory()

--- a/src/Key/Deterministic/HierarchicalKeyFactory.php
+++ b/src/Key/Deterministic/HierarchicalKeyFactory.php
@@ -4,7 +4,11 @@ namespace BitWasp\Bitcoin\Key\Deterministic;
 
 use BitWasp\Bitcoin\Bitcoin;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
 use BitWasp\Bitcoin\Crypto\Hash;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptDataFactory;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Network\NetworkInterface;
 use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
@@ -26,26 +30,31 @@ class HierarchicalKeyFactory
 
     /**
      * @param EcAdapterInterface|null $ecAdapter
+     * @param ScriptDataFactory|null $scriptDataFactory
      * @return HierarchicalKey
+     * @throws \Exception
      */
-    public static function generateMasterKey(EcAdapterInterface $ecAdapter = null)
+    public static function generateMasterKey(EcAdapterInterface $ecAdapter = null, ScriptDataFactory $scriptDataFactory = null)
     {
         $ecAdapter = $ecAdapter ?: Bitcoin::getEcAdapter();
         $buffer = PrivateKeyFactory::create(true, $ecAdapter);
-        return self::fromEntropy($buffer->getBuffer(), $ecAdapter);
+        return self::fromEntropy($buffer->getBuffer(), $ecAdapter, $scriptDataFactory);
     }
 
     /**
      * @param BufferInterface $entropy
      * @param EcAdapterInterface $ecAdapter
+     * @param ScriptDataFactory|null $scriptFactory
      * @return HierarchicalKey
+     * @throws \Exception
      */
-    public static function fromEntropy(BufferInterface $entropy, EcAdapterInterface $ecAdapter = null)
+    public static function fromEntropy(BufferInterface $entropy, EcAdapterInterface $ecAdapter = null, ScriptDataFactory $scriptFactory = null)
     {
         $ecAdapter = $ecAdapter ?: Bitcoin::getEcAdapter();
+        $scriptFactory = $scriptFactory ?: new P2pkhScriptDataFactory(EcSerializer::getSerializer(PublicKeySerializerInterface::class, true, $ecAdapter));
         $seed = Hash::hmac('sha512', $entropy, new Buffer('Bitcoin seed', null, $ecAdapter->getMath()));
         $privateKey = PrivateKeyFactory::fromHex($seed->slice(0, 32), true, $ecAdapter);
-        return new HierarchicalKey($ecAdapter, 0, 0, 0, $seed->slice(32, 32), $privateKey);
+        return new HierarchicalKey($ecAdapter, $scriptFactory, 0, 0, 0, $seed->slice(32, 32), $privateKey);
     }
 
     /**

--- a/src/Key/Deterministic/Slip132/PrefixRegistry.php
+++ b/src/Key/Deterministic/Slip132/PrefixRegistry.php
@@ -22,6 +22,7 @@ class PrefixRegistry
             if (count($prefixes) !== 2) {
                 throw new \InvalidArgumentException("Expecting two BIP32 prefixes");
             }
+            // private, public
             if (strlen($prefixes[0]) !== 8 || !ctype_xdigit($prefixes[0])) {
                 throw new \InvalidArgumentException("Invalid private prefix");
             }

--- a/src/Key/Deterministic/Slip132/PrefixRegistry.php
+++ b/src/Key/Deterministic/Slip132/PrefixRegistry.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\Deterministic\Slip132;
+
+class PrefixRegistry
+{
+    /**
+     * @var array
+     */
+    private $registry = [];
+
+    /**
+     * PrefixRegistry constructor.
+     * @param array $registry
+     */
+    public function __construct(array $registry)
+    {
+        foreach ($registry as $scriptType => $prefixes) {
+            if (!is_string($scriptType)) {
+                throw new \InvalidArgumentException("Expecting script type as key");
+            }
+            if (count($prefixes) !== 2) {
+                throw new \InvalidArgumentException("Expecting two BIP32 prefixes");
+            }
+            if (strlen($prefixes[0]) !== 8 || !ctype_xdigit($prefixes[0])) {
+                throw new \InvalidArgumentException("Invalid private prefix");
+            }
+            if (strlen($prefixes[1]) !== 8 || !ctype_xdigit($prefixes[1])) {
+                throw new \InvalidArgumentException("Invalid public prefix");
+            }
+        }
+        $this->registry = $registry;
+    }
+
+    /**
+     * @param string $scriptType
+     * @return array
+     */
+    public function getPrefixes($scriptType)
+    {
+        if (!array_key_exists($scriptType, $this->registry)) {
+            throw new \InvalidArgumentException("Unknown script type");
+        }
+        return $this->registry[$scriptType];
+    }
+}

--- a/src/Key/Deterministic/Slip132/Slip132.php
+++ b/src/Key/Deterministic/Slip132/Slip132.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\Deterministic\Slip132;
+
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\ScriptPrefix;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+
+class Slip132
+{
+    /**
+     * @var KeyToScriptHelper
+     */
+    private $helper;
+
+    /**
+     * Slip132PrefixRegistry constructor.
+
+     * @param KeyToScriptHelper $helper
+     */
+    public function __construct(KeyToScriptHelper $helper = null)
+    {
+        $this->helper = $helper ?: new KeyToScriptHelper(Bitcoin::getEcAdapter());
+    }
+
+    /**
+     * @param PrefixRegistry $registry
+     * @param ScriptDataFactory $factory
+     * @return ScriptPrefix
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    private function loadPrefix(PrefixRegistry $registry, ScriptDataFactory $factory)
+    {
+        list ($private, $public) = $registry->getPrefixes($factory->getScriptType());
+        return new ScriptPrefix($factory, $private, $public);
+    }
+
+    /**
+     * xpub on bitcoin
+     * @param PrefixRegistry $registry
+     * @return ScriptPrefix
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function p2pkh(PrefixRegistry $registry)
+    {
+        return $this->loadPrefix($registry, $this->helper->getP2pkhFactory());
+    }
+
+    /**
+     * xpub on bitcoin
+     * @param PrefixRegistry $registry
+     * @return ScriptPrefix
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function p2shP2pkh(PrefixRegistry $registry)
+    {
+        return $this->loadPrefix($registry, $this->helper->getP2shFactory($this->helper->getP2pkhFactory()));
+    }
+
+    /**
+     * ypub on bitcoin
+     * @param PrefixRegistry $registry
+     * @return ScriptPrefix
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function p2shP2wpkh(PrefixRegistry $registry)
+    {
+        return $this->loadPrefix($registry, $this->helper->getP2shFactory($this->helper->getP2wpkhFactory()));
+    }
+
+    /**
+     * Ypub on bitcoin
+     * @param PrefixRegistry $registry
+     * @return ScriptPrefix
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function p2shP2wshP2pkh(PrefixRegistry $registry)
+    {
+        return $this->loadPrefix($registry, $this->helper->getP2shP2wshFactory($this->helper->getP2pkhFactory()));
+    }
+
+    /**
+     * zpub on bitcoin
+     * @param PrefixRegistry $registry
+     * @return ScriptPrefix
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function p2wpkh(PrefixRegistry $registry)
+    {
+        return $this->loadPrefix($registry, $this->helper->getP2wpkhFactory());
+    }
+
+    /**
+     * Zpub on bitcoin
+     * @param PrefixRegistry $registry
+     * @return ScriptPrefix
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function p2wshP2pkh(PrefixRegistry $registry)
+    {
+        return $this->loadPrefix($registry, $this->helper->getP2wshFactory($this->helper->getP2pkhFactory()));
+    }
+}

--- a/src/Key/KeyToScript/Decorator/P2shP2wshScriptDecorator.php
+++ b/src/Key/KeyToScript/Decorator/P2shP2wshScriptDecorator.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Decorator;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Script\P2shScript;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Script\WitnessScript;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+
+class P2shP2wshScriptDecorator extends ScriptHashDecorator
+{
+    /**
+     * @var string[]
+     */
+    protected $allowedScriptTypes = [
+        ScriptType::P2PKH,
+        ScriptType::P2PK,
+    ];
+
+    /**
+     * @var string
+     */
+    protected $decorateType = "scripthash|witness_v0_scripthash";
+
+    /**
+     * @param KeyInterface $key
+     * @return ScriptAndSignData
+     * @throws \BitWasp\Bitcoin\Exceptions\P2shScriptException
+     * @throws \BitWasp\Bitcoin\Exceptions\WitnessScriptException
+     */
+    public function convertKey(KeyInterface $key)
+    {
+        $witnessScript = new WitnessScript($this->scriptDataFactory->convertKey($key)->getScriptPubKey());
+        $redeemScript = new P2shScript($witnessScript);
+        return new ScriptAndSignData(
+            $redeemScript->getOutputScript(),
+            (new SignData())
+                ->p2sh($redeemScript)
+                ->p2wsh($witnessScript)
+        );
+    }
+}

--- a/src/Key/KeyToScript/Decorator/P2shScriptDecorator.php
+++ b/src/Key/KeyToScript/Decorator/P2shScriptDecorator.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Decorator;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Script\P2shScript;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+
+class P2shScriptDecorator extends ScriptHashDecorator
+{
+    /**
+     * @var array
+     */
+    protected $allowedScriptTypes = [
+        ScriptType::P2PKH,
+        ScriptType::P2PK,
+        ScriptType::P2WKH,
+    ];
+
+    /**
+     * @var string
+     */
+    protected $decorateType = ScriptType::P2SH;
+
+    /**
+     * @param KeyInterface $key
+     * @return ScriptAndSignData
+     * @throws \BitWasp\Bitcoin\Exceptions\P2shScriptException
+     */
+    public function convertKey(KeyInterface $key)
+    {
+        $redeemScript = new P2shScript($this->scriptDataFactory->convertKey($key)->getScriptPubKey());
+        return new ScriptAndSignData(
+            $redeemScript->getOutputScript(),
+            (new SignData())
+                ->p2sh($redeemScript)
+        );
+    }
+}

--- a/src/Key/KeyToScript/Decorator/P2wshScriptDecorator.php
+++ b/src/Key/KeyToScript/Decorator/P2wshScriptDecorator.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Decorator;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Script\WitnessScript;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+
+class P2wshScriptDecorator extends ScriptHashDecorator
+{
+    /**
+     * @var array
+     */
+    protected $allowedScriptTypes = [
+        ScriptType::P2PKH,
+        ScriptType::P2PK,
+    ];
+
+    /**
+     * @var string
+     */
+    protected $decorateType = ScriptType::P2WSH;
+
+    /**
+     * @param KeyInterface $key
+     * @return ScriptAndSignData
+     * @throws \BitWasp\Bitcoin\Exceptions\WitnessScriptException
+     */
+    public function convertKey(KeyInterface $key)
+    {
+        $witnessScript = new WitnessScript($this->scriptDataFactory->convertKey($key)->getScriptPubKey());
+        return new ScriptAndSignData(
+            $witnessScript->getOutputScript(),
+            (new SignData())
+                ->p2wsh($witnessScript)
+        );
+    }
+}

--- a/src/Key/KeyToScript/Decorator/ScriptHashDecorator.php
+++ b/src/Key/KeyToScript/Decorator/ScriptHashDecorator.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Decorator;
+
+use BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\KeyToScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptDataFactory;
+
+abstract class ScriptHashDecorator extends ScriptDataFactory
+{
+    /**
+     * @var KeyToScriptDataFactory
+     */
+    protected $scriptDataFactory;
+
+    /**
+     * @var string[]
+     */
+    protected $allowedScriptTypes = [];
+
+    /**
+     * @var string
+     */
+    protected $decorateType;
+
+    /**
+     * ScriptHashDecorator constructor.
+     * @param KeyToScriptDataFactory $scriptDataFactory
+     * @throws DisallowedScriptDataFactoryException
+     */
+    public function __construct(KeyToScriptDataFactory $scriptDataFactory)
+    {
+        if (!in_array($scriptDataFactory->getScriptType(), $this->allowedScriptTypes, true)) {
+            throw new DisallowedScriptDataFactoryException("Unsupported key-to-script factory for this script-hash type.");
+        }
+        $this->scriptDataFactory = $scriptDataFactory;
+    }
+
+    /**
+     * @return string
+     */
+    public function getScriptType()
+    {
+        return sprintf("%s|%s", $this->decorateType, $this->scriptDataFactory->getScriptType());
+    }
+}

--- a/src/Key/KeyToScript/Factory/KeyToScriptDataFactory.php
+++ b/src/Key/KeyToScript/Factory/KeyToScriptDataFactory.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Factory;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptDataFactory;
+
+abstract class KeyToScriptDataFactory extends ScriptDataFactory
+{
+    /**
+     * @var PublicKeySerializerInterface
+     */
+    protected $pubKeySerializer;
+
+    /**
+     * KeyToP2PKScriptFactory constructor.
+     * @param PublicKeySerializerInterface|null $pubKeySerializer
+     */
+    public function __construct(PublicKeySerializerInterface $pubKeySerializer = null)
+    {
+        if (null === $pubKeySerializer) {
+            $pubKeySerializer = EcSerializer::getSerializer(PublicKeySerializerInterface::class, true);
+        }
+
+        $this->pubKeySerializer = $pubKeySerializer;
+    }
+
+    /**
+     * @param PublicKeyInterface $publicKey
+     * @return ScriptAndSignData
+     */
+    abstract protected function convertKeyToScriptData(PublicKeyInterface $publicKey);
+
+    /**
+     * @param KeyInterface $key
+     * @return ScriptAndSignData
+     */
+    public function convertKey(KeyInterface $key)
+    {
+        if ($key->isPrivate()) {
+            /** @var PrivateKeyInterface $key */
+            $key = $key->getPublicKey();
+        }
+        /** @var PublicKeyInterface $key */
+        return $this->convertKeyToScriptData($key);
+    }
+}

--- a/src/Key/KeyToScript/Factory/P2pkScriptDataFactory.php
+++ b/src/Key/KeyToScript/Factory/P2pkScriptDataFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Factory;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+
+class P2pkScriptDataFactory extends KeyToScriptDataFactory
+{
+    /**
+     * @return string
+     */
+    public function getScriptType()
+    {
+        return ScriptType::P2PK;
+    }
+
+    /**
+     * @param PublicKeyInterface $publicKey
+     * @return ScriptAndSignData
+     */
+    protected function convertKeyToScriptData(PublicKeyInterface $publicKey)
+    {
+        return new ScriptAndSignData(
+            ScriptFactory::scriptPubKey()->p2pk($publicKey),
+            new SignData()
+        );
+    }
+}

--- a/src/Key/KeyToScript/Factory/P2pkhScriptDataFactory.php
+++ b/src/Key/KeyToScript/Factory/P2pkhScriptDataFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Factory;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+
+class P2pkhScriptDataFactory extends KeyToScriptDataFactory
+{
+    /**
+     * @return string
+     */
+    public function getScriptType()
+    {
+        return ScriptType::P2PKH;
+    }
+
+    /**
+     * @param PublicKeyInterface $publicKey
+     * @return ScriptAndSignData
+     */
+    protected function convertKeyToScriptData(PublicKeyInterface $publicKey)
+    {
+        return new ScriptAndSignData(
+            ScriptFactory::scriptPubKey()->p2pkh($publicKey->getPubKeyHash($this->pubKeySerializer)),
+            new SignData()
+        );
+    }
+}

--- a/src/Key/KeyToScript/Factory/P2wpkhScriptDataFactory.php
+++ b/src/Key/KeyToScript/Factory/P2wpkhScriptDataFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript\Factory;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+
+class P2wpkhScriptDataFactory extends KeyToScriptDataFactory
+{
+    /**
+     * @return string
+     */
+    public function getScriptType()
+    {
+        return ScriptType::P2WKH;
+    }
+
+    /**
+     * @param PublicKeyInterface $publicKey
+     * @return ScriptAndSignData
+     */
+    protected function convertKeyToScriptData(PublicKeyInterface $publicKey)
+    {
+        return new ScriptAndSignData(
+            ScriptFactory::scriptPubKey()->p2wkh($publicKey->getPubKeyHash($this->pubKeySerializer)),
+            new SignData()
+        );
+    }
+}

--- a/src/Key/KeyToScript/KeyToScriptHelper.php
+++ b/src/Key/KeyToScript/KeyToScriptHelper.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shP2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\KeyToScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class KeyToScriptHelper
+{
+
+    /**
+     * @var mixed
+     */
+    private $cache = [];
+
+    /**
+     * @var PublicKeySerializerInterface
+     */
+    private $pubKeySer;
+
+    /**
+     * Slip132PrefixRegistry constructor.
+     * @param EcAdapterInterface $ecAdapter
+     */
+    public function __construct(EcAdapterInterface $ecAdapter)
+    {
+        $this->pubKeySer = EcSerializer::getSerializer(PublicKeySerializerInterface::class, true, $ecAdapter);
+    }
+
+    /**
+     * @param array ...$scriptPaths
+     * @return string
+     */
+    private function makeScriptKey(... $scriptPaths)
+    {
+        return implode("|", $scriptPaths);
+    }
+
+    /**
+     * @return P2pkhScriptDataFactory
+     */
+    public function getP2pkhFactory()
+    {
+        $key = ScriptType::P2PKH;
+        if (!array_key_exists($key, $this->cache)) {
+            $this->cache[$key] = new P2pkhScriptDataFactory($this->pubKeySer);
+        }
+        return $this->cache[$key];
+    }
+
+    /**
+     * @return P2wpkhScriptDataFactory
+     */
+    public function getP2wpkhFactory()
+    {
+        $key = ScriptType::P2WKH;
+        if (!array_key_exists($key, $this->cache)) {
+            $this->cache[$key] = new P2wpkhScriptDataFactory($this->pubKeySer);
+        }
+        return $this->cache[$key];
+    }
+
+    /**
+     * @param KeyToScriptDataFactory $scriptFactory
+     * @return P2shScriptDecorator
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     */
+    public function getP2shFactory(KeyToScriptDataFactory $scriptFactory)
+    {
+        $key = $this->makeScriptKey(ScriptType::P2SH, $scriptFactory->getScriptType());
+        if (!array_key_exists($key, $this->cache)) {
+            $this->cache[$key] = new P2shScriptDecorator($scriptFactory);
+        }
+        return $this->cache[$key];
+    }
+
+    /**
+     * @param KeyToScriptDataFactory $scriptFactory
+     * @return P2wshScriptDecorator
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     */
+    public function getP2wshFactory(KeyToScriptDataFactory $scriptFactory)
+    {
+        $key = $this->makeScriptKey(ScriptType::P2WSH, $scriptFactory->getScriptType());
+        if (!array_key_exists($key, $this->cache)) {
+            $this->cache[$key] = new P2wshScriptDecorator($scriptFactory);
+        }
+        return $this->cache[$key];
+    }
+
+    /**
+     * @param KeyToScriptDataFactory $scriptFactory
+     * @return P2shP2wshScriptDecorator
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     */
+    public function getP2shP2wshFactory(KeyToScriptDataFactory $scriptFactory)
+    {
+        $key = $this->makeScriptKey(ScriptType::P2SH, ScriptType::P2WSH, $scriptFactory->getScriptType());
+        if (!array_key_exists($key, $this->cache)) {
+            $this->cache[$key] = new P2shP2wshScriptDecorator($scriptFactory);
+        }
+        return $this->cache[$key];
+    }
+}

--- a/src/Key/KeyToScript/ScriptAndSignData.php
+++ b/src/Key/KeyToScript/ScriptAndSignData.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript;
+
+use BitWasp\Bitcoin\Address\BaseAddressCreator;
+use BitWasp\Bitcoin\Script\ScriptInterface;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+
+class ScriptAndSignData
+{
+    /**
+     * @var ScriptInterface
+     */
+    private $scriptPubKey;
+
+    /**
+     * @var SignData
+     */
+    private $signData;
+
+    /**
+     * ScriptAndSignData constructor.
+     * @param ScriptInterface $scriptPubKey
+     * @param SignData $signData
+     */
+    public function __construct(ScriptInterface $scriptPubKey, SignData $signData)
+    {
+        $this->scriptPubKey = $scriptPubKey;
+        $this->signData = $signData;
+    }
+
+    /**
+     * @return ScriptInterface
+     */
+    public function getScriptPubKey()
+    {
+        return $this->scriptPubKey;
+    }
+
+    /**
+     * @param BaseAddressCreator $creator
+     * @return \BitWasp\Bitcoin\Address\Address
+     */
+    public function getAddress(BaseAddressCreator $creator)
+    {
+        return $creator->fromOutputScript($this->scriptPubKey);
+    }
+
+    /**
+     * @return SignData
+     */
+    public function getSignData()
+    {
+        return $this->signData;
+    }
+}

--- a/src/Key/KeyToScript/ScriptDataFactory.php
+++ b/src/Key/KeyToScript/ScriptDataFactory.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace BitWasp\Bitcoin\Key\KeyToScript;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
+
+abstract class ScriptDataFactory
+{
+    /**
+     * @param KeyInterface $key
+     * @return ScriptAndSignData
+     */
+    abstract public function convertKey(KeyInterface $key);
+
+    /**
+     * @return string
+     */
+    abstract public function getScriptType();
+}

--- a/src/Network/Slip132/BitcoinRegistry.php
+++ b/src/Network/Slip132/BitcoinRegistry.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Slip132;
+
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\PrefixRegistry;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class BitcoinRegistry extends PrefixRegistry
+{
+    public function __construct()
+    {
+        $map = [];
+        foreach ([
+                     [["0488ade4", "0488b21e"], /* xpub */ [ScriptType::P2PKH]],
+                     [["0488ade4", "0488b21e"], /* xpub */ [ScriptType::P2SH, ScriptType::P2PKH]],
+                     [["049d7878", "049d7cb2"], /* ypub */ [ScriptType::P2SH, ScriptType::P2WKH]],
+                     [["0295b005", "0295b43f"], /* Ypub */ [ScriptType::P2SH, ScriptType::P2WSH, ScriptType::P2PKH]],
+                     [["04b2430c", "04b24746"], /* zpub */ [ScriptType::P2WKH]],
+                     [["02aa7a99", "02aa7ed3"], /* Zpub */ [ScriptType::P2WSH, ScriptType::P2PKH]],
+                 ] as $row) {
+            list ($prefixList, $scriptType) = $row;
+            $type = implode("|", $scriptType);
+            $map[$type] = $prefixList;
+        }
+
+        parent::__construct($map);
+    }
+}

--- a/src/Network/Slip132/BitcoinRegistry.php
+++ b/src/Network/Slip132/BitcoinRegistry.php
@@ -11,6 +11,7 @@ class BitcoinRegistry extends PrefixRegistry
     {
         $map = [];
         foreach ([
+                     // private, public
                      [["0488ade4", "0488b21e"], /* xpub */ [ScriptType::P2PKH]],
                      [["0488ade4", "0488b21e"], /* xpub */ [ScriptType::P2SH, ScriptType::P2PKH]],
                      [["049d7878", "049d7cb2"], /* ypub */ [ScriptType::P2SH, ScriptType::P2WKH]],

--- a/src/Network/Slip132/BitcoinTestnetRegistry.php
+++ b/src/Network/Slip132/BitcoinTestnetRegistry.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Slip132;
+
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\PrefixRegistry;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class BitcoinTestnetRegistry extends PrefixRegistry
+{
+    public function __construct()
+    {
+        $map = [];
+        foreach ([
+                     // private, public
+                     [["04358394", "043587cf"], /* xpub */ [ScriptType::P2PKH]],
+                     [["04358394", "043587cf"], /* xpub */ [ScriptType::P2SH, ScriptType::P2PKH]],
+                     [["044a4e28", "044a5262"], /* ypub */ [ScriptType::P2SH, ScriptType::P2WKH]],
+                     [["045f18bc", "045f1cf6"], /* zpub */ [ScriptType::P2WKH]],
+                     [["02575048", "02575483"], /* Zpub */ [ScriptType::P2WSH, ScriptType::P2PKH]],
+                 ] as $row) {
+            list ($prefixList, $scriptType) = $row;
+            $type = implode("|", $scriptType);
+            $map[$type] = $prefixList;
+        }
+
+        parent::__construct($map);
+    }
+}

--- a/src/Script/ScriptInfo/Multisig.php
+++ b/src/Script/ScriptInfo/Multisig.php
@@ -40,7 +40,7 @@ class Multisig
     public function __construct(ScriptInterface $script, PublicKeySerializerInterface $pubKeySerializer = null)
     {
         if (null === $pubKeySerializer) {
-            $pubKeySerializer = EcSerializer::getSerializer(PublicKeySerializerInterface::class, false, Bitcoin::getEcAdapter());
+            $pubKeySerializer = EcSerializer::getSerializer(PublicKeySerializerInterface::class, true, Bitcoin::getEcAdapter());
         }
 
         $parse = $script->getScriptParser()->decode();

--- a/src/Serializer/Key/HierarchicalKey/RawExtendedKeySerializer.php
+++ b/src/Serializer/Key/HierarchicalKey/RawExtendedKeySerializer.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace BitWasp\Bitcoin\Serializer\Key\HierarchicalKey;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Serializer\Types;
+use BitWasp\Buffertools\Buffer;
+use BitWasp\Buffertools\BufferInterface;
+use BitWasp\Buffertools\Exceptions\ParserOutOfRange;
+use BitWasp\Buffertools\Parser;
+
+class RawExtendedKeySerializer
+{
+    /**
+     * @var EcAdapterInterface
+     */
+    private $ecAdapter;
+
+    /**
+     * @var \BitWasp\Buffertools\Types\ByteString
+     */
+    private $bytestring4;
+
+    /**
+     * @var \BitWasp\Buffertools\Types\Uint8
+     */
+    private $uint8;
+
+    /**
+     * @var \BitWasp\Buffertools\Types\Uint32
+     */
+    private $uint32;
+
+    /**
+     * @var \BitWasp\Buffertools\Types\ByteString
+     */
+    private $bytestring32;
+
+    /**
+     * @var \BitWasp\Buffertools\Types\ByteString
+     */
+    private $bytestring33;
+
+    /**
+     * RawExtendedKeySerializer constructor.
+     * @param EcAdapterInterface $ecAdapter
+     */
+    public function __construct(EcAdapterInterface $ecAdapter)
+    {
+        $this->ecAdapter = $ecAdapter;
+        $this->bytestring4 = Types::bytestring(4);
+        $this->uint8 = Types::uint8();
+        $this->uint32 = Types::uint32();
+        $this->bytestring32 = Types::bytestring(32);
+        $this->bytestring33 = Types::bytestring(33);
+    }
+
+    /**
+     * @param RawKeyParams $keyParams
+     * @return BufferInterface
+     * @throws \Exception
+     */
+    public function serialize(RawKeyParams $keyParams)
+    {
+        return new Buffer(
+            pack("H*", $keyParams->getPrefix()) .
+            $this->uint8->write($keyParams->getDepth()) .
+            $this->uint32->write($keyParams->getParentFingerprint()) .
+            $this->uint32->write($keyParams->getSequence()) .
+            $this->bytestring32->write($keyParams->getChainCode()) .
+            $this->bytestring33->write($keyParams->getKeyData())
+        );
+    }
+
+    /**
+     * @param Parser $parser
+     * @return RawKeyParams
+     * @throws ParserOutOfRange
+     */
+    public function fromParser(Parser $parser)
+    {
+        try {
+            return new RawKeyParams(
+                $this->bytestring4->read($parser)->getHex(),
+                $this->uint8->read($parser),
+                $this->uint32->read($parser),
+                $this->uint32->read($parser),
+                $this->bytestring32->read($parser),
+                $this->bytestring33->read($parser)
+            );
+        } catch (ParserOutOfRange $e) {
+            throw new ParserOutOfRange('Failed to extract HierarchicalKey from parser');
+        }
+    }
+}

--- a/src/Serializer/Key/HierarchicalKey/RawKeyParams.php
+++ b/src/Serializer/Key/HierarchicalKey/RawKeyParams.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace BitWasp\Bitcoin\Serializer\Key\HierarchicalKey;
+
+use BitWasp\Buffertools\BufferInterface;
+
+class RawKeyParams
+{
+    /**
+     * @var string
+     */
+    private $prefix;
+
+    /**
+     * @var int
+     */
+    private $depth;
+
+    /**
+     * @var int
+     */
+    private $parentFpr;
+
+    /**
+     * @var int
+     */
+    private $sequence;
+
+    /**
+     * @var BufferInterface
+     */
+    private $chainCode;
+
+    /**
+     * @var BufferInterface
+     */
+    private $keyData;
+
+    /**
+     * RawKeyParams constructor.
+     * @param string $prefix
+     * @param int $depth
+     * @param int $parentFingerprint
+     * @param int $sequence
+     * @param BufferInterface $chainCode
+     * @param BufferInterface $keyData
+     */
+    public function __construct($prefix, $depth, $parentFingerprint, $sequence, BufferInterface $chainCode, BufferInterface $keyData)
+    {
+        $this->prefix = $prefix;
+        $this->depth = $depth;
+        $this->parentFpr = $parentFingerprint;
+        $this->sequence = $sequence;
+        $this->chainCode = $chainCode;
+        $this->keyData = $keyData;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPrefix()
+    {
+        return $this->prefix;
+    }
+
+    /**
+     * @return int
+     */
+    public function getDepth()
+    {
+        return $this->depth;
+    }
+
+    /**
+     * @return int
+     */
+    public function getParentFingerprint()
+    {
+        return $this->parentFpr;
+    }
+
+    /**
+     * @return int
+     */
+    public function getSequence()
+    {
+        return $this->sequence;
+    }
+
+    /**
+     * @return BufferInterface
+     */
+    public function getChainCode()
+    {
+        return $this->chainCode;
+    }
+
+    /**
+     * @return BufferInterface
+     */
+    public function getKeyData()
+    {
+        return $this->keyData;
+    }
+}

--- a/tests/Key/Deterministic/Bip44KeyAndAddressTest.php
+++ b/tests/Key/Deterministic/Bip44KeyAndAddressTest.php
@@ -138,7 +138,6 @@ class Bip44KeyAndAddressTest extends AbstractTestCase
             new ExtendedKeySerializer($adapter, $config)
         );
 
-        echo $ent->getHex().PHP_EOL;
         $root = HierarchicalKeyFactory::fromEntropy($ent, $adapter, $prefix->getScriptDataFactory());
         $account = $root->derivePath("44'/0'/0'");
 

--- a/tests/Key/Deterministic/Bip44KeyAndAddressTest.php
+++ b/tests/Key/Deterministic/Bip44KeyAndAddressTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic;
+
+use BitWasp\Bitcoin\Address\AddressCreator;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Mnemonic\Bip39\Bip39SeedGenerator;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class Bip44KeyAndAddressTest extends AbstractTestCase
+{
+    /**
+     * The explicitly provided factory is P2PKH, so that
+     * interacts nicely with an extended key serializer which
+     * has no config. Networks p2pkh prefixes correspond to the
+     * hd pub / priv bytes.
+     *
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @throws \Exception
+     */
+    public function testBip44WithExplicitFactory(EcAdapterInterface $adapter)
+    {
+        // This test shows that when we specify the P2PKH
+        // ScriptDataFactory, the traditional serializer
+        // still works, because the prefixes are actually
+        // those from the Networks hdpub / hdpriv bytes
+
+        $addrCreator = new AddressCreator();
+        $bip39 = new Bip39SeedGenerator();
+        $btc = NetworkFactory::bitcoin();
+        $registry = new BitcoinRegistry();
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $prefix = $slip132->p2pkh($registry);
+
+        $ent = $bip39->getSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+
+        $root = HierarchicalKeyFactory::fromEntropy($ent, $adapter, $prefix->getScriptDataFactory());
+
+        $account = $root->derivePath("44'/0'/0'");
+
+        $this->assertEquals(
+            "xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb",
+            $account->toExtendedPrivateKey($btc)
+        );
+
+        $this->assertEquals(
+            "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj",
+            $account->toExtendedPublicKey($btc)
+        );
+
+        $firstAddress = $account->derivePath("0/0");
+
+        $this->assertEquals(
+            "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA",
+            $firstAddress->getAddress($addrCreator)->getAddress($btc)
+        );
+    }
+
+    /**
+     * The default factory is P2PKH, so serializer without a GlobalPrefixConfig
+     * can serialize this fine. This necessary to adhere to old behaviour.
+     *
+     * @see https://github.com/satoshilabs/slips/blob/master/slip-0132.md#bitcoin-test-vectors
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \Exception
+     */
+    public function testBip44WithDefaultFactory(EcAdapterInterface $adapter)
+    {
+        $addrCreator = new AddressCreator();
+        $bip39 = new Bip39SeedGenerator();
+        $btc = NetworkFactory::bitcoin();
+
+        $ent = $bip39->getSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+
+        $root = HierarchicalKeyFactory::fromEntropy($ent, $adapter);
+
+        $account = $root->derivePath("44'/0'/0'");
+
+        $this->assertEquals(
+            "xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb",
+            $account->toExtendedPrivateKey($btc)
+        );
+
+        $this->assertEquals(
+            "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj",
+            $account->toExtendedPublicKey($btc)
+        );
+
+        $firstAddress = $account->derivePath("0/0");
+
+        $this->assertEquals(
+            "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA",
+            $firstAddress->getAddress($addrCreator)->getAddress($btc)
+        );
+    }
+
+    /**
+     * Using the new semantics entirely: Initialize with
+     * a factory (though default), then relying on a
+     * serializer with a properly initialized config to allow
+     * serializing our key.
+     *
+     * @see https://github.com/satoshilabs/slips/blob/master/slip-0132.md#bitcoin-test-vectors
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \Exception
+     */
+    public function testBip44WithConfig(EcAdapterInterface $adapter)
+    {
+        $addrCreator = new AddressCreator();
+        $bip39 = new Bip39SeedGenerator();
+        $btc = NetworkFactory::bitcoin();
+        $registry = new BitcoinRegistry();
+
+        $ent = $bip39->getSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $prefix = $slip132->p2pkh($registry);
+
+        $config = new GlobalPrefixConfig([
+            new NetworkConfig($btc, [
+                $prefix,
+            ])
+        ]);
+        $serializer = new Base58ExtendedKeySerializer(
+            new ExtendedKeySerializer($adapter, $config)
+        );
+
+        echo $ent->getHex().PHP_EOL;
+        $root = HierarchicalKeyFactory::fromEntropy($ent, $adapter, $prefix->getScriptDataFactory());
+        $account = $root->derivePath("44'/0'/0'");
+
+        $this->assertEquals(
+            "xprv9xpXFhFpqdQK3TmytPBqXtGSwS3DLjojFhTGht8gwAAii8py5X6pxeBnQ6ehJiyJ6nDjWGJfZ95WxByFXVkDxHXrqu53WCRGypk2ttuqncb",
+            $serializer->serialize($btc, $account)
+        );
+
+        $this->assertEquals(
+            "xpub6BosfCnifzxcFwrSzQiqu2DBVTshkCXacvNsWGYJVVhhawA7d4R5WSWGFNbi8Aw6ZRc1brxMyWMzG3DSSSSoekkudhUd9yLb6qx39T9nMdj",
+            $serializer->serialize($btc, $account->withoutPrivateKey())
+        );
+
+        $firstAddress = $account->derivePath("0/0");
+
+        $this->assertEquals(
+            "1LqBGSKuX5yYUonjxT5qGfpUsXKYYWeabA",
+            $firstAddress->getAddress($addrCreator)->getAddress($btc)
+        );
+    }
+}

--- a/tests/Key/Deterministic/Bip49Test.php
+++ b/tests/Key/Deterministic/Bip49Test.php
@@ -51,16 +51,6 @@ class Bip49Test extends AbstractTestCase
             "03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f",
             $firstKey->getPrivateKey()->getPublicKey()->getHex()
         );
-
-        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
-        $registry = new BitcoinRegistry();
-        $prefix = $slip132->p2shP2wpkh($registry);
-        $p2shP2wpkhKey = $firstKey->withScriptFactory($prefix->getScriptDataFactory());
-        $address = $p2shP2wpkhKey->getAddress(new AddressCreator());
-        $this->assertEquals(
-            "2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2",
-            $address->getAddress($tbtc)
-        );
     }
 
     /**

--- a/tests/Key/Deterministic/Bip49Test.php
+++ b/tests/Key/Deterministic/Bip49Test.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic;
+
+use BitWasp\Bitcoin\Address\AddressCreator;
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Mnemonic\Bip39\Bip39SeedGenerator;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class Bip49Test extends AbstractTestCase
+{
+    public function testBip49WithoutPrefix()
+    {
+        $bip39 = new Bip39SeedGenerator();
+        $adapter = Bitcoin::getEcAdapter();
+        $tbtc = NetworkFactory::bitcoinTestnet();
+
+        $ent = $bip39->getSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+
+        $root = HierarchicalKeyFactory::fromEntropy($ent, $adapter);
+        $this->assertEquals(
+            "tprv8ZgxMBicQKsPe5YMU9gHen4Ez3ApihUfykaqUorj9t6FDqy3nP6eoXiAo2ssvpAjoLroQxHqr3R5nE3a5dU3DHTjTgJDd7zrbniJr6nrCzd",
+            $root->toExtendedPrivateKey($tbtc)
+        );
+
+        $account = $root->derivePath("49'/1'/0'");
+
+        $this->assertEquals(
+            "tprv8gRrNu65W2Msef2BdBSUgFdRTGzC8EwVXnV7UGS3faeXtuMVtGfEdidVeGbThs4ELEoayCAzZQ4uUji9DUiAs7erdVskqju7hrBcDvDsdbY",
+            $account->toExtendedPrivateKey($tbtc)
+        );
+
+        $firstKey = $account->derivePath("0/0");
+
+        $this->assertEquals(
+            "cULrpoZGXiuC19Uhvykx7NugygA3k86b3hmdCeyvHYQZSxojGyXJ",
+            $firstKey->getPrivateKey()->toWif($tbtc)
+        );
+
+        $this->assertEquals(
+            "03a1af804ac108a8a51782198c2d034b28bf90c8803f5a53f76276fa69a4eae77f",
+            $firstKey->getPrivateKey()->getPublicKey()->getHex()
+        );
+
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2shP2wpkh($registry);
+        $p2shP2wpkhKey = $firstKey->withScriptFactory($prefix->getScriptDataFactory());
+        $address = $p2shP2wpkhKey->getAddress(new AddressCreator());
+        $this->assertEquals(
+            "2Mww8dCYPUpKHofjgcXcBCEGmniw9CoaiD2",
+            $address->getAddress($tbtc)
+        );
+    }
+
+    /**
+     * @see https://github.com/satoshilabs/slips/blob/master/slip-0132.md#bitcoin-test-vectors
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @throws \Exception
+     */
+    public function testBip49WithHdPrefix(EcAdapterInterface $adapter)
+    {
+        $addrCreator = new AddressCreator();
+        $bip39 = new Bip39SeedGenerator();
+        $btc = NetworkFactory::bitcoin();
+
+        $slip132Registry = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132Registry->p2shP2wpkh($registry);
+
+        $ent = $bip39->getSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+
+        $root = HierarchicalKeyFactory::fromEntropy($ent, $adapter, $prefix->getScriptDataFactory());
+
+        $config = new GlobalPrefixConfig([
+            new NetworkConfig($btc, [
+                $prefix
+            ])
+        ]);
+        $serializer = new Base58ExtendedKeySerializer(
+            new ExtendedKeySerializer($adapter, $config)
+        );
+        $account = $root->derivePath("49'/0'/0'");
+
+        $this->assertEquals(
+            "yprvAHwhK6RbpuS3dgCYHM5jc2ZvEKd7Bi61u9FVhYMpgMSuZS613T1xxQeKTffhrHY79hZ5PsskBjcc6C2V7DrnsMsNaGDaWev3GLRQRgV7hxF",
+            $serializer->serialize($btc, $account)
+        );
+
+        $this->assertEquals(
+            "ypub6Ww3ibxVfGzLrAH1PNcjyAWenMTbbAosGNB6VvmSEgytSER9azLDWCxoJwW7Ke7icmizBMXrzBx9979FfaHxHcrArf3zbeJJJUZPf663zsP",
+            $serializer->serialize($btc, $account->withoutPrivateKey())
+        );
+
+        $firstAddress = $account->derivePath("0/0");
+
+        $this->assertEquals(
+            "37VucYSaXLCAsxYyAPfbSi9eh4iEcbShgf",
+            $firstAddress->getAddress($addrCreator)->getAddress($btc)
+        );
+    }
+}

--- a/tests/Key/Deterministic/Bip84Test.php
+++ b/tests/Key/Deterministic/Bip84Test.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic;
+
+use BitWasp\Bitcoin\Address\AddressCreator;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Mnemonic\Bip39\Bip39SeedGenerator;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class Bip84Test extends AbstractTestCase
+{
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @throws \Exception
+     */
+    public function testBip84(EcAdapterInterface $adapter)
+    {
+        $btc = NetworkFactory::bitcoin();
+
+        $slip132Registry = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132Registry->p2wpkh($registry);
+        $p2wpkhScriptDataFactory = $prefix->getScriptDataFactory();
+
+        $globalConfig = new GlobalPrefixConfig([
+            new NetworkConfig($btc, [
+                $prefix,
+            ])
+        ]);
+
+        $ser = new Base58ExtendedKeySerializer(
+            new ExtendedKeySerializer($adapter, $globalConfig)
+        );
+
+        $bip39 = new Bip39SeedGenerator();
+        $ent = $bip39->getSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+
+        $addrFactory = new AddressCreator();
+
+        $rootPriv = HierarchicalKeyFactory::fromEntropy($ent, $adapter, $p2wpkhScriptDataFactory);
+        $this->assertEquals(
+            "zprvAWgYBBk7JR8Gjrh4UJQ2uJdG1r3WNRRfURiABBE3RvMXYSrRJL62XuezvGdPvG6GFBZduosCc1YP5wixPox7zhZLfiUm8aunE96BBa4Kei5",
+            $ser->serialize($btc, $rootPriv)
+        );
+
+        $rootPub = $rootPriv->withoutPrivateKey();
+        $this->assertEquals(
+            "zpub6jftahH18ngZxLmXaKw3GSZzZsszmt9WqedkyZdezFtWRFBZqsQH5hyUmb4pCEeZGmVfQuP5bedXTB8is6fTv19U1GQRyQUKQGUTzyHACMF",
+            $ser->serialize($btc, $rootPub)
+        );
+
+        $xprivKey = $rootPriv->derivePath("84'/0'/0'");
+        $this->assertEquals(
+            "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE",
+            $ser->serialize($btc, $xprivKey)
+        );
+
+        $xpubKey = $xprivKey->withoutPrivateKey();
+        $this->assertEquals(
+            "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+            $ser->serialize($btc, $xpubKey)
+        );
+
+        $account0_0_prv = $xprivKey->derivePath("0/0");
+        $this->assertEquals(
+            "KyZpNDKnfs94vbrwhJneDi77V6jF64PWPF8x5cdJb8ifgg2DUc9d",
+            $account0_0_prv->getPrivateKey()->toWif()
+        );
+        $this->assertEquals(
+            "0330d54fd0dd420a6e5f8d3624f5f3482cae350f79d5f0753bf5beef9c2d91af3c",
+            $account0_0_prv->getPublicKey()->getHex()
+        );
+        $this->assertEquals(
+            "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",
+            $account0_0_prv->getAddress($addrFactory)->getAddress()
+        );
+
+        $account0_1_prv = $xprivKey->derivePath("0/1");
+        $this->assertEquals(
+            "Kxpf5b8p3qX56DKEe5NqWbNUP9MnqoRFzZwHRtsFqhzuvUJsYZCy",
+            $account0_1_prv->getPrivateKey()->toWif()
+        );
+        $this->assertEquals(
+            "03e775fd51f0dfb8cd865d9ff1cca2a158cf651fe997fdc9fee9c1d3b5e995ea77",
+            $account0_1_prv->getPublicKey()->getHex()
+        );
+        $this->assertEquals(
+            "bc1qnjg0jd8228aq7egyzacy8cys3knf9xvrerkf9g",
+            $account0_1_prv->getAddress($addrFactory)->getAddress()
+        );
+
+        $account1_0_prv = $xprivKey->derivePath("1/0");
+        $this->assertEquals(
+            "KxuoxufJL5csa1Wieb2kp29VNdn92Us8CoaUG3aGtPtcF3AzeXvF",
+            $account1_0_prv->getPrivateKey()->toWif()
+        );
+        $this->assertEquals(
+            "03025324888e429ab8e3dbaf1f7802648b9cd01e9b418485c5fa4c1b9b5700e1a6",
+            $account1_0_prv->getPublicKey()->getHex()
+        );
+        $this->assertEquals(
+            "bc1q8c6fshw2dlwun7ekn9qwf37cu2rn755upcp6el",
+            $account1_0_prv->getAddress($addrFactory)->getAddress()
+        );
+    }
+
+    /**
+     * @see https://github.com/satoshilabs/slips/blob/master/slip-0132.md#bitcoin-test-vectors
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \Exception
+     */
+    public function testBip84WithConfig(EcAdapterInterface $adapter)
+    {
+        $addrCreator = new AddressCreator();
+        $bip39 = new Bip39SeedGenerator();
+        $btc = NetworkFactory::bitcoin();
+
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2wpkh($registry);
+        $ent = $bip39->getSeed("abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon abandon about");
+
+        $config = new GlobalPrefixConfig([
+            new NetworkConfig($btc, [
+                $prefix,
+            ])
+        ]);
+        $serializer = new Base58ExtendedKeySerializer(
+            new ExtendedKeySerializer($adapter, $config)
+        );
+
+        $root = HierarchicalKeyFactory::fromEntropy($ent, $adapter, $prefix->getScriptDataFactory());
+        $account = $root->derivePath("84'/0'/0'");
+
+        $this->assertEquals(
+            "zprvAdG4iTXWBoARxkkzNpNh8r6Qag3irQB8PzEMkAFeTRXxHpbF9z4QgEvBRmfvqWvGp42t42nvgGpNgYSJA9iefm1yYNZKEm7z6qUWCroSQnE",
+            $serializer->serialize($btc, $account)
+        );
+
+        $this->assertEquals(
+            "zpub6rFR7y4Q2AijBEqTUquhVz398htDFrtymD9xYYfG1m4wAcvPhXNfE3EfH1r1ADqtfSdVCToUG868RvUUkgDKf31mGDtKsAYz2oz2AGutZYs",
+            $serializer->serialize($btc, $account->withoutPrivateKey())
+        );
+
+        $firstAddress = $account->derivePath("0/0");
+
+        $this->assertEquals(
+            "bc1qcr8te4kr609gcawutmrza0j4xv80jy8z306fyu",
+            $firstAddress->getAddress($addrCreator)->getAddress($btc)
+        );
+    }
+}

--- a/tests/Key/Deterministic/HdPrefix/GlobalPrefixConfigTest.php
+++ b/tests/Key/Deterministic/HdPrefix/GlobalPrefixConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic\HdPrefix;
+
+use BitWasp\Bitcoin\Bitcoin;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class GlobalPrefixConfigTest extends AbstractTestCase
+{
+    public function testInvalidArray()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("expecting array of NetworkPrefixConfig");
+
+        new GlobalPrefixConfig([
+            Bitcoin::getNetwork()
+        ]);
+    }
+
+    public function testDuplicateNetworksNotAllowed()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("multiple configs for network");
+
+        new GlobalPrefixConfig([
+            new NetworkConfig(NetworkFactory::bitcoin(), []),
+            new NetworkConfig(NetworkFactory::bitcoin(), []),
+        ]);
+    }
+
+    public function testMultipleNetworksWorks()
+    {
+        $btc = NetworkFactory::bitcoin();
+        $btcConfig = new NetworkConfig($btc, []);
+        $tbtc = NetworkFactory::bitcoinTestnet();
+        $tbtcConfig = new NetworkConfig($tbtc, []);
+        $config = new GlobalPrefixConfig([
+            $btcConfig,
+            $tbtcConfig,
+        ]);
+
+        $this->assertSame($btcConfig, $config->getNetworkConfig($btc));
+        $this->assertSame($tbtcConfig, $config->getNetworkConfig($tbtc));
+    }
+
+    public function testUnknownNetwork()
+    {
+        $btc = NetworkFactory::bitcoin();
+        $btcConfig = new NetworkConfig($btc, []);
+        $tbtc = NetworkFactory::bitcoinTestnet();
+        $config = new GlobalPrefixConfig([
+            $btcConfig,
+        ]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Network not registered with GlobalHdPrefixConfig");
+
+        $config->getNetworkConfig($tbtc);
+    }
+}

--- a/tests/Key/Deterministic/HdPrefix/NetworkConfigTest.php
+++ b/tests/Key/Deterministic/HdPrefix/NetworkConfigTest.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic\HdPrefix;
+
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\ScriptPrefix;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class NetworkConfigTest extends AbstractTestCase
+{
+    public function testGetNetwork()
+    {
+        $network = NetworkFactory::bitcoin();
+        $config = new NetworkConfig($network, []);
+        $this->assertEquals($network, $config->getNetwork());
+    }
+
+    public function testGetConfigForUnknownScriptType()
+    {
+        $network = NetworkFactory::bitcoin();
+        $config = new NetworkConfig($network, []);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Script type not configured for network");
+
+        $config->getConfigForScriptType(ScriptType::P2WKH);
+    }
+
+    public function testGetConfigByScriptType()
+    {
+        $pubPrefix = "04b24746";
+        $privPrefix = "04b2430c";
+        $factory = new P2wpkhScriptDataFactory();
+        $prefix = new ScriptPrefix($factory, $privPrefix, $pubPrefix);
+
+        $network = NetworkFactory::bitcoin();
+        $config = new NetworkConfig($network, [$prefix]);
+
+        $prefixConfig = $config->getConfigForScriptType($factory->getScriptType());
+        $this->assertEquals($prefixConfig, $prefix);
+    }
+
+    public function testGetConfigByPrefix()
+    {
+        $factory = new P2wpkhScriptDataFactory();
+        $prefix = new ScriptPrefix($factory, "04b2430c", "04b24746");
+
+        $network = NetworkFactory::bitcoin();
+        $config = new NetworkConfig($network, [$prefix]);
+
+        $prefixConfig = $config->getConfigForPrefix($prefix->getPrivatePrefix());
+        $this->assertEquals($prefixConfig, $prefix);
+
+        $prefixConfig = $config->getConfigForPrefix($prefix->getPublicPrefix());
+        $this->assertEquals($prefixConfig, $prefix);
+    }
+
+    public function testGetConfigForUnknownPrefix()
+    {
+        $network = NetworkFactory::bitcoin();
+        $config = new NetworkConfig($network, []);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Prefix not configured for network");
+
+        $config->getConfigForPrefix("abababab");
+    }
+
+    public function testInvalidArrayIsRejected()
+    {
+        $network = NetworkFactory::bitcoin();
+
+        $pubPrefix = "04b24746";
+        $privPrefix = "04b2430c";
+        $factory = new P2wpkhScriptDataFactory();
+        $prefix = new ScriptPrefix($factory, $privPrefix, $pubPrefix);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("expecting array of NetworkPrefixConfig");
+
+        new NetworkConfig($network, [
+            $prefix,
+            $network
+        ]);
+    }
+
+    public function testCheckForPublicPrefixOverwriting()
+    {
+        $network = NetworkFactory::bitcoin();
+
+        $prefix1 = new ScriptPrefix(new P2wpkhScriptDataFactory(), "aaaaaaaa", "bbbbbbbb");
+        $prefix2 = new ScriptPrefix(new P2pkhScriptDataFactory(), "abababab", "bbbbbbbb");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("A BIP32 prefix for pubkeyhash conflicts with the public BIP32 prefix of witness_v0_keyhash");
+
+        new NetworkConfig($network, [
+            $prefix1,
+            $prefix2,
+        ]);
+    }
+
+    public function testCheckForPrivatePrefixOverwriting()
+    {
+        $network = NetworkFactory::bitcoin();
+
+        $prefix1 = new ScriptPrefix(new P2wpkhScriptDataFactory(), "aaaaaaaa", "ffffbbbb");
+        $prefix2 = new ScriptPrefix(new P2pkhScriptDataFactory(), "aaaaaaaa", "ddddbbbb");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("A BIP32 prefix for pubkeyhash conflicts with the private BIP32 prefix of witness_v0_keyhash");
+
+        new NetworkConfig($network, [
+            $prefix1,
+            $prefix2,
+        ]);
+    }
+
+    public function testCheckForScriptTypeOverwriting()
+    {
+        $network = NetworkFactory::bitcoin();
+
+        $prefix1 = new ScriptPrefix(new P2pkhScriptDataFactory(), "abcdef12", "34567890");
+        $prefix2 = new ScriptPrefix(new P2pkhScriptDataFactory(), "aaaaaaaa", "bbbbbbbb");
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage("The script type pubkeyhash has a conflict");
+
+        new NetworkConfig($network, [
+            $prefix1,
+            $prefix2,
+        ]);
+    }
+}

--- a/tests/Key/Deterministic/HdPrefix/ScriptPrefixTest.php
+++ b/tests/Key/Deterministic/HdPrefix/ScriptPrefixTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic\HdPrefix;
+
+use BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\ScriptPrefix;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class ScriptPrefixTest extends AbstractTestCase
+{
+    public function testScriptPrefix()
+    {
+        $factory = new P2wpkhScriptDataFactory();
+        $pubPrefix = "04b24746";
+        $privPrefix = "04b2430c";
+        $prefix = new ScriptPrefix($factory, $privPrefix, $pubPrefix);
+        $this->assertEquals($pubPrefix, $prefix->getPublicPrefix());
+        $this->assertEquals($privPrefix, $prefix->getPrivatePrefix());
+        $this->assertEquals($factory, $prefix->getScriptDataFactory());
+    }
+
+    public function testBadLengthPrivatePrefix()
+    {
+        $factory = new P2wpkhScriptDataFactory();
+        $pubPrefix = "04b24746";
+        $privPrefix = "dadd0c";
+        $this->expectException(InvalidNetworkParameter::class);
+        $this->expectExceptionMessage("Invalid HD private prefix: wrong length");
+
+        new ScriptPrefix($factory, $privPrefix, $pubPrefix);
+    }
+
+    public function testBadHexPrivatePrefix()
+    {
+        $factory = new P2wpkhScriptDataFactory();
+        $pubPrefix = "04b24746";
+        $privPrefix = "dadgad0c";
+        $this->expectException(InvalidNetworkParameter::class);
+        $this->expectExceptionMessage("Invalid HD private prefix: expecting hex");
+
+        new ScriptPrefix($factory, $privPrefix, $pubPrefix);
+    }
+
+    public function testBadLengthPublicPrefix()
+    {
+        $factory = new P2wpkhScriptDataFactory();
+        $privPrefix = "04b24746";
+        $pubPrefix = "dadd0c";
+        $this->expectException(InvalidNetworkParameter::class);
+        $this->expectExceptionMessage("Invalid HD public prefix: wrong length");
+
+        new ScriptPrefix($factory, $privPrefix, $pubPrefix);
+    }
+
+    public function testBadHexPublicPrefix()
+    {
+        $factory = new P2wpkhScriptDataFactory();
+        $privPrefix = "04b24746";
+        $pubPrefix = "dadgad0c";
+        $this->expectException(InvalidNetworkParameter::class);
+        $this->expectExceptionMessage("Invalid HD public prefix: expecting hex");
+
+        new ScriptPrefix($factory, $privPrefix, $pubPrefix);
+    }
+}

--- a/tests/Key/Deterministic/HierarchicalKeySignTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeySignTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\ScriptPrefix;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Bitcoin\Transaction\Factory\Signer;
+use BitWasp\Bitcoin\Transaction\Factory\TxBuilder;
+use BitWasp\Bitcoin\Transaction\OutPoint;
+use BitWasp\Bitcoin\Transaction\TransactionOutput;
+use BitWasp\Buffertools\Buffer;
+
+class HierarchicalKeySignTest extends AbstractTestCase
+{
+    public function getEndToEndFixtures()
+    {
+        $fixtures = [];
+        foreach ($this->getEcAdapters() as $adapterRow) {
+            $adapter = $adapterRow[0];
+            $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+            $registry = new BitcoinRegistry();
+            $fixtures[] = [$adapter, $slip132->p2pkh($registry), 44];
+            $fixtures[] = [$adapter, $slip132->p2shP2wpkh($registry), 49];
+            $fixtures[] = [$adapter, $slip132->p2wpkh($registry), 84];
+        }
+        return $fixtures;
+    }
+
+    /**
+     * @dataProvider getEndToEndFixtures
+     * @param EcAdapterInterface $adapter
+     * @param ScriptPrefix $prefix
+     * @param int $purpose
+     * @throws \Exception
+     */
+    public function testEndToEnd(EcAdapterInterface $adapter, ScriptPrefix $prefix, $purpose)
+    {
+        $key = HierarchicalKeyFactory::generateMasterKey($adapter, $prefix->getScriptDataFactory());
+        $account = $key->derivePath("{$purpose}'/0'/0'");
+        $external = $account->deriveChild(0);
+        $key0 = $external->deriveChild(0);
+        $key1 = $external->deriveChild(1);
+        $key2 = $external->deriveChild(2);
+
+        $spkAndData = $key0->getScriptAndSignData();
+        $txOut = new TransactionOutput(
+            12312312,
+            $spkAndData->getScriptPubKey()
+        );
+
+        $outpoint = new OutPoint(Buffer::hex("79f20b268e5c7808e7df760151aa8e41d8f99280f96ad9c96b91df00a9bb5773"), 0);
+
+        $txBuilder = new TxBuilder();
+        $txBuilder->spendOutPoint($outpoint);
+        $txBuilder->output(12000000, $key1->getScriptAndSignData()->getScriptPubKey());
+        $txBuilder->output(302312, $key2->getScriptAndSignData()->getScriptPubKey());
+        $unsigned = $txBuilder->get();
+
+        $signer = new Signer($unsigned, $adapter);
+        $input = $signer->input(0, $txOut, $spkAndData->getSignData());
+        $input->sign($key0->getPrivateKey());
+        $this->assertTrue($input->verify());
+    }
+}

--- a/tests/Key/Deterministic/HierarchicalKeyTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeyTest.php
@@ -8,6 +8,8 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKey;
 use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkScriptDataFactory;
 use BitWasp\Bitcoin\Key\PrivateKeyFactory;
 use BitWasp\Bitcoin\Key\PublicKeyFactory;
 use BitWasp\Bitcoin\Math\Math;
@@ -78,6 +80,7 @@ class HierarchicalKeyTest extends AbstractTestCase
     {
         new HierarchicalKey(
             Bitcoin::getEcAdapter(),
+            new P2pkhScriptDataFactory(),
             1,
             1,
             1,
@@ -514,7 +517,15 @@ class HierarchicalKeyTest extends AbstractTestCase
 
         /** @var EcAdapterInterface $mock */
         /** @var PrivateKeyInterface $mockPriv */
-        $key = new \BitWasp\Bitcoin\Key\Deterministic\HierarchicalKey($mock, 0, 0, 0, new Buffer('00', 32), $mockPriv);
+        $key = new \BitWasp\Bitcoin\Key\Deterministic\HierarchicalKey(
+            $mock,
+            new P2pkScriptDataFactory(),
+            0,
+            0,
+            0,
+            new Buffer('00', 32),
+            $mockPriv
+        );
 
         $this->assertEquals(0, $this->HK_run_count);
         $expected = 1;

--- a/tests/Key/Deterministic/Slip132/PrefixRegistryTest.php
+++ b/tests/Key/Deterministic/Slip132/PrefixRegistryTest.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic\Slip132;
+
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\PrefixRegistry;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class PrefixRegistryTest extends AbstractTestCase
+{
+    public function testMaps()
+    {
+        $key = 'abc';
+        $pub = 'abcd1234';
+        $priv = 'abcd1234';
+
+        $registry = new PrefixRegistry([
+            $key => [$priv, $pub]
+        ]);
+
+        $res = $registry->getPrefixes($key);
+        $this->assertInternalType('array', $res);
+        $this->assertCount(2, $res);
+        $this->assertEquals($priv, $res[0]);
+        $this->assertEquals($pub, $res[1]);
+    }
+
+    public function testUnknown()
+    {
+        $registry = new PrefixRegistry([]);
+
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Unknown script type");
+
+        $registry->getPrefixes('abc');
+    }
+
+    public function testInvalidArray()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Expecting script type as key");
+
+        new PrefixRegistry([
+            ''
+        ]);
+    }
+
+    public function testInvalidValue()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Expecting two BIP32 prefixes");
+
+        new PrefixRegistry([
+            ScriptType::P2WKH => ['', '', ''],
+        ]);
+    }
+
+    public function testInvalidPub()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid public prefix");
+
+        new PrefixRegistry([
+            ScriptType::P2WKH => ['aaaaaaaa', ''],
+        ]);
+    }
+
+    public function testInvalidPriv()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage("Invalid private prefix");
+
+        new PrefixRegistry([
+            ScriptType::P2WKH => ['', 'aaaaaaaa'],
+        ]);
+    }
+}

--- a/tests/Key/Deterministic/Slip132/Slip132Test.php
+++ b/tests/Key/Deterministic/Slip132/Slip132Test.php
@@ -1,0 +1,144 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic\Slip132;
+
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class Slip132Test extends AbstractTestCase
+{
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function testXpubP2pkh(EcAdapterInterface $adapter)
+    {
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2pkh($registry);
+
+        list ($priv, $pub) = $registry->getPrefixes($prefix->getScriptDataFactory()->getScriptType());
+        $this->assertEquals($pub, $prefix->getPublicPrefix());
+        $this->assertEquals($priv, $prefix->getPrivatePrefix());
+
+        $factory = $prefix->getScriptDataFactory();
+        $this->assertEquals(
+            ScriptType::P2PKH,
+            $factory->getScriptType()
+        );
+    }
+
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function testXpubP2sh(EcAdapterInterface $adapter)
+    {
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2shP2pkh($registry);
+
+        list ($priv, $pub) = $registry->getPrefixes($prefix->getScriptDataFactory()->getScriptType());
+        $this->assertEquals($pub, $prefix->getPublicPrefix());
+        $this->assertEquals($priv, $prefix->getPrivatePrefix());
+
+        $factory = $prefix->getScriptDataFactory();
+        $this->assertEquals(ScriptType::P2SH . "|" . ScriptType::P2PKH, $factory->getScriptType());
+    }
+
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function testypubP2shP2wpkh(EcAdapterInterface $adapter)
+    {
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2shP2wpkh($registry);
+
+        list ($priv, $pub) = $registry->getPrefixes($prefix->getScriptDataFactory()->getScriptType());
+        $this->assertEquals($pub, $prefix->getPublicPrefix());
+        $this->assertEquals($priv, $prefix->getPrivatePrefix());
+
+        $factory = $prefix->getScriptDataFactory();
+        $this->assertEquals(
+            ScriptType::P2SH . "|" . ScriptType::P2WKH,
+            $factory->getScriptType()
+        );
+    }
+
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function testYpubP2shP2wshP2pkh(EcAdapterInterface $adapter)
+    {
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2shP2wshP2pkh($registry);
+
+        list ($priv, $pub) = $registry->getPrefixes($prefix->getScriptDataFactory()->getScriptType());
+        $this->assertEquals($pub, $prefix->getPublicPrefix());
+        $this->assertEquals($priv, $prefix->getPrivatePrefix());
+        $factory = $prefix->getScriptDataFactory();
+        $this->assertEquals(
+            ScriptType::P2SH . "|" . ScriptType::P2WSH . "|" . ScriptType::P2PKH,
+            $factory->getScriptType()
+        );
+    }
+
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function testzpubP2wpkh(EcAdapterInterface $adapter)
+    {
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2wpkh($registry);
+
+        list ($priv, $pub) = $registry->getPrefixes($prefix->getScriptDataFactory()->getScriptType());
+        $this->assertEquals($pub, $prefix->getPublicPrefix());
+        $this->assertEquals($priv, $prefix->getPrivatePrefix());
+
+        $factory = $prefix->getScriptDataFactory();
+        $this->assertEquals(
+            ScriptType::P2WKH,
+            $factory->getScriptType()
+        );
+    }
+
+    /**
+     * @dataProvider getEcAdapters
+     * @param EcAdapterInterface $adapter
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     */
+    public function testZpubP2shP2wshP2pkh(EcAdapterInterface $adapter)
+    {
+        $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+        $registry = new BitcoinRegistry();
+        $prefix = $slip132->p2wshP2pkh($registry);
+
+        list ($priv, $pub) = $registry->getPrefixes($prefix->getScriptDataFactory()->getScriptType());
+        $this->assertEquals($pub, $prefix->getPublicPrefix());
+        $this->assertEquals($priv, $prefix->getPrivatePrefix());
+
+        $factory = $prefix->getScriptDataFactory();
+        $this->assertEquals(
+            ScriptType::P2WSH . "|" . ScriptType::P2PKH,
+            $factory->getScriptType()
+        );
+    }
+}

--- a/tests/Key/KeyToScript/Decorator/NestedP2shP2wshScriptDecoratorTest.php
+++ b/tests/Key/KeyToScript/Decorator/NestedP2shP2wshScriptDecoratorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\KeyToScript\Decorator;
+
+use BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shP2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\KeyToScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class NestedP2shP2wshScriptDecoratorTest extends AbstractTestCase
+{
+    public function getAllowedScriptFactories()
+    {
+        return [
+            [new P2pkhScriptDataFactory()],
+            [new P2pkScriptDataFactory()],
+        ];
+    }
+
+    /**
+     * @dataProvider getAllowedScriptFactories
+     * @param KeyToScriptDataFactory $factory
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     */
+    public function testAllowedScriptType(KeyToScriptDataFactory $factory)
+    {
+        $p2shFactory = new P2shP2wshScriptDecorator($factory);
+        $this->assertEquals(ScriptType::P2SH . "|" . ScriptType::P2WSH . "|" . $factory->getScriptType(), $p2shFactory->getScriptType());
+    }
+
+    public function testNotAllowed()
+    {
+        $this->expectException(DisallowedScriptDataFactoryException::class);
+        new P2shP2wshScriptDecorator(new P2wpkhScriptDataFactory());
+    }
+}

--- a/tests/Key/KeyToScript/Decorator/P2shScriptDecoratorTest.php
+++ b/tests/Key/KeyToScript/Decorator/P2shScriptDecoratorTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\KeyToScript\Decorator;
+
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\KeyToScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class P2shScriptDecoratorTest extends AbstractTestCase
+{
+    public function getAllowedScriptFactories()
+    {
+        return [
+            [new P2pkhScriptDataFactory()],
+            [new P2pkScriptDataFactory()],
+            [new P2wpkhScriptDataFactory()],
+        ];
+    }
+
+    /**
+     * @dataProvider getAllowedScriptFactories
+     * @param KeyToScriptDataFactory $factory
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     */
+    public function testAllowedScriptType(KeyToScriptDataFactory $factory)
+    {
+        $p2shFactory = new P2shScriptDecorator($factory);
+        $this->assertEquals(ScriptType::P2SH . "|" . $factory->getScriptType(), $p2shFactory->getScriptType());
+    }
+}

--- a/tests/Key/KeyToScript/Decorator/P2wshScriptDecoratorTest.php
+++ b/tests/Key/KeyToScript/Decorator/P2wshScriptDecoratorTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\KeyToScript\Decorator;
+
+use BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\KeyToScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class P2wshScriptDecoratorTest extends AbstractTestCase
+{
+    public function getAllowedScriptFactories()
+    {
+        return [
+            [new P2pkhScriptDataFactory()],
+            [new P2pkScriptDataFactory()],
+        ];
+    }
+
+    /**
+     * @dataProvider getAllowedScriptFactories
+     * @param KeyToScriptDataFactory $factory
+     * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
+     */
+    public function testAllowedScriptType(KeyToScriptDataFactory $factory)
+    {
+        $p2shFactory = new P2wshScriptDecorator($factory);
+        $this->assertEquals(ScriptType::P2WSH . "|" . $factory->getScriptType(), $p2shFactory->getScriptType());
+    }
+
+    public function testNotAllowed()
+    {
+        $this->expectException(DisallowedScriptDataFactoryException::class);
+        new P2wshScriptDecorator(new P2wpkhScriptDataFactory());
+    }
+}

--- a/tests/Key/KeyToScript/Factory/P2pkScriptDataFactoryTest.php
+++ b/tests/Key/KeyToScript/Factory/P2pkScriptDataFactoryTest.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\KeyToScript\Factory;
+
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shP2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkScriptDataFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class P2pkScriptDataFactoryTest extends AbstractTestCase
+{
+    public function testP2pk()
+    {
+        $factory = new P2pkScriptDataFactory();
+        $this->assertEquals(ScriptType::P2PK, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+        $script = $factory->convertKey($publicKey);
+        $this->assertEquals(
+            "21038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2bac",
+            $script->getScriptPubKey()->getHex()
+        );
+        $this->assertFalse($script->getSignData()->hasRedeemScript());
+        $this->assertFalse($script->getSignData()->hasWitnessScript());
+    }
+
+    public function testP2shP2pk()
+    {
+        $factory = new P2shScriptDecorator(new P2pkScriptDataFactory());
+        $this->assertEquals(ScriptType::P2SH . "|" . ScriptType::P2PK, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+
+        $script = $factory->convertKey($publicKey);
+
+        $this->assertTrue($script->getSignData()->hasRedeemScript());
+        $this->assertFalse($script->getSignData()->hasWitnessScript());
+
+        $this->assertEquals(
+            "a914c99d9ebb5a4828e4e1b606dd6a51a2babebbdc0987",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertEquals(
+            "21038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2bac",
+            $script->getSignData()->getRedeemScript()->getHex()
+        );
+    }
+
+    public function testP2wshP2pk()
+    {
+        $factory = new P2wshScriptDecorator(new P2pkScriptDataFactory());
+        $this->assertEquals(ScriptType::P2WSH . "|" . ScriptType::P2PK, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+
+        $script = $factory->convertKey($publicKey);
+
+        $this->assertFalse($script->getSignData()->hasRedeemScript());
+        $this->assertTrue($script->getSignData()->hasWitnessScript());
+
+        $this->assertEquals(
+            "00200f9ea7bae7166c980169059e39443ed13324495b0d6678ce716262e879591210",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertEquals(
+            "21038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2bac",
+            $script->getSignData()->getWitnessScript()->getHex()
+        );
+    }
+
+    public function testP2shP2wshP2pk()
+    {
+        $factory = new P2shP2wshScriptDecorator(new P2pkScriptDataFactory());
+        $this->assertEquals(ScriptType::P2SH . "|" . ScriptType::P2WSH . "|" . ScriptType::P2PK, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+
+        $script = $factory->convertKey($publicKey);
+
+        $this->assertTrue($script->getSignData()->hasRedeemScript());
+        $this->assertTrue($script->getSignData()->hasWitnessScript());
+
+        $this->assertEquals(
+            "a9146d185c7042d01ea8276dc6be6603101dc441d8a487",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertEquals(
+            "00200f9ea7bae7166c980169059e39443ed13324495b0d6678ce716262e879591210",
+            $script->getSignData()->getRedeemScript()->getHex()
+        );
+
+        $this->assertEquals(
+            "21038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2bac",
+            $script->getSignData()->getWitnessScript()->getHex()
+        );
+    }
+}

--- a/tests/Key/KeyToScript/Factory/P2pkhScriptDataFactoryTest.php
+++ b/tests/Key/KeyToScript/Factory/P2pkhScriptDataFactoryTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\KeyToScript\Factory;
+
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shP2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\PrivateKeyFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class P2pkhScriptDataFactoryTest extends AbstractTestCase
+{
+    public function testP2pk()
+    {
+        $factory = new P2pkhScriptDataFactory();
+        $this->assertEquals(ScriptType::P2PKH, $factory->getScriptType());
+
+        $privKeyHex = "8de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $privKey = PrivateKeyFactory::fromHex($privKeyHex);
+        $publicKey = $privKey->getPublicKey();
+        $script = $factory->convertKey($publicKey);
+        $this->assertEquals(
+            "76a914f61c6c67fb0e03bab869ce2243e87e60655b09cd88ac",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertFalse($script->getSignData()->hasRedeemScript());
+        $this->assertFalse($script->getSignData()->hasWitnessScript());
+
+        $script = $factory->convertKey($privKey);
+        $this->assertEquals(
+            "76a914f61c6c67fb0e03bab869ce2243e87e60655b09cd88ac",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertFalse($script->getSignData()->hasRedeemScript());
+        $this->assertFalse($script->getSignData()->hasWitnessScript());
+    }
+
+    public function testP2shP2pkh()
+    {
+        $factory = new P2shScriptDecorator(new P2pkhScriptDataFactory());
+        $this->assertEquals(ScriptType::P2SH . "|" . ScriptType::P2PKH, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+
+        $script = $factory->convertKey($publicKey);
+
+        $this->assertTrue($script->getSignData()->hasRedeemScript());
+        $this->assertFalse($script->getSignData()->hasWitnessScript());
+
+        $this->assertEquals(
+            "a9142162ff7c23d47a0c331f95c67d7c3e22abb12a0287",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertEquals(
+            "76a914851a33a5ef0d4279bd5854949174e2c65b1d450088ac",
+            $script->getSignData()->getRedeemScript()->getHex()
+        );
+    }
+
+    public function testP2wshP2pk()
+    {
+        $factory = new P2wshScriptDecorator(new P2pkhScriptDataFactory());
+        $this->assertEquals(ScriptType::P2WSH . "|" . ScriptType::P2PKH, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+
+        $script = $factory->convertKey($publicKey);
+
+        $this->assertFalse($script->getSignData()->hasRedeemScript());
+        $this->assertTrue($script->getSignData()->hasWitnessScript());
+
+        $this->assertEquals(
+            "0020578db4b54a6961060b71385c17d3280379a557224c52b11b19a3a1c1eef606a0",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertEquals(
+            "76a914851a33a5ef0d4279bd5854949174e2c65b1d450088ac",
+            $script->getSignData()->getWitnessScript()->getHex()
+        );
+    }
+
+    public function testP2shP2wshP2pk()
+    {
+        $factory = new P2shP2wshScriptDecorator(new P2pkhScriptDataFactory());
+        $this->assertEquals(ScriptType::P2SH . "|" . ScriptType::P2WSH . "|" . ScriptType::P2PKH, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+
+        $script = $factory->convertKey($publicKey);
+
+        $this->assertTrue($script->getSignData()->hasRedeemScript());
+        $this->assertTrue($script->getSignData()->hasWitnessScript());
+
+        $this->assertEquals(
+            "a91444a641c4e06eb6118c99e5ed29954b705b50fb6a87",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertEquals(
+            "0020578db4b54a6961060b71385c17d3280379a557224c52b11b19a3a1c1eef606a0",
+            $script->getSignData()->getRedeemScript()->getHex()
+        );
+
+        $this->assertEquals(
+            "76a914851a33a5ef0d4279bd5854949174e2c65b1d450088ac",
+            $script->getSignData()->getWitnessScript()->getHex()
+        );
+    }
+}

--- a/tests/Key/KeyToScript/Factory/P2wpkhScriptDataFactoryTest.php
+++ b/tests/Key/KeyToScript/Factory/P2wpkhScriptDataFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\KeyToScript\Factory;
+
+use BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shP2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2shScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Decorator\P2wshScriptDecorator;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\PublicKeyFactory;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class P2wpkhScriptDataFactoryTest extends AbstractTestCase
+{
+    public function testP2wpk()
+    {
+        $factory = new P2wpkhScriptDataFactory();
+        $this->assertEquals(ScriptType::P2WKH, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+        $script = $factory->convertKey($publicKey);
+        $this->assertEquals(
+            "0014851a33a5ef0d4279bd5854949174e2c65b1d4500",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertFalse($script->getSignData()->hasRedeemScript());
+        $this->assertFalse($script->getSignData()->hasWitnessScript());
+    }
+
+    public function testP2shP2wpkh()
+    {
+        $factory = new P2shScriptDecorator(new P2wpkhScriptDataFactory());
+        $this->assertEquals(ScriptType::P2SH . "|" . ScriptType::P2WKH, $factory->getScriptType());
+
+        $publicKeyHex = "038de63cf582d058a399a176825c045672d5ff8ea25b64d28d4375dcdb14c02b2b";
+        $publicKey = PublicKeyFactory::fromHex($publicKeyHex);
+
+        $script = $factory->convertKey($publicKey);
+
+        $this->assertTrue($script->getSignData()->hasRedeemScript());
+        $this->assertFalse($script->getSignData()->hasWitnessScript());
+
+        $this->assertEquals(
+            "a9140d061ae2c8ad224a81142a2e02181f5173b576b387",
+            $script->getScriptPubKey()->getHex()
+        );
+
+        $this->assertEquals(
+            "0014851a33a5ef0d4279bd5854949174e2c65b1d4500",
+            $script->getSignData()->getRedeemScript()->getHex()
+        );
+    }
+
+    public function testP2wshP2wpkhIsInvalid()
+    {
+        $this->expectException(DisallowedScriptDataFactoryException::class);
+        new P2wshScriptDecorator(new P2wpkhScriptDataFactory());
+    }
+
+    public function testP2shP2wshP2wpkhIsInvalid()
+    {
+        $this->expectException(DisallowedScriptDataFactoryException::class);
+        new P2shP2wshScriptDecorator(new P2wpkhScriptDataFactory());
+    }
+}

--- a/tests/Key/KeyToScript/ScriptAndSignDataTest.php
+++ b/tests/Key/KeyToScript/ScriptAndSignDataTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\KeyToScript;
+
+use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
+use BitWasp\Bitcoin\Script\P2shScript;
+use BitWasp\Bitcoin\Script\ScriptFactory;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Bitcoin\Transaction\Factory\SignData;
+use BitWasp\Buffertools\Buffer;
+
+class ScriptAndSignDataTest extends AbstractTestCase
+{
+    public function testScriptAndSignDataSpk()
+    {
+        $script1 = ScriptFactory::scriptPubKey()->p2pkh(new Buffer("A", 20));
+        $signData = new SignData();
+
+        $scriptAndSignData = new ScriptAndSignData($script1, $signData);
+
+        $this->assertEquals($script1, $scriptAndSignData->getScriptPubKey());
+        $this->assertEquals($signData, $scriptAndSignData->getSignData());
+    }
+
+    public function testScriptAndSignDataRs()
+    {
+        $redeemScript = new P2shScript(ScriptFactory::scriptPubKey()->p2pkh(new Buffer("A", 20)));
+        $signData = (new SignData())
+            ->p2sh($redeemScript)
+        ;
+
+        $scriptAndSignData = new ScriptAndSignData($redeemScript->getOutputScript(), $signData);
+
+        $this->assertEquals($redeemScript->getOutputScript(), $scriptAndSignData->getScriptPubKey());
+        $this->assertEquals($signData, $scriptAndSignData->getSignData());
+        $this->assertEquals($redeemScript, $scriptAndSignData->getSignData()->getRedeemScript());
+    }
+}

--- a/tests/Network/Slip132/BitcoinRegistryTest.php
+++ b/tests/Network/Slip132/BitcoinRegistryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic\HdPrefix\Slip132;
+
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class BitcoinRegistryTest extends AbstractTestCase
+{
+    /**
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @throws \BitWasp\Bitcoin\Exceptions\MissingBip32Prefix
+     */
+    public function testXpubP2pkh()
+    {
+        $network = new Bitcoin();
+        $registry = new BitcoinRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2PKH);
+
+        $this->assertEquals(
+            $network->getHDPubByte(),
+            $pub
+        );
+
+        $this->assertEquals(
+            $network->getHDPrivByte(),
+            $priv
+        );
+    }
+    /**
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @throws \BitWasp\Bitcoin\Exceptions\MissingBip32Prefix
+     */
+    public function testXpubP2shP2pkh()
+    {
+        $network = new Bitcoin();
+        $registry = new BitcoinRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2SH . "|" . ScriptType::P2PKH);
+
+        $this->assertEquals(
+            $network->getHDPubByte(),
+            $pub
+        );
+
+        $this->assertEquals(
+            $network->getHDPrivByte(),
+            $priv
+        );
+    }
+
+    public function testypubP2shP2wpkh()
+    {
+        $registry = new BitcoinRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2SH . "|" . ScriptType::P2WKH);
+
+        $this->assertEquals("049d7cb2", $pub);
+        $this->assertEquals("049d7878", $priv);
+    }
+
+    public function testYpubP2shP2wshP2pkh()
+    {
+        $registry = new BitcoinRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2SH . "|" . ScriptType::P2WSH . "|" . ScriptType::P2PKH);
+
+        $this->assertEquals("0295b43f", $pub);
+        $this->assertEquals("0295b005", $priv);
+    }
+
+    public function testzpubP2wpkh()
+    {
+        $registry = new BitcoinRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2WKH);
+
+        $this->assertEquals("04b24746", $pub);
+        $this->assertEquals("04b2430c", $priv);
+    }
+
+    public function testZpubP2shP2wshP2pkh()
+    {
+        $registry = new BitcoinRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2WSH . "|" . ScriptType::P2PKH);
+
+        $this->assertEquals("02aa7ed3", $pub);
+        $this->assertEquals("02aa7a99", $priv);
+    }
+}

--- a/tests/Network/Slip132/BitcoinTestnetRegistryTest.php
+++ b/tests/Network/Slip132/BitcoinTestnetRegistryTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Key\Deterministic\HdPrefix\Slip132;
+
+use BitWasp\Bitcoin\Network\Networks\Bitcoin;
+use BitWasp\Bitcoin\Network\Networks\BitcoinTestnet;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinTestnetRegistry;
+use BitWasp\Bitcoin\Script\ScriptType;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+
+class BitcoinTestnetRegistryTest extends AbstractTestCase
+{
+    /**
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @throws \BitWasp\Bitcoin\Exceptions\MissingBip32Prefix
+     */
+    public function testXpubP2pkh()
+    {
+        $network = new BitcoinTestnet();
+        $registry = new BitcoinTestnetRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2PKH);
+
+        $this->assertEquals(
+            $network->getHDPubByte(),
+            $pub
+        );
+
+        $this->assertEquals(
+            $network->getHDPrivByte(),
+            $priv
+        );
+    }
+    /**
+     * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @throws \BitWasp\Bitcoin\Exceptions\MissingBip32Prefix
+     */
+    public function testXpubP2shP2pkh()
+    {
+        $network = new BitcoinTestnet();
+        $registry = new BitcoinTestnetRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2SH . "|" . ScriptType::P2PKH);
+
+        $this->assertEquals(
+            $network->getHDPubByte(),
+            $pub
+        );
+
+        $this->assertEquals(
+            $network->getHDPrivByte(),
+            $priv
+        );
+    }
+
+    public function testypubP2shP2wpkh()
+    {
+        $registry = new BitcoinTestnetRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2SH . "|" . ScriptType::P2WKH);
+
+        $this->assertEquals("044a5262", $pub);
+        $this->assertEquals("044a4e28", $priv);
+    }
+
+    public function testYpubP2shP2wshP2pkh()
+    {
+        $this->expectExceptionMessage("Unknown script type");
+        $this->expectException(\InvalidArgumentException::class);
+
+        $registry = new BitcoinTestnetRegistry();
+        $registry->getPrefixes(ScriptType::P2SH . "|" . ScriptType::P2WSH . "|" . ScriptType::P2PKH);
+    }
+
+    public function testzpubP2wpkh()
+    {
+        $registry = new BitcoinTestnetRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2WKH);
+
+        $this->assertEquals("045f1cf6", $pub);
+        $this->assertEquals("045f18bc", $priv);
+    }
+
+    public function testZpubP2shP2wshP2pkh()
+    {
+        $registry = new BitcoinTestnetRegistry();
+        list ($priv, $pub) = $registry->getPrefixes(ScriptType::P2WSH . "|" . ScriptType::P2PKH);
+
+        $this->assertEquals("02575483", $pub);
+        $this->assertEquals("02575048", $priv);
+    }
+}

--- a/tests/Serializer/Key/HierarchicalKey/ExtendedKeySerializerTest.php
+++ b/tests/Serializer/Key/HierarchicalKey/ExtendedKeySerializerTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace BitWasp\Bitcoin\Tests\Serializer\Key\HierarchicalKey;
+
+use BitWasp\Bitcoin\Address\AddressCreator;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Key\PublicKeySerializerInterface;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\GlobalPrefixConfig;
+use BitWasp\Bitcoin\Key\Deterministic\HdPrefix\NetworkConfig;
+use BitWasp\Bitcoin\Key\Deterministic\Slip132\Slip132;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKey;
+use BitWasp\Bitcoin\Key\Deterministic\HierarchicalKeyFactory;
+use BitWasp\Bitcoin\Network\Slip132\BitcoinRegistry;
+use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
+use BitWasp\Bitcoin\Key\KeyToScript\KeyToScriptHelper;
+use BitWasp\Bitcoin\Network\NetworkFactory;
+use BitWasp\Bitcoin\Network\NetworkInterface;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\Base58ExtendedKeySerializer;
+use BitWasp\Bitcoin\Serializer\Key\HierarchicalKey\ExtendedKeySerializer;
+use BitWasp\Bitcoin\Tests\AbstractTestCase;
+use BitWasp\Buffertools\Buffer;
+
+class ExtendedKeySerializerTest extends AbstractTestCase
+{
+    protected $seed = '000102030405060708090a0b0c0d0e0f';
+
+    /**
+     * @param Base58ExtendedKeySerializer $serializer
+     * @param NetworkInterface $network
+     * @param $serialized
+     */
+    public function checkConsistency(
+        Base58ExtendedKeySerializer $serializer,
+        NetworkInterface $network,
+        $serialized
+    ) {
+        $parsed = $serializer->parse($network, $serialized);
+        $serializedAgain = $serializer->serialize($network, $parsed);
+        $this->assertEquals(
+            $serialized,
+            $serializedAgain,
+            "should equal, we tested encode(decode()) == strval"
+        );
+    }
+
+    /**
+     * @param Base58ExtendedKeySerializer $serializer
+     * @param HierarchicalKey $key
+     * @param AddressCreator $addressCreator
+     * @param NetworkInterface $network
+     * @param $expectedPriv
+     * @param $expectedPub
+     * @param $expectedAddress
+     */
+    public function checkFixture(
+        Base58ExtendedKeySerializer $serializer,
+        HierarchicalKey $key,
+        AddressCreator $addressCreator,
+        NetworkInterface $network,
+        $expectedPriv,
+        $expectedPub,
+        $expectedAddress
+    ) {
+
+        $serializedPriv = $serializer->serialize($network, $key);
+        $this->assertEquals(
+            $expectedPriv,
+            $serializedPriv
+        );
+        $this->checkConsistency($serializer, $network, $serializedPriv);
+
+        $serializedPub = $serializer->serialize($network, $key->withoutPrivateKey());
+        $this->assertEquals(
+            $expectedPub,
+            $serializedPub
+        );
+        $this->checkConsistency($serializer, $network, $serializedPub);
+
+        $this->assertEquals(
+            $expectedAddress,
+            $key->getAddress($addressCreator)->getAddress($network)
+        );
+    }
+
+    public function getEquivalentConfigurations()
+    {
+        $network = NetworkFactory::bitcoin();
+
+        $serializer = [];
+        foreach ($this->getEcAdapters() as $adapterRow) {
+            $adapter = $adapterRow[0];
+            $bitcoinPrefixes = new BitcoinRegistry();
+            $slip132 = new Slip132(new KeyToScriptHelper($adapter));
+            $prefix = $slip132->p2pkh($bitcoinPrefixes);
+            $globalConfig = new GlobalPrefixConfig([
+                new NetworkConfig(
+                    $network,
+                    [$prefix]
+                )
+            ]);
+            $serializer[] = [$adapter, $network, new Base58ExtendedKeySerializer(new ExtendedKeySerializer($adapter))];
+            $serializer[] = [$adapter, $network, new Base58ExtendedKeySerializer(new ExtendedKeySerializer($adapter, $globalConfig))];
+        }
+        return $serializer;
+    }
+
+    /**
+     * @dataProvider getEquivalentConfigurations
+     * @param EcAdapterInterface $adapter
+     * @param NetworkInterface $network
+     * @param Base58ExtendedKeySerializer $serializer
+     * @throws \Exception
+     */
+    public function testBasicElectrumBip32(EcAdapterInterface $adapter, NetworkInterface $network, Base58ExtendedKeySerializer $serializer)
+    {
+        $addressCreator = new AddressCreator();
+        $scriptFactory = new P2pkhScriptDataFactory(EcSerializer::getSerializer(PublicKeySerializerInterface::class, true, $adapter));
+
+        $entropy = Buffer::hex($this->seed);
+        $key = HierarchicalKeyFactory::fromEntropy($entropy, $adapter, $scriptFactory);
+
+        $this->checkFixture(
+            $serializer,
+            $key,
+            $addressCreator,
+            $network,
+            "xprv9s21ZrQH143K3QTDL4LXw2F7HEK3wJUD2nW2nRk4stbPy6cq3jPPqjiChkVvvNKmPGJxWUtg6LnF5kejMRNNU3TGtRBeJgk33yuGBxrMPHi",
+            "xpub661MyMwAqRbcFtXgS5sYJABqqG9YLmC4Q1Rdap9gSE8NqtwybGhePY2gZ29ESFjqJoCu1Rupje8YtGqsefD265TMg7usUDFdp6W1EGMcet8",
+            "15mKKb2eos1hWa6tisdPwwDC1a5J1y9nma"
+        );
+
+        $key1 = $key->derivePath("0'");
+
+        $this->checkFixture(
+            $serializer,
+            $key1,
+            $addressCreator,
+            $network,
+            "xprv9uHRZZhk6KAJC1avXpDAp4MDc3sQKNxDiPvvkX8Br5ngLNv1TxvUxt4cV1rGL5hj6KCesnDYUhd7oWgT11eZG7XnxHrnYeSvkzY7d2bhkJ7",
+            "xpub68Gmy5EdvgibQVfPdqkBBCHxA5htiqg55crXYuXoQRKfDBFA1WEjWgP6LHhwBZeNK1VTsfTFUHCdrfp1bgwQ9xv5ski8PX9rL2dZXvgGDnw",
+            "19Q2WoS5hSS6T8GjhK8KZLMgmWaq4neXrh"
+        );
+
+        $key2 = $key1->derivePath("1");
+
+        $this->checkFixture(
+            $serializer,
+            $key2,
+            $addressCreator,
+            $network,
+            "xprv9wTYmMFdV23N2TdNG573QoEsfRrWKQgWeibmLntzniatZvR9BmLnvSxqu53Kw1UmYPxLgboyZQaXwTCg8MSY3H2EU4pWcQDnRnrVA1xe8fs",
+            "xpub6ASuArnXKPbfEwhqN6e3mwBcDTgzisQN1wXN9BJcM47sSikHjJf3UFHKkNAWbWMiGj7Wf5uMash7SyYq527Hqck2AxYysAA7xmALppuCkwQ",
+            "1JQheacLPdM5ySCkrZkV66G2ApAXe1mqLj"
+        );
+
+        $key3 = $key2->derivePath("2'");
+
+        $this->checkFixture(
+            $serializer,
+            $key3,
+            $addressCreator,
+            $network,
+            "xprv9z4pot5VBttmtdRTWfWQmoH1taj2axGVzFqSb8C9xaxKymcFzXBDptWmT7FwuEzG3ryjH4ktypQSAewRiNMjANTtpgP4mLTj34bhnZX7UiM",
+            "xpub6D4BDPcP2GT577Vvch3R8wDkScZWzQzMMUm3PWbmWvVJrZwQY4VUNgqFJPMM3No2dFDFGTsxxpG5uJh7n7epu4trkrX7x7DogT5Uv6fcLW5",
+            "1NjxqbA9aZWnh17q1UW3rB4EPu79wDXj7x"
+        );
+    }
+}

--- a/tests/Serializer/Key/HierarchicalKey/HexExtendedKeySerializerTest.php
+++ b/tests/Serializer/Key/HierarchicalKey/HexExtendedKeySerializerTest.php
@@ -18,7 +18,7 @@ class HexExtendedKeySerializerTest extends AbstractTestCase
     public function testInvalidKey(EcAdapterInterface $adapter)
     {
         $network = NetworkFactory::bitcoinTestnet();
-        $serializer = new ExtendedKeySerializer($adapter, $network);
+        $serializer = new ExtendedKeySerializer($adapter);
         $serializer->parse($network, new Buffer());
     }
 }


### PR DESCRIPTION
Adds the following functions to HierarchicalKey:
 - getScriptAndSignData() - returning a new type containing the scriptPubKey, and SignData
 - getAddress(BaseAddressCreator $creator) - tries to create an address using the provided AddressCreator

Alternative to #659. Introduces the feature to HierarchicalKey directly, and modifies the ExtendedKeySerializer so it can load the prefix/script types from the config (if provided). if it's not provided, we validate against the networks hdpub/priv prefixes and initialize as p2pkh. 

The HierarchicalKeyFactory can now create these types of keys by accepting a ScriptDataFactory as an optional parameter. 

HierarchicalKey still has the methods toExtendedKey/toExtendedPublicKey/toExtendedPrivateKey, but they won't know about a prefix config, so they'll throw an error if you try to use them while using a non-P2PKH key. 

To serialize such a key, you need to create your own Base58ExtendedKeySerializer (see examples in tests in this PR) and serialize with that. 

BC breaks:
 - HierarchicalKey::toPublic() was removed. Used to be mutable. Added this instead, which returns a new object only with a public key: HierarchicalKey::withoutPrivateKey() 
 - HierarchicalKey __construct() takes a new parameter at the second position, the ScriptDataFactory