### PR TITLE
Zcash Network and support for multi-byte address prefixes

### DIFF
--- a/src/Address/AddressCreator.php
+++ b/src/Address/AddressCreator.php
@@ -28,12 +28,12 @@ class AddressCreator extends BaseAddressCreator
     {
         try {
             $data = Base58::decodeCheck($strAddress);
-            $prefixByte = $data->slice(0, 1)->getHex();
+            $prefixByte = $data->slice(0, $network->getP2shPrefixLength())->getHex();
 
             if ($prefixByte === $network->getP2shByte()) {
                 return new ScriptHashAddress($data->slice(1));
             } else if ($prefixByte === $network->getAddressByte()) {
-                return new PayToPubKeyHashAddress($data->slice(1));
+                return new PayToPubKeyHashAddress($data->slice($network->getAddressPrefixLength()));
             }
         } catch (\Exception $e) {
             // Just return null

--- a/src/Network/Network.php
+++ b/src/Network/Network.php
@@ -200,6 +200,15 @@ class Network implements NetworkInterface
     {
         return $this->getBase58Prefix(self::BASE58_ADDRESS_P2PKH);
     }
+    /**
+     * @return int
+     * @throws MissingBase58Prefix
+     * @see NetworkInterface::getAddressPrefixLength()
+     */
+    public function getAddressPrefixLength(): int
+    {
+        return strlen($this->getAddressByte()) / 2;
+    }
 
     /**
      * @return string
@@ -209,6 +218,16 @@ class Network implements NetworkInterface
     public function getP2shByte(): string
     {
         return $this->getBase58Prefix(self::BASE58_ADDRESS_P2SH);
+    }
+
+    /**
+     * @return int
+     * @throws MissingBase58Prefix
+     * @see NetworkInterface::getP2shPrefixLength()
+     */
+    public function getP2shPrefixLength(): int
+    {
+        return strlen($this->getP2shByte()) / 2;
     }
 
     /**

--- a/src/Network/NetworkFactory.php
+++ b/src/Network/NetworkFactory.php
@@ -96,4 +96,12 @@ class NetworkFactory
     {
         return new Networks\DashTestnet();
     }
+
+    /**
+     * @return NetworkInterface
+     */
+    public static function zcash()
+    {
+        return new Networks\Zcash();
+    }
 }

--- a/src/Network/NetworkInterface.php
+++ b/src/Network/NetworkInterface.php
@@ -14,6 +14,13 @@ interface NetworkInterface
     public function getAddressByte(): string;
 
     /**
+     * Return a address prefix length in bytes
+     *
+     * @return int
+     */
+    public function getAddressPrefixLength(): int;
+
+    /**
      * Return the string that binds address signed messages to
      * this network
      *
@@ -34,6 +41,13 @@ interface NetworkInterface
      * @return string
      */
     public function getP2shByte(): string;
+
+    /**
+     * Return the p2sh prefix length in bytes for the network
+     *
+     * @return int
+     */
+    public function getP2shPrefixLength(): int;
 
     /**
      * Get the private key byte for the network

--- a/src/Network/Networks/Zcash.php
+++ b/src/Network/Networks/Zcash.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace BitWasp\Bitcoin\Network\Networks;
+
+use BitWasp\Bitcoin\Network\Network;
+use BitWasp\Bitcoin\Script\ScriptType;
+
+class Zcash extends Network
+{
+    /**
+     * {@inheritdoc}
+     * @see Network::$base58PrefixMap
+     */
+    protected $base58PrefixMap = [
+        // https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L139-L144
+        self::BASE58_ADDRESS_P2PKH => "1cb8",
+        self::BASE58_ADDRESS_P2SH => "1cbd",
+        self::BASE58_WIF => "80",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32PrefixMap
+     */
+    protected $bip32PrefixMap = [
+        // https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L146-L147
+        self::BIP32_PREFIX_XPUB => "0488b21e",
+        self::BIP32_PREFIX_XPRV => "0488ade4",
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$bip32ScriptTypeMap
+     */
+    protected $bip32ScriptTypeMap = [
+        self::BIP32_PREFIX_XPUB => ScriptType::P2PKH,
+        self::BIP32_PREFIX_XPRV => ScriptType::P2PKH,
+    ];
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$signedMessagePrefix
+     */
+    protected $signedMessagePrefix = "Zcash Signed Message";
+
+    /**
+     * {@inheritdoc}
+     * @see Network::$p2pMagic
+     */
+    // https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L111-L114
+    protected $p2pMagic = "6427e924";
+
+    /**
+     * Network constructor.
+     * @throws InvalidNetworkParameter
+     */
+    public function __construct()
+    {
+        // intentionally skipped validation
+    }
+}

--- a/tests/Address/AddressTest.php
+++ b/tests/Address/AddressTest.php
@@ -31,6 +31,8 @@ class AddressTest extends AbstractTestCase
                 return NetworkFactory::bitcoin();
             case 'tbtc':
                 return NetworkFactory::bitcoinTestnet();
+            case 'zec':
+                return NetworkFactory::zcash();
             default:
                 throw new \RuntimeException("Invalid test fixture, unknown network");
         }

--- a/tests/Data/addresstests.json
+++ b/tests/Data/addresstests.json
@@ -131,6 +131,12 @@
             "hash": "33b5ea4cee854383bb1ef23223af8544351dc148",
             "network": "btc",
             "address": "15iRPUaoGPkxAdsR9Pg7amifytRj7h1nJf"
+        },
+        {
+            "publickey": "03005d784682e7ae5933d39a8ebf2758f610aefe238b2f0ea06a26c20fa9d4733e",
+            "hash": "e1c34e05292274d459949e910b758b8d104ede1b",
+            "network": "zec",
+            "address": "t1eTL1WZWMFj5DTsingVqcPsfFzUSzPEEiM"
         }
     ]
 }


### PR DESCRIPTION
This pull request does not break anything, but adds support for ZCash.
ZCash has double byte [address prefixes](https://github.com/zcash/zcash/blob/master/src/chainparams.cpp#L139-L144), so i had to modify some classes. 
Also in Zcash Network class i had to replace __construct method with empty one because Network class has validation of this prefixes and of cause if fails on length check - i don't know how you want do deal with it. I would just remove length validation. If prefixes are wrong - your test suit will fail anyway.
Test case added.