### PR TITLE
use new litecoin testnet prefix for P2SH addresses (0xc4 => 0x3a)

### DIFF
--- a/src/Network/Networks/LitecoinTestnet.php
+++ b/src/Network/Networks/LitecoinTestnet.php
@@ -13,7 +13,7 @@ class LitecoinTestnet extends Network
      */
     protected $base58PrefixMap = [
         self::BASE58_ADDRESS_P2PKH => "6f",
-        self::BASE58_ADDRESS_P2SH => "c4",
+        self::BASE58_ADDRESS_P2SH => "3a",
         self::BASE58_WIF => "ef",
     ];
 

--- a/tests/Network/Networks/LitecoinTestnetTest.php
+++ b/tests/Network/Networks/LitecoinTestnetTest.php
@@ -13,7 +13,7 @@ class LitecoinTestnetTest extends AbstractTestCase
     {
         $network = new LitecoinTestnet();
         $this->assertEquals('6f', $network->getAddressByte());
-        $this->assertEquals('c4', $network->getP2shByte());
+        $this->assertEquals('3a', $network->getP2shByte());
         $this->assertEquals('ef', $network->getPrivByte());
         $this->assertEquals('04358394', $network->getHDPrivByte());
         $this->assertEquals('043587cf', $network->getHDPubByte());


### PR DESCRIPTION
See #610, #677 