### PR TITLE
0.0.35: Deprecate invalid Slip132 methods

### DIFF
--- a/src/Key/Deterministic/Slip132/Slip132.php
+++ b/src/Key/Deterministic/Slip132/Slip132.php
@@ -77,6 +77,7 @@ class Slip132
      * @return ScriptPrefix
      * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
      * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @deprecated
      */
     public function p2shP2wshP2pkh(PrefixRegistry $registry)
     {
@@ -100,6 +101,7 @@ class Slip132
      * @return ScriptPrefix
      * @throws \BitWasp\Bitcoin\Exceptions\DisallowedScriptDataFactoryException
      * @throws \BitWasp\Bitcoin\Exceptions\InvalidNetworkParameter
+     * @deprecated
      */
     public function p2wshP2pkh(PrefixRegistry $registry)
     {


### PR DESCRIPTION
Marking them deprecated per issue #703 

Hopefully not many people were using these - since there wasn't technically a release of the master branch this version is the v0.0.35.0 is the only formally released version with support for these..

The master branch will have support removed right away, since it wasn't technically released in the first place.