### PR TITLE
Bump secp256k1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
   - nightly
 
 env:
-  - PHPUNIT=true PHPUNIT_EXT=true BITCOIN_VERSION="0.15.0"
+  - PHPUNIT=true PHPUNIT_EXT=true BITCOIN_VERSION="0.16.1"
 
 dist: trusty
 sudo: required
@@ -20,14 +20,14 @@ cache:
 matrix:
   exclude:
     - php: 7.2
-      env: PHPUNIT=true PHPUNIT_EXT=true BITCOIN_VERSION="0.15.0"
+      env: PHPUNIT=true PHPUNIT_EXT=true BITCOIN_VERSION="0.16.1"
 
   include:
     # add extra test runs for php7: coverage, codestyle, examples, rpc tests
     - php: 7.2
-      env: PHPUNIT=true BITCOIN_VERSION="0.15.0" PHPUNIT_EXT=true COVERAGE=true CODE_STYLE=true EXAMPLES=true
+      env: PHPUNIT=true BITCOIN_VERSION="0.16.1" PHPUNIT_EXT=true COVERAGE=true CODE_STYLE=true EXAMPLES=true
     - php: 7.0
-      env: RPC_TEST=true BITCOIN_VERSION="0.15.0"
+      env: RPC_TEST=true BITCOIN_VERSION="0.16.1"
 
 install:
     - |
@@ -53,15 +53,8 @@ install:
             make && sudo make install && cd ..;
         fi
     - |
-        if [ "$PHPUNIT_EXT" = "true" ] && [ "$TRAVIS_PHP_VERSION" = "5.6" ]; then
-            git clone -b v0.0 https://github.com/Bit-Wasp/secp256k1-php &&
-            cd secp256k1-php/secp256k1 &&
-            phpize && ./configure &&
-            make && sudo make install && cd ../..;
-        fi
-    - |
-        if [ "$PHPUNIT_EXT" = "true" ] && [ "$TRAVIS_PHP_VERSION" != "5.6" ]; then
-            git clone -b v0.1.3 https://github.com/Bit-Wasp/secp256k1-php &&
+        if [ "$PHPUNIT_EXT" = "true" ]; then
+            git clone -b v0.2.0 https://github.com/Bit-Wasp/secp256k1-php &&
             cd secp256k1-php/secp256k1 &&
             phpize && ./configure &&
             make && sudo make install && cd ../..;

--- a/composer.json
+++ b/composer.json
@@ -23,10 +23,7 @@
     }
   },
   "require": {
-    "php-64bit": ">=5.6",
-    "ext-gmp": "*",
-    "ext-openssl": "*",
-    "ext-bcmath": "*",
+    "php-64bit": ">=7.0",
     "paragonie/random_compat": "^1.4.0|^2.0.0",
     "pleonasm/merkle-tree": "1.0.0",
     "composer/semver": "^1.4.0",

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "lastguest/murmurhash": "v2.0.0",
     "mdanter/ecc": "^0.5.0",
     "bitwasp/buffertools": "^0.5.0",
-    "bitwasp/secp256k1-php": "^0.1.2",
+    "bitwasp/secp256k1-php": "^0.2.0",
     "bitwasp/bech32": "^0.0.1"
   },
   "require-dev": {

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Adapter/EcAdapter.php
@@ -128,7 +128,7 @@ class EcAdapter implements EcAdapterInterface
      */
     private function doRecover(BufferInterface $msg32, CompactSignature $compactSig): PublicKey
     {
-        $publicKey = '';
+        $publicKey = null;
         /** @var resource $publicKey */
         $context = $this->context;
         $sig = $compactSig->getResource();

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PrivateKey.php
@@ -79,12 +79,11 @@ class PrivateKey extends Key implements PrivateKeyInterface
     {
         $context = $this->ecAdapter->getContext();
 
-        /** @var resource $sig_t */
-        $sig_t = '';
+        $sig_t = null;
         if (1 !== secp256k1_ecdsa_sign($context, $sig_t, $msg32->getBinary(), $this->secretBin)) {
             throw new \RuntimeException('Secp256k1: failed to sign');
         }
-
+        /** @var resource $sig_t */
         $derSig = '';
         secp256k1_ecdsa_signature_serialize_der($context, $derSig, $sig_t);
 
@@ -106,14 +105,15 @@ class PrivateKey extends Key implements PrivateKeyInterface
     {
         $context = $this->ecAdapter->getContext();
         
-        $sig_t = '';
+        $sig_t = null;
         if (1 !== secp256k1_ecdsa_sign_recoverable($context, $sig_t, $msg32->getBinary(), $this->secretBin)) {
             throw new \RuntimeException('Secp256k1: failed to sign');
         }
-
-        $recid = '';
+        /** @var resource $sig_t
+         */
+        $recid = 0;
         $ser = '';
-        if (!secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $sig_t, $ser, $recid)) {
+        if (!secp256k1_ecdsa_recoverable_signature_serialize_compact($context, $ser, $recid, $sig_t)) {
             throw new \RuntimeException('Failed to obtain recid');
         }
 
@@ -160,12 +160,11 @@ class PrivateKey extends Key implements PrivateKeyInterface
     {
         if (null === $this->publicKey) {
             $context = $this->ecAdapter->getContext();
-            $publicKey_t = '';
-            /** @var resource $publicKey_t */
+            $publicKey_t = null;
             if (1 !== secp256k1_ec_pubkey_create($context, $publicKey_t, $this->getBinary())) {
                 throw new \RuntimeException('Failed to create public key');
             }
-
+            /** @var resource $publicKey_t */
             $this->publicKey = new PublicKey($this->ecAdapter, $publicKey_t, $this->compressed);
         }
 

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PublicKey.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PublicKey.php
@@ -59,8 +59,11 @@ class PublicKey extends Key implements PublicKeyInterface
      */
     public function verify(BufferInterface $msg32, SignatureInterface $signature): bool
     {
+        $ctx = $this->ecAdapter->getContext();
+        $normalized = null;
+        secp256k1_ecdsa_signature_normalize($ctx, $normalized, $signature->getResource());
         /** @var Signature $signature */
-        return (bool) secp256k1_ecdsa_verify($this->ecAdapter->getContext(), $signature->getResource(), $msg32->getBinary(), $this->pubkey_t);
+        return (bool) secp256k1_ecdsa_verify($ctx, $normalized, $msg32->getBinary(), $this->pubkey_t);
     }
 
     /**
@@ -121,7 +124,7 @@ class PublicKey extends Key implements PublicKeyInterface
         }
 
         /** @var resource $clone */
-        $clone = '';
+        $clone = null;
         if (1 !== secp256k1_ec_pubkey_parse($context, $clone, $serialized)) {
             throw new \Exception('Secp256k1 pubkey parse');
         }

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PublicKey.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Key/PublicKey.php
@@ -72,7 +72,9 @@ class PublicKey extends Key implements PublicKeyInterface
         $context = $this->ecAdapter->getContext();
         $pubA = '';
         $pubB = '';
-        if (!(secp256k1_ec_pubkey_serialize($context, $pubA, $this->pubkey_t, (int) $this->compressed) && secp256k1_ec_pubkey_serialize($context, $pubB, $other->pubkey_t, (int) $this->compressed))) {
+        $flags = $this->compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+
+        if (!(secp256k1_ec_pubkey_serialize($context, $pubA, $this->pubkey_t, $flags) && secp256k1_ec_pubkey_serialize($context, $pubB, $other->pubkey_t, $flags))) {
             throw new \RuntimeException('Unable to serialize public key during equals');
         }
 
@@ -113,7 +115,8 @@ class PublicKey extends Key implements PublicKeyInterface
     {
         $context = $this->ecAdapter->getContext();
         $serialized = '';
-        if (1 !== secp256k1_ec_pubkey_serialize($context, $serialized, $this->pubkey_t, (int) $this->compressed)) {
+        $flags = $this->compressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED;
+        if (1 !== secp256k1_ec_pubkey_serialize($context, $serialized, $this->pubkey_t, $flags)) {
             throw new \Exception('Secp256k1: pubkey serialize');
         }
 

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Key/PublicKeySerializer.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Key/PublicKeySerializer.php
@@ -67,12 +67,11 @@ class PublicKeySerializer implements PublicKeySerializerInterface
     public function parse(BufferInterface $buffer): PublicKeyInterface
     {
         $binary = $buffer->getBinary();
-        $pubkey_t = '';
-        /** @var resource $pubkey_t */
+        $pubkey_t = null;
         if (!secp256k1_ec_pubkey_parse($this->ecAdapter->getContext(), $pubkey_t, $binary)) {
             throw new \RuntimeException('Secp256k1 failed to parse public key');
         }
-
+        /** @var resource $pubkey_t */
         return new PublicKey(
             $this->ecAdapter,
             $pubkey_t,

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Key/PublicKeySerializer.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Key/PublicKeySerializer.php
@@ -39,7 +39,7 @@ class PublicKeySerializer implements PublicKeySerializerInterface
             $this->ecAdapter->getContext(),
             $serialized,
             $publicKey->getResource(),
-            (int) $isCompressed
+            $isCompressed ? SECP256K1_EC_COMPRESSED : SECP256K1_EC_UNCOMPRESSED
         )) {
             throw new \RuntimeException('Secp256k1: Failed to serialize public key');
         }

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Signature/CompactSignatureSerializer.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Signature/CompactSignatureSerializer.php
@@ -33,8 +33,8 @@ class CompactSignatureSerializer implements CompactSignatureSerializerInterface
     private function doSerialize(CompactSignature $signature)
     {
         $sig_t = '';
-        $recid = '';
-        if (!secp256k1_ecdsa_recoverable_signature_serialize_compact($this->ecAdapter->getContext(), $signature->getResource(), $sig_t, $recid)) {
+        $recid = 0;
+        if (!secp256k1_ecdsa_recoverable_signature_serialize_compact($this->ecAdapter->getContext(), $sig_t, $recid, $signature->getResource())) {
             throw new \RuntimeException('Secp256k1 serialize compact failure');
         }
 
@@ -73,12 +73,11 @@ class CompactSignatureSerializer implements CompactSignatureSerializerInterface
         $isCompressed = ($recoveryFlags & 4) !== 0;
         $recoveryId = $recoveryFlags - ($isCompressed ? 4 : 0);
 
-        $sig_t = '';
-        /** @var resource $sig_t */
+        $sig_t = null;
         if (!secp256k1_ecdsa_recoverable_signature_parse_compact($this->ecAdapter->getContext(), $sig_t, $sig->getBinary(), $recoveryId)) {
             throw new \RuntimeException('Unable to parse compact signature');
         }
-
+        /** @var resource $sig_t */
         return new CompactSignature($this->ecAdapter, $sig_t, $recoveryId, $isCompressed);
     }
 }

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Signature/DerSignatureSerializer.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Serializer/Signature/DerSignatureSerializer.php
@@ -95,7 +95,7 @@ class DerSignatureSerializer implements DerSignatureSerializerInterface
         $derSignature = (new Parser($derSignature))->getBuffer();
         $binary = $derSignature->getBinary();
 
-        $sig_t = '';
+        $sig_t = null;
         /** @var resource $sig_t */
         if (!ecdsa_signature_parse_der_lax($this->ecAdapter->getContext(), $sig_t, $binary)) {
             throw new \RuntimeException('Secp256k1: parse der failure');

--- a/src/Crypto/EcAdapter/Impl/Secp256k1/Signature/CompactSignature.php
+++ b/src/Crypto/EcAdapter/Impl/Secp256k1/Signature/CompactSignature.php
@@ -51,8 +51,8 @@ class CompactSignature extends Signature implements CompactSignatureInterface
         }
 
         $ser = '';
-        $recidout = '';
-        secp256k1_ecdsa_recoverable_signature_serialize_compact($ecAdapter->getContext(), $secp256k1_ecdsa_signature_t, $ser, $recidout);
+        $recidout = 0;
+        secp256k1_ecdsa_recoverable_signature_serialize_compact($ecAdapter->getContext(), $ser, $recidout, $secp256k1_ecdsa_signature_t);
         list ($r, $s) = array_map(
             function ($val) use ($math) {
                 return (new Buffer($val))->getGmp();

--- a/stubs/Secp256k1Stubs.php
+++ b/stubs/Secp256k1Stubs.php
@@ -1,3 +1,4 @@
 <?php
 
-require "../vendor/bitwasp/secp256k1-php/stubs/Secp256k1Stubs.php";
+require "../vendor/bitwasp/secp256k1-php/stubs/const.php";
+require "../vendor/bitwasp/secp256k1-php/stubs/functions.php";


### PR DESCRIPTION
ext-secp256k1 released v0.2.0 today, raising it's minimum PHP version to 7.0, and fixing parameter order wrt upstream of two functions, and passing responsibility for normalizing signatures to the caller before calling verify()

This PR adds the necessary modifications, and bumps support to v0.2.0