### PR TITLE
Throw exception should BIP32 produce an invalid key. Don't increment counter

### DIFF
--- a/src/Exceptions/InvalidDerivationException.php
+++ b/src/Exceptions/InvalidDerivationException.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace BitWasp\Bitcoin\Exceptions;
+
+class InvalidDerivationException extends \Exception
+{
+
+}

--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -11,6 +11,7 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\Key\KeyInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PrivateKeyInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Key\PublicKeyInterface;
 use BitWasp\Bitcoin\Crypto\Hash;
+use BitWasp\Bitcoin\Exceptions\InvalidDerivationException;
 use BitWasp\Bitcoin\Key\KeyToScript\ScriptAndSignData;
 use BitWasp\Bitcoin\Key\KeyToScript\ScriptDataFactory;
 use BitWasp\Bitcoin\Network\NetworkInterface;
@@ -292,8 +293,8 @@ class HierarchicalKey
         $offset = $hash->slice(0, 32);
         $chain = $hash->slice(32);
 
-        if (false === $this->ecAdapter->validatePrivateKey($offset)) {
-            return $this->deriveChild($sequence + 1);
+        if (!$this->ecAdapter->validatePrivateKey($offset)) {
+            throw new InvalidDerivationException("Derived invalid key for index {$sequence}, use next index");
         }
 
         $key = $this->isPrivate() ? $this->getPrivateKey() : $this->getPublicKey();

--- a/tests/Key/Deterministic/HierarchicalKeyTest.php
+++ b/tests/Key/Deterministic/HierarchicalKeyTest.php
@@ -437,13 +437,13 @@ class HierarchicalKeyTest extends AbstractTestCase
     }
 
     /**
-     *
+     * @expectedException \BitWasp\Bitcoin\Exceptions\InvalidDerivationException
+     * @expectedExceptionMessage Derived invalid key for index 1, use next index
      */
     public function testSkipsInvalidKey()
     {
         $math = new Math();
         $generator = EccFactory::getSecgCurves($math)->generator256k1();
-
 
         $k = $math->sub($generator->getOrder(), gmp_init(1));
         $pubKeyFactory = new PublicKeyFactory();
@@ -547,12 +547,7 @@ class HierarchicalKeyTest extends AbstractTestCase
         );
 
         $this->assertEquals(0, $this->HK_run_count);
-        $expected = 1;
-        $child = $key->deriveChild($expected);
-        $this->assertNotEquals($expected, $child->getSequence());
-        $this->assertEquals(2, $child->getSequence());
-        $this->assertEquals(2, $this->HK_run_count);
-        $this->assertEquals(gmp_strval($math->add($k, gmp_init(1)), 10), gmp_strval($child->getPrivateKey()->getSecret(), 10));
+        $key->deriveChild(1);
     }
 
     /**


### PR DESCRIPTION
The current implementation automatically derives $sequence+1 if a requested derivation is invalid. It's important for developers to handle this if it ever occurs during a multisignature account (where public key index should always match). 

The current behavior is also very undesirable when deriving branch keys in the path, since these are usually fixed by the purpose of the wallet (BIP44 and related schemes). 

The behavior was already tested, so no issues releasing this with the next major BC break.