### PR TITLE
Refactor some classes following phpstan notices

### DIFF
--- a/src/Amount.php
+++ b/src/Amount.php
@@ -18,11 +18,11 @@ class Amount
     }
 
     /**
-     * @param string $double
+     * @param string $btcAmount
      * @return int
      */
-    public function toSatoshis(string $double): int
+    public function toSatoshis(string $btcAmount): int
     {
-        return (int) bcmul((string) $double, (string) self::COIN, 0);
+        return (int) bcmul($btcAmount, (string) self::COIN, 0);
     }
 }

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Signature/DerSignatureSerializer.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Signature/DerSignatureSerializer.php
@@ -9,12 +9,12 @@ use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Adapter\EcAdapter;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Signature\Signature;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Signature\DerSignatureSerializerInterface;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Signature\SignatureInterface;
+use BitWasp\Bitcoin\Serializer\Types;
 use BitWasp\Buffertools\Buffer;
 use BitWasp\Buffertools\BufferInterface;
+use BitWasp\Buffertools\Buffertools;
 use BitWasp\Buffertools\Exceptions\ParserOutOfRange;
 use BitWasp\Buffertools\Parser;
-use BitWasp\Buffertools\Template;
-use BitWasp\Buffertools\TemplateFactory;
 
 class DerSignatureSerializer implements DerSignatureSerializerInterface
 {
@@ -24,11 +24,17 @@ class DerSignatureSerializer implements DerSignatureSerializerInterface
     private $ecAdapter;
 
     /**
+     * @var \BitWasp\Buffertools\Types\VarString
+     */
+    private $varstring;
+
+    /**
      * @param EcAdapter $adapter
      */
     public function __construct(EcAdapter $adapter)
     {
         $this->ecAdapter = $adapter;
+        $this->varstring = Types::varstring();
     }
 
     /**
@@ -40,63 +46,34 @@ class DerSignatureSerializer implements DerSignatureSerializerInterface
     }
 
     /**
-     * @return Template
-     */
-    private function getInnerTemplate(): Template
-    {
-        return (new TemplateFactory())
-            ->uint8()
-            ->varstring()
-            ->uint8()
-            ->varstring()
-            ->getTemplate();
-    }
-
-    /**
-     * @return Template
-     */
-    private function getOuterTemplate(): Template
-    {
-        return (new TemplateFactory())
-            ->uint8()
-            ->varstring()
-            ->getTemplate();
-    }
-
-    /**
      * @param SignatureInterface $signature
      * @return BufferInterface
      * @throws \Exception
      */
     public function serialize(SignatureInterface $signature): BufferInterface
     {
-        $math = $this->ecAdapter->getMath();
-
         // Ensure that the R and S hex's are of even length
-        $rBin = $math->intToString($signature->getR());
-        $sBin = $math->intToString($signature->getS());
+        $rBin = gmp_export($signature->getR(), 1, GMP_MSW_FIRST | GMP_BIG_ENDIAN);
+        $sBin = gmp_export($signature->getS(), 1, GMP_MSW_FIRST | GMP_BIG_ENDIAN);
 
         // Pad R and S if their highest bit is flipped, ie,
         // they are negative.
-        $rt = $rBin[0] & pack('H*', '80');
-        if (ord($rt) === 128) {
-            $rBin = pack('H*', '00') . $rBin;
+        if ((ord($rBin[0]) & 0x80) === 0x80) {
+            $rBin = "\x00$rBin";
         }
 
-        $st = $sBin[0] & pack('H*', '80');
-        if (ord($st) === 128) {
-            $sBin = pack('H*', '00') . $sBin;
+        if ((ord($sBin[0]) & 0x80) === 0x80) {
+            $sBin = "\x00$sBin";
         }
 
-        return $this->getOuterTemplate()->write([
-            0x30,
-            $this->getInnerTemplate()->write([
-                0x02,
-                new Buffer($rBin, null),
-                0x02,
-                new Buffer($sBin, null)
-            ])
-        ]);
+        $inner = sprintf("\x02%s%s\x02%s%s",
+            Buffertools::numToVarIntBin(strlen($rBin)),
+            $rBin,
+            Buffertools::numToVarIntBin(strlen($sBin)),
+            $sBin
+        );
+
+        return new Buffer(sprintf("\x30%s%s", Buffertools::numToVarIntBin(strlen($inner)), $inner));
     }
 
     /**
@@ -106,20 +83,31 @@ class DerSignatureSerializer implements DerSignatureSerializerInterface
      */
     public function fromParser(Parser $parser): SignatureInterface
     {
-        try {
-            list (, $inner) = $this->getOuterTemplate()->parse($parser);
-            list (, $r, , $s) = $this->getInnerTemplate()->parse(new Parser($inner));
-            /** @var Buffer $r */
-            /** @var Buffer $s */
+        $prefix = $parser->readBytes(1);
+        if ($prefix->getBinary() != "\x30") {
+            throw new \RuntimeException("invalid signature");
+        }
+        $inner = $this->varstring->read($parser);
 
-            return new Signature(
-                $this->ecAdapter,
-                $r->getGmp(),
-                $s->getGmp()
-            );
+        try {
+            $pinner = new Parser($inner);
+
+            $rPref = $pinner->readBytes(1);
+            if ($rPref->getBinary() != "\x02") {
+                throw new \RuntimeException("invalid signature");
+            }
+            $r = $this->varstring->read($pinner);
+
+            $sPref = $pinner->readBytes(1);
+            if ($sPref->getBinary() != "\x02") {
+                throw new \RuntimeException("invalid signature");
+            }
+            $s = $this->varstring->read($pinner);
         } catch (ParserOutOfRange $e) {
             throw new ParserOutOfRange('Failed to extract full signature from parser');
         }
+
+        return new Signature($this->ecAdapter, $r->getGmp(), $s->getGmp());
     }
 
     /**

--- a/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Signature/DerSignatureSerializer.php
+++ b/src/Crypto/EcAdapter/Impl/PhpEcc/Serializer/Signature/DerSignatureSerializer.php
@@ -66,7 +66,8 @@ class DerSignatureSerializer implements DerSignatureSerializerInterface
             $sBin = "\x00$sBin";
         }
 
-        $inner = sprintf("\x02%s%s\x02%s%s",
+        $inner = sprintf(
+            "\x02%s%s\x02%s%s",
             Buffertools::numToVarIntBin(strlen($rBin)),
             $rBin,
             Buffertools::numToVarIntBin(strlen($sBin)),

--- a/src/Key/Deterministic/HierarchicalKey.php
+++ b/src/Key/Deterministic/HierarchicalKey.php
@@ -327,7 +327,7 @@ class HierarchicalKey
         $key = $this;
         for ($i = 0; $i < $numParts; $i++) {
             try {
-                $key = $key->deriveChild((int) $parts[$i]);
+                $key = $key->deriveChild($parts[$i]);
             } catch (InvalidDerivationException $e) {
                 if ($i === $numParts - 1) {
                     throw new InvalidDerivationException($e->getMessage());

--- a/src/Key/KeyToScript/Factory/KeyToScriptDataFactory.php
+++ b/src/Key/KeyToScript/Factory/KeyToScriptDataFactory.php
@@ -44,7 +44,6 @@ abstract class KeyToScriptDataFactory extends ScriptDataFactory
      */
     public function convertKey(KeyInterface... $keys): ScriptAndSignData
     {
-        /** @var PublicKeyInterface[] $pubs */
         $pubs = [];
         foreach ($keys as $key) {
             if ($key instanceof PrivateKeyInterface) {

--- a/src/Key/KeyToScript/Factory/P2wpkhScriptDataFactory.php
+++ b/src/Key/KeyToScript/Factory/P2wpkhScriptDataFactory.php
@@ -29,6 +29,9 @@ class P2wpkhScriptDataFactory extends KeyToScriptDataFactory
         if (count($keys) !== 1) {
             throw new \InvalidArgumentException("Invalid number of keys");
         }
+        if (!$keys[0]->isCompressed()) {
+            throw new \InvalidArgumentException("Cannot create P2WPKH address for non-compressed public key");
+        }
         return new ScriptAndSignData(
             ScriptFactory::scriptPubKey()->p2wkh($keys[0]->getPubKeyHash($this->pubKeySerializer)),
             new SignData()

--- a/src/Key/KeyToScript/KeyToScriptHelper.php
+++ b/src/Key/KeyToScript/KeyToScriptHelper.php
@@ -14,15 +14,9 @@ use BitWasp\Bitcoin\Key\KeyToScript\Factory\KeyToScriptDataFactory;
 use BitWasp\Bitcoin\Key\KeyToScript\Factory\MultisigScriptDataFactory;
 use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2pkhScriptDataFactory;
 use BitWasp\Bitcoin\Key\KeyToScript\Factory\P2wpkhScriptDataFactory;
-use BitWasp\Bitcoin\Script\ScriptType;
 
 class KeyToScriptHelper
 {
-    /**
-     * @var ScriptDataFactory[]
-     */
-    private $cache = [];
-
     /**
      * @var PublicKeySerializerInterface
      */
@@ -42,11 +36,7 @@ class KeyToScriptHelper
      */
     public function getP2pkhFactory(): P2pkhScriptDataFactory
     {
-        $key = ScriptType::P2PKH;
-        if (!array_key_exists($key, $this->cache)) {
-            $this->cache[$key] = new P2pkhScriptDataFactory($this->pubKeySer);
-        }
-        return $this->cache[$key];
+        return new P2pkhScriptDataFactory($this->pubKeySer);
     }
 
     /**
@@ -65,11 +55,7 @@ class KeyToScriptHelper
      */
     public function getP2wpkhFactory(): P2wpkhScriptDataFactory
     {
-        $key = ScriptType::P2WKH;
-        if (!array_key_exists($key, $this->cache)) {
-            $this->cache[$key] = new P2wpkhScriptDataFactory($this->pubKeySer);
-        }
-        return $this->cache[$key];
+        return new P2wpkhScriptDataFactory($this->pubKeySer);
     }
 
     /**
@@ -79,11 +65,7 @@ class KeyToScriptHelper
      */
     public function getP2shFactory(KeyToScriptDataFactory $scriptFactory): ScriptDataFactory
     {
-        $key = sprintf("%s|%s", ScriptType::P2SH, $scriptFactory->getScriptType());
-        if (!array_key_exists($key, $this->cache)) {
-            $this->cache[$key] = new P2shScriptDecorator($scriptFactory);
-        }
-        return $this->cache[$key];
+        return new P2shScriptDecorator($scriptFactory);
     }
 
     /**
@@ -93,11 +75,7 @@ class KeyToScriptHelper
      */
     public function getP2wshFactory(KeyToScriptDataFactory $scriptFactory): ScriptDataFactory
     {
-        $key = sprintf("%s|%s", ScriptType::P2WSH, $scriptFactory->getScriptType());
-        if (!array_key_exists($key, $this->cache)) {
-            $this->cache[$key] = new P2wshScriptDecorator($scriptFactory);
-        }
-        return $this->cache[$key];
+        return new P2wshScriptDecorator($scriptFactory);
     }
 
     /**
@@ -107,10 +85,6 @@ class KeyToScriptHelper
      */
     public function getP2shP2wshFactory(KeyToScriptDataFactory $scriptFactory): ScriptDataFactory
     {
-        $key = sprintf("%s|%s|%s", ScriptType::P2SH, ScriptType::P2WSH, $scriptFactory->getScriptType());
-        if (!array_key_exists($key, $this->cache)) {
-            $this->cache[$key] = new P2shP2wshScriptDecorator($scriptFactory);
-        }
-        return $this->cache[$key];
+        return new P2shP2wshScriptDecorator($scriptFactory);
     }
 }

--- a/src/Mnemonic/Bip39/Bip39Mnemonic.php
+++ b/src/Mnemonic/Bip39/Bip39Mnemonic.php
@@ -92,13 +92,13 @@ class Bip39Mnemonic implements MnemonicInterface
             throw new \InvalidArgumentException("Invalid entropy length");
         }
 
-        $CS = $ENT / 32;
+        $CS = $ENT >> 5; // divide by 32, convinces static analysis result is an integer
         $bits = gmp_strval($entropy->getGmp(), 2) . $this->calculateChecksum($entropy, $CS);
         $bits = str_pad($bits, ($ENT + $CS), '0', STR_PAD_LEFT);
 
         $result = [];
         foreach (str_split($bits, 11) as $bit) {
-            $result[] = $this->wordList->getWord((int) bindec($bit));
+            $result[] = $this->wordList->getWord(bindec($bit));
         }
 
         return $result;
@@ -148,7 +148,7 @@ class Bip39Mnemonic implements MnemonicInterface
         $entArray = str_split(substr($bits, 0, $ENT), 8);
         $chars = [];
         for ($i = 0; $i < $ENT / 8; $i++) {
-            $chars[] = (int) bindec($entArray[$i]);
+            $chars[] = bindec($entArray[$i]);
         }
 
         // Check checksum

--- a/src/Script/Interpreter/Interpreter.php
+++ b/src/Script/Interpreter/Interpreter.php
@@ -343,7 +343,7 @@ class Interpreter implements InterpreterInterface
      * @param bool $value
      * @return bool
      */
-    public function checkExec(Stack $vfStack, $value): bool
+    public function checkExec(Stack $vfStack, bool $value): bool
     {
         $ret = 0;
         foreach ($vfStack as $item) {
@@ -783,23 +783,23 @@ class Interpreter implements InterpreterInterface
                             } else if ($opCode === Opcodes::OP_SUB) {
                                 $num = $this->math->sub($num1, $num2);
                             } else if ($opCode === Opcodes::OP_BOOLAND) {
-                                $num = $this->math->cmp($num1, $zero) !== 0 && $this->math->cmp($num2, $zero) !== 0;
+                                $num = (int) ($this->math->cmp($num1, $zero) !== 0 && $this->math->cmp($num2, $zero) !== 0);
                             } else if ($opCode === Opcodes::OP_BOOLOR) {
-                                $num = $this->math->cmp($num1, $zero) !== 0 || $this->math->cmp($num2, $zero) !== 0;
+                                $num = (int) ($this->math->cmp($num1, $zero) !== 0 || $this->math->cmp($num2, $zero) !== 0);
                             } elseif ($opCode === Opcodes::OP_NUMEQUAL) {
-                                $num = $this->math->cmp($num1, $num2) === 0;
+                                $num = (int) ($this->math->cmp($num1, $num2) === 0);
                             } elseif ($opCode === Opcodes::OP_NUMEQUALVERIFY) {
-                                $num = $this->math->cmp($num1, $num2) === 0;
+                                $num = (int) ($this->math->cmp($num1, $num2) === 0);
                             } elseif ($opCode === Opcodes::OP_NUMNOTEQUAL) {
-                                $num = $this->math->cmp($num1, $num2) !== 0;
+                                $num = (int) ($this->math->cmp($num1, $num2) !== 0);
                             } elseif ($opCode === Opcodes::OP_LESSTHAN) {
-                                $num = $this->math->cmp($num1, $num2) < 0;
+                                $num = (int) ($this->math->cmp($num1, $num2) < 0);
                             } elseif ($opCode === Opcodes::OP_GREATERTHAN) {
-                                $num = $this->math->cmp($num1, $num2) > 0;
+                                $num = (int) ($this->math->cmp($num1, $num2) > 0);
                             } elseif ($opCode === Opcodes::OP_LESSTHANOREQUAL) {
-                                $num = $this->math->cmp($num1, $num2) <= 0;
+                                $num = (int) ($this->math->cmp($num1, $num2) <= 0);
                             } elseif ($opCode === Opcodes::OP_GREATERTHANOREQUAL) {
-                                $num = $this->math->cmp($num1, $num2) >= 0;
+                                $num = (int) ($this->math->cmp($num1, $num2) >= 0);
                             } elseif ($opCode === Opcodes::OP_MIN) {
                                 $num = ($this->math->cmp($num1, $num2) <= 0) ? $num1 : $num2;
                             } else {

--- a/src/Script/Interpreter/Number.php
+++ b/src/Script/Interpreter/Number.php
@@ -22,13 +22,13 @@ class Number extends Serializable
     private $math;
 
     /**
-     * @var int
+     * @var int|string
      */
     private $number;
 
     /**
      * Number constructor.
-     * @param int $number
+     * @param int|string $number
      * @param Math $math
      */
     public function __construct($number, Math $math)
@@ -38,7 +38,7 @@ class Number extends Serializable
     }
 
     /**
-     * @param int $number
+     * @param int|string $number
      * @param Math|null $math
      * @return self
      */
@@ -79,7 +79,6 @@ class Number extends Serializable
 
         if ($fRequireMinimal && $size > 0) {
             $binary = $vch->getBinary();
-            //$chars = array_values(unpack("C*", $binary));
             if ((ord($binary[$size - 1]) & 0x7f) === 0) {
                 if ($size <= 1 || (ord($binary[$size - 2]) & 0x80) === 0) {
                     throw new \RuntimeException('Non-minimally encoded script number');
@@ -95,9 +94,9 @@ class Number extends Serializable
 
     /**
      * @param BufferInterface $buffer
-     * @return int
+     * @return string
      */
-    private function parseBuffer(BufferInterface $buffer)
+    private function parseBuffer(BufferInterface $buffer): string
     {
         $size = $buffer->getSize();
         if ($size === 0) {
@@ -124,7 +123,7 @@ class Number extends Serializable
     /**
      * @return BufferInterface
      */
-    private function serialize()
+    private function serialize(): BufferInterface
     {
         if ((int) $this->number === 0) {
             return new Buffer('', 0);

--- a/src/Script/Interpreter/Number.php
+++ b/src/Script/Interpreter/Number.php
@@ -160,7 +160,7 @@ class Number extends Serializable
     /**
      * @return int
      */
-    public function getInt()
+    public function getInt(): int
     {
         if ($this->math->cmp(gmp_init($this->number, 10), gmp_init(self::MAX)) > 0) {
             return self::MAX;
@@ -168,7 +168,7 @@ class Number extends Serializable
             return self::MIN;
         }
 
-        return $this->number;
+        return (int) $this->number;
     }
 
     /**

--- a/src/Script/Script.php
+++ b/src/Script/Script.php
@@ -165,7 +165,7 @@ class Script extends Serializable implements ScriptInterface
      */
     public function countWitnessSigOps(ScriptInterface $scriptSig, ScriptWitnessInterface $scriptWitness, int $flags): int
     {
-        if ($flags & InterpreterInterface::VERIFY_WITNESS === 0) {
+        if (($flags & InterpreterInterface::VERIFY_WITNESS) === 0) {
             return 0;
         }
 
@@ -177,10 +177,13 @@ class Script extends Serializable implements ScriptInterface
 
         if ((new OutputClassifier())->isPayToScriptHash($this)) {
             $parsed = $scriptSig->getScriptParser()->decode();
-            $subscript = new Script(end($parsed)->getData());
-            if ($subscript->isWitness($program)) {
-                /** @var WitnessProgram $program */
-                return $this->witnessSigOps($program, $scriptWitness);
+            $count = count($parsed);
+            if ($count > 0) {
+                $subscript = new Script($parsed[$count - 1]->getData());
+                if ($subscript->isWitness($program)) {
+                    /** @var WitnessProgram $program */
+                    return $this->witnessSigOps($program, $scriptWitness);
+                }
             }
         }
 

--- a/src/Script/functions.php
+++ b/src/Script/functions.php
@@ -14,7 +14,7 @@ function decodeOpN(int $op): int
         throw new \RuntimeException("Invalid opcode");
     }
 
-    return (int) $op - (Opcodes::OP_1 - 1);
+    return $op - (Opcodes::OP_1 - 1);
 }
 
 function encodeOpN(int $op): int
@@ -27,5 +27,5 @@ function encodeOpN(int $op): int
         throw new \RuntimeException("Invalid value");
     }
 
-    return (int) Opcodes::OP_1 + $op - 1;
+    return Opcodes::OP_1 + $op - 1;
 }

--- a/src/Serializer/Block/BitcoindBlockSerializer.php
+++ b/src/Serializer/Block/BitcoindBlockSerializer.php
@@ -53,12 +53,12 @@ class BitcoindBlockSerializer
     public function serialize(BlockInterface $block): BufferInterface
     {
         $buffer = $this->blockSerializer->serialize($block);
-        $size = $buffer->getSize();
-        return new Buffer(
-            Buffertools::flipBytes(pack("H*", $this->network->getNetMagicBytes())) .
-            $this->size->write($size) .
+        return new Buffer(sprintf(
+            "%s%s%s",
+            strrev(pack("H*", $this->network->getNetMagicBytes())),
+            pack("V", $buffer->getSize()),
             $buffer->getBinary()
-        );
+        ));
     }
 
     /**

--- a/src/Serializer/MessageSigner/SignedMessageSerializer.php
+++ b/src/Serializer/MessageSigner/SignedMessageSerializer.php
@@ -72,8 +72,12 @@ class SignedMessageSerializer
         $sigStart = $sigHeaderPos + strlen(self::SIG_START);
 
         $sig = trim(substr($content, $sigStart, $sigEnd - $sigStart));
-        $sig = new Buffer(base64_decode($sig));
-        $compactSig = $this->csSerializer->parse($sig);
+        $decoded = base64_decode($sig);
+        if (false === $decoded) {
+            throw new \RuntimeException('Invalid base64');
+        }
+
+        $compactSig = $this->csSerializer->parse(new Buffer($decoded));
 
         return new SignedMessage($message, $compactSig);
     }

--- a/src/Signature/TransactionSignature.php
+++ b/src/Signature/TransactionSignature.php
@@ -68,6 +68,25 @@ class TransactionSignature extends Serializable implements TransactionSignatureI
             && $this->hashType === $other->getHashType();
     }
 
+    private static function verifyElement($fieldName, $start, $length, $binaryString)
+    {
+        if ($length === 0) {
+            throw new SignatureNotCanonical('Signature ' . $fieldName . ' length is zero');
+        }
+        $typePrefix = ord($binaryString[$start - 2]);
+        if ($typePrefix !== 0x02) {
+            throw new SignatureNotCanonical('Signature ' . $fieldName . ' value type mismatch');
+        }
+
+        $first = ord($binaryString[$start + 0]);
+        if (($first & 0x80) === 128) {
+            throw new SignatureNotCanonical('Signature ' . $fieldName . ' value is negative');
+        }
+        if ($length > 1 && $first === 0 && (ord($binaryString[$start + 1]) & 0x80) === 0) {
+            throw new SignatureNotCanonical('Signature ' . $fieldName . ' value excessively padded');
+        }
+    }
+
     /**
      * @param BufferInterface $sig
      * @return bool
@@ -75,24 +94,6 @@ class TransactionSignature extends Serializable implements TransactionSignatureI
      */
     public static function isDERSignature(BufferInterface $sig): bool
     {
-        $checkVal = function ($fieldName, $start, $length, $binaryString) {
-            if ($length === 0) {
-                throw new SignatureNotCanonical('Signature ' . $fieldName . ' length is zero');
-            }
-            $typePrefix = ord(substr($binaryString, $start - 2, 1));
-            if ($typePrefix !== 0x02) {
-                throw new SignatureNotCanonical('Signature ' . $fieldName . ' value type mismatch');
-            }
-            $val = substr($binaryString, $start, $length);
-            $vAnd = $val[0] & chr(0x80);
-            if (ord($vAnd) === 128) {
-                throw new SignatureNotCanonical('Signature ' . $fieldName . ' value is negative');
-            }
-            if ($length > 1 && $val[0] === "\x00" && !ord(($val[1] & chr(0x80)))) {
-                throw new SignatureNotCanonical('Signature ' . $fieldName . ' value excessively padded');
-            }
-        };
-
         $bin = $sig->getBinary();
         $size = $sig->getSize();
         if ($size < 9) {
@@ -123,8 +124,8 @@ class TransactionSignature extends Serializable implements TransactionSignatureI
             throw new SignatureNotCanonical('Signature R+S length mismatch');
         }
 
-        $checkVal('R', $startR, $lenR, $bin);
-        $checkVal('S', $startS, $lenS, $bin);
+        self::verifyElement('R', $startR, $lenR, $bin);
+        self::verifyElement('S', $startS, $lenS, $bin);
 
         return true;
     }

--- a/src/Signature/TransactionSignature.php
+++ b/src/Signature/TransactionSignature.php
@@ -68,7 +68,7 @@ class TransactionSignature extends Serializable implements TransactionSignatureI
             && $this->hashType === $other->getHashType();
     }
 
-    private static function verifyElement($fieldName, $start, $length, $binaryString)
+    private static function verifyElement(string $fieldName, int $start, int $length, string $binaryString)
     {
         if ($length === 0) {
             throw new SignatureNotCanonical('Signature ' . $fieldName . ' length is zero');

--- a/src/Transaction/Factory/ScriptInfo/CheckLocktimeVerify.php
+++ b/src/Transaction/Factory/ScriptInfo/CheckLocktimeVerify.php
@@ -65,7 +65,7 @@ class CheckLocktimeVerify
 
         $numLockTime = Number::buffer($chunks[0]->getData(), $fMinimal, 5);
 
-        return new static((int) $numLockTime->getInt());
+        return new static($numLockTime->getInt());
     }
 
     /**

--- a/src/Transaction/Factory/ScriptInfo/CheckSequenceVerify.php
+++ b/src/Transaction/Factory/ScriptInfo/CheckSequenceVerify.php
@@ -60,7 +60,7 @@ class CheckSequenceVerify
 
         $numLockTime = Number::buffer($chunks[0]->getData(), $fMinimal, 5);
 
-        return new static((int) $numLockTime->getInt());
+        return new static($numLockTime->getInt());
     }
 
     /**

--- a/src/Transaction/SignatureHash/V1Hasher.php
+++ b/src/Transaction/SignatureHash/V1Hasher.php
@@ -127,7 +127,6 @@ class V1Hasher extends SigHash
         int $sighashType = SigHash::ALL
     ): BufferInterface {
 
-        $sighashType = $sighashType;
         $hashPrevOuts = $this->hashPrevOuts($sighashType);
         $hashSequence = $this->hashSequences($sighashType);
         $hashOutputs = $this->hashOutputs($sighashType, $inputToSign);

--- a/src/Transaction/SignatureHash/V1Hasher.php
+++ b/src/Transaction/SignatureHash/V1Hasher.php
@@ -127,7 +127,7 @@ class V1Hasher extends SigHash
         int $sighashType = SigHash::ALL
     ): BufferInterface {
 
-        $sighashType = (int) $sighashType;
+        $sighashType = $sighashType;
         $hashPrevOuts = $this->hashPrevOuts($sighashType);
         $hashSequence = $this->hashSequences($sighashType);
         $hashOutputs = $this->hashOutputs($sighashType, $inputToSign);

--- a/src/Transaction/TransactionInput.php
+++ b/src/Transaction/TransactionInput.php
@@ -13,7 +13,6 @@ use BitWasp\Buffertools\BufferInterface;
 
 class TransactionInput extends Serializable implements TransactionInputInterface
 {
-
     /**
      * @var OutPointInterface
      */
@@ -25,7 +24,7 @@ class TransactionInput extends Serializable implements TransactionInputInterface
     private $script;
 
     /**
-     * @var string|int
+     * @var int
      */
     private $sequence;
 

--- a/src/Uri.php
+++ b/src/Uri.php
@@ -15,7 +15,12 @@ class Uri
     /**
      * @var AddressInterface
      */
-    private $address;
+    private $bip21Address;
+
+    /**
+     * @var AddressInterface|null
+     */
+    private $bip72Address;
 
     /**
      * @var null|string
@@ -53,11 +58,13 @@ class Uri
             if ($address === null) {
                 throw new \InvalidArgumentException('Cannot provide a null address with bip0021');
             }
-        } else if ($convention !== self::BIP0072) {
+            $this->bip21Address = $address;
+        } else if ($convention === self::BIP0072) {
+            $this->bip72Address = $address;
+        } else {
             throw new \InvalidArgumentException("Invalid convention for bitcoin uri");
         }
 
-        $this->address = $address;
         $this->rule = $convention;
     }
 
@@ -119,9 +126,9 @@ class Uri
     public function uri(NetworkInterface $network = null): string
     {
         if ($this->rule === self::BIP0072) {
-            $address = $this->address === null ? '' : $this->address->getAddress($network);
+            $address = $this->bip72Address === null ? '' : $this->bip72Address->getAddress($network);
         } else {
-            $address = $this->address->getAddress($network);
+            $address = $this->bip21Address->getAddress($network);
         }
 
         $url = 'bitcoin:' . $address;

--- a/tests/Serializer/Signature/DerSignatureSerializerTest.php
+++ b/tests/Serializer/Signature/DerSignatureSerializerTest.php
@@ -28,7 +28,8 @@ class DerSignatureSerializerTest extends AbstractTestCase
         $serializer->parse(new Buffer());
     }
 
-    public function testPhpeccIsConsistent() {
+    public function testPhpeccIsConsistent()
+    {
         $r = 1;
         $s = 1;
         $adapter = EcAdapterFactory::getPhpEcc(new Math(), EccFactory::getSecgCurves()->generator256k1());

--- a/tests/Serializer/Signature/DerSignatureSerializerTest.php
+++ b/tests/Serializer/Signature/DerSignatureSerializerTest.php
@@ -5,10 +5,14 @@ declare(strict_types=1);
 namespace BitWasp\Bitcoin\Tests\Serializer\Signature;
 
 use BitWasp\Bitcoin\Crypto\EcAdapter\Adapter\EcAdapterInterface;
+use BitWasp\Bitcoin\Crypto\EcAdapter\EcAdapterFactory;
 use BitWasp\Bitcoin\Crypto\EcAdapter\EcSerializer;
+use BitWasp\Bitcoin\Crypto\EcAdapter\Impl\PhpEcc\Signature\Signature as PhpeccSignature;
 use BitWasp\Bitcoin\Crypto\EcAdapter\Serializer\Signature\DerSignatureSerializerInterface;
+use BitWasp\Bitcoin\Math\Math;
 use BitWasp\Bitcoin\Tests\AbstractTestCase;
 use BitWasp\Buffertools\Buffer;
+use Mdanter\Ecc\EccFactory;
 
 class DerSignatureSerializerTest extends AbstractTestCase
 {
@@ -22,5 +26,18 @@ class DerSignatureSerializerTest extends AbstractTestCase
         /** @var DerSignatureSerializerInterface $serializer */
         $serializer = EcSerializer::getSerializer(DerSignatureSerializerInterface::class, true, $adapter);
         $serializer->parse(new Buffer());
+    }
+
+    public function testPhpeccIsConsistent() {
+        $r = 1;
+        $s = 1;
+        $adapter = EcAdapterFactory::getPhpEcc(new Math(), EccFactory::getSecgCurves()->generator256k1());
+        $signature = new PhpeccSignature($adapter, gmp_init($r), gmp_init($s));
+        /** @var DerSignatureSerializerInterface $serializer */
+        $serializer = EcSerializer::getSerializer(DerSignatureSerializerInterface::class, true, $adapter);
+        $buffer = $serializer->serialize($signature);
+        $parsed = $serializer->parse($buffer);
+        $this->assertEquals($signature->getR(), $parsed->getR());
+        $this->assertEquals($signature->getS(), $parsed->getS());
     }
 }


### PR DESCRIPTION
Noteworthy changes:
 - Uri::setAmountBtc now requires a string value, not a float. Not really a BC break, because PHP7 versions haven't really been tagged yet.
 - P2wpkhScriptDataFactory now prohibits uncompressed keys