### PR TITLE
ProofOfWork: renaming check -> checkPow

### DIFF
--- a/src/Chain/ProofOfWork.php
+++ b/src/Chain/ProofOfWork.php
@@ -38,7 +38,7 @@ class ProofOfWork
      * @param int $bits
      * @return \GMP
      */
-    public function getTarget($bits): \GMP
+    public function getTarget(int $bits): \GMP
     {
         $negative = false;
         $overflow = false;
@@ -85,7 +85,7 @@ class ProofOfWork
      * @param int $nBits
      * @return bool
      */
-    public function check(BufferInterface $hash, int $nBits): bool
+    public function checkPow(BufferInterface $hash, int $nBits): bool
     {
         $negative = false;
         $overflow = false;
@@ -96,7 +96,7 @@ class ProofOfWork
         }
 
         if ($this->math->cmp($hash->getGmp(), $target) > 0) {
-            throw new \RuntimeException("Hash doesn't match nBits");
+            return false;
         }
 
         return true;
@@ -109,7 +109,7 @@ class ProofOfWork
      */
     public function checkHeader(BlockHeaderInterface $header): bool
     {
-        return $this->check($header->getHash(), $header->getBits());
+        return $this->checkPow($header->getHash(), $header->getBits());
     }
 
     /**

--- a/tests/Chain/ProofOfWorkTest.php
+++ b/tests/Chain/ProofOfWorkTest.php
@@ -42,20 +42,16 @@ class ProofOfWorkTest extends AbstractTestCase
         $params = new Params($math);
         $pow = new ProofOfWork(new Math(), $params);
         $bits = 1;
-        $pow->check(Buffer::hex('00000000a3bbe4fd1da16a29dbdaba01cc35d6fc74ee17f794cf3aab94f7aaa0'), $bits);
+        $pow->checkPow(Buffer::hex('00000000a3bbe4fd1da16a29dbdaba01cc35d6fc74ee17f794cf3aab94f7aaa0'), $bits);
     }
 
-    /**
-     * @expectedException \RuntimeException
-     * @expectedExceptionMessage Hash doesn't match nBits
-     */
     public function testWhereHashTooLow()
     {
         $math = new Math();
         $params = new Params($math);
         $pow = new ProofOfWork(new Math(), $params);
         $bits = 0x181287ba;
-        $pow->check(Buffer::hex('00000000a3bbe4fd1da16a29dbdaba01cc35d6fc74ee17f794cf3aab94f7aaa0'), $bits);
+        $this->assertFalse($pow->checkPow(Buffer::hex('00000000a3bbe4fd1da16a29dbdaba01cc35d6fc74ee17f794cf3aab94f7aaa0'), $bits));
     }
 
     /**


### PR DESCRIPTION
ProofOfWork::check currently throws when the hash is not valid for a given bits, despite indicating it returns a boolean via it's return type. The exception here seems overkill, so this PR returns false in that case.

Since after this PR exceptions would not be thrown, users of this function may fail to notice validation failures. Hence I feel it's worth making the change a breaking change, signalling to people who don't notice the PR or release notes.