### PR TITLE
replace unsafe usage of new static()

### DIFF
--- a/src/Script/ScriptInfo/Multisig.php
+++ b/src/Script/ScriptInfo/Multisig.php
@@ -90,7 +90,7 @@ class Multisig
      * @param Operation[] $decoded
      * @param PublicKeySerializerInterface|null $pubKeySerializer
      * @param bool $allowVerify
-     * @return static
+     * @return Multisig
      */
     public static function fromDecodedScript(array $decoded, PublicKeySerializerInterface $pubKeySerializer = null, $allowVerify = false)
     {
@@ -119,7 +119,7 @@ class Multisig
             throw new \LogicException('No public keys found in script');
         }
 
-        return new static($requiredSigs, $publicKeyBuffers, $opCode, $allowVerify, $pubKeySerializer);
+        return new Multisig($requiredSigs, $publicKeyBuffers, $opCode, $allowVerify, $pubKeySerializer);
     }
 
     /**

--- a/src/Script/ScriptInfo/PayToPubkey.php
+++ b/src/Script/ScriptInfo/PayToPubkey.php
@@ -60,7 +60,7 @@ class PayToPubkey
             throw new \InvalidArgumentException('Malformed pay-to-pubkey script');
         }
 
-        return new static($chunks[1]->getOp(), $chunks[0]->getData(), $allowVerify);
+        return new PayToPubkey($chunks[1]->getOp(), $chunks[0]->getData(), $allowVerify);
     }
 
     /**

--- a/src/Script/ScriptInfo/PayToPubkeyHash.php
+++ b/src/Script/ScriptInfo/PayToPubkeyHash.php
@@ -57,9 +57,9 @@ class PayToPubkeyHash
     /**
      * @param Operation[] $chunks
      * @param bool $allowVerify
-     * @return static
+     * @return PayToPubKeyHash
      */
-    public static function fromDecodedScript(array $chunks, bool $allowVerify = false)
+    public static function fromDecodedScript(array $chunks, bool $allowVerify = false): PayToPubKeyHash
     {
         if (count($chunks) !== 5) {
             throw new \RuntimeException('Malformed pay-to-pubkey-hash script');
@@ -72,7 +72,7 @@ class PayToPubkeyHash
             throw new \RuntimeException('Malformed pay-to-pubkey-hash script');
         }
 
-        return new static($chunks[4]->getOp(), $chunks[2]->getData(), $allowVerify);
+        return new PayToPubkeyHash($chunks[4]->getOp(), $chunks[2]->getData(), $allowVerify);
     }
 
     /**

--- a/src/Transaction/Factory/ScriptInfo/CheckLocktimeVerify.php
+++ b/src/Transaction/Factory/ScriptInfo/CheckLocktimeVerify.php
@@ -43,9 +43,9 @@ class CheckLocktimeVerify
     /**
      * @param Operation[] $chunks
      * @param bool $fMinimal
-     * @return static
+     * @return CheckLocktimeVerify
      */
-    public static function fromDecodedScript(array $chunks, bool $fMinimal = false): self
+    public static function fromDecodedScript(array $chunks, bool $fMinimal = false): CheckLocktimeVerify
     {
         if (count($chunks) !== 3) {
             throw new \RuntimeException("Invalid number of items for CLTV");
@@ -65,7 +65,7 @@ class CheckLocktimeVerify
 
         $numLockTime = Number::buffer($chunks[0]->getData(), $fMinimal, 5);
 
-        return new static($numLockTime->getInt());
+        return new CheckLocktimeVerify($numLockTime->getInt());
     }
 
     /**

--- a/src/Transaction/Factory/ScriptInfo/CheckSequenceVerify.php
+++ b/src/Transaction/Factory/ScriptInfo/CheckSequenceVerify.php
@@ -40,7 +40,7 @@ class CheckSequenceVerify
      * @param bool $fMinimal
      * @return static
      */
-    public static function fromDecodedScript(array $chunks, $fMinimal = false): self
+    public static function fromDecodedScript(array $chunks, $fMinimal = false): CheckSequenceVerify
     {
         if (count($chunks) !== 3) {
             throw new \RuntimeException("Invalid number of items for CSV");
@@ -60,7 +60,7 @@ class CheckSequenceVerify
 
         $numLockTime = Number::buffer($chunks[0]->getData(), $fMinimal, 5);
 
-        return new static($numLockTime->getInt());
+        return new CheckSequenceVerify($numLockTime->getInt());
     }
 
     /**

--- a/src/Transaction/OutPoint.php
+++ b/src/Transaction/OutPoint.php
@@ -44,11 +44,11 @@ class OutPoint extends Serializable implements OutPointInterface
     }
 
     /**
-     * @return static
+     * @return OutPointInterface
      */
-    public static function makeCoinbase(): self
+    public static function makeCoinbase(): OutPointInterface
     {
-        return new static(new Buffer("", 32), 0xffffffff);
+        return new OutPoint(new Buffer("", 32), 0xffffffff);
     }
 
     /**


### PR DESCRIPTION
These were highlighted by a new phpstan rule - these calls are unsafe as the constructor isn't known in this context.