### PR TITLE
1.0: deprecation notice for StackInterface (unused)

### DIFF
--- a/src/Script/Interpreter/StackInterface.php
+++ b/src/Script/Interpreter/StackInterface.php
@@ -6,6 +6,9 @@ namespace BitWasp\Bitcoin\Script\Interpreter;
 
 use BitWasp\Buffertools\BufferInterface;
 
+/**
+ * @deprecated v2.0.0 Unused in project
+ */
 interface StackInterface extends \ArrayAccess, \Iterator
 {
     /**


### PR DESCRIPTION
This interface isn't used anywhere, and can be removed in an upcoming release