### PR TITLE
Update mdanter/ecc to accept v1 and unblock php 8 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "pleonasm/merkle-tree": "1.0.0",
     "composer/semver": "^1.4.0|^3.2.0",
     "lastguest/murmurhash": "v2.0.0",
-    "mdanter/ecc": "^0.5.0",
+    "mdanter/ecc": "^0.5.0|^1.0.0",
     "bitwasp/buffertools": "^0.5.0",
     "bitwasp/bech32": "^0.0.1"
   },


### PR DESCRIPTION
mdanter/ecc v0.5 requires php ^7.0, the v1 handle php 8 and there is no breaking change

Diff between v0.5.2 and v1.0.0: https://github.com/phpecc/phpecc/compare/v0.5.2...v1.0.0
Release note: https://github.com/phpecc/phpecc/blob/master/doc/release-notes-1.0.0.md