### PR TITLE
Migrate to secure ECC library

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "pleonasm/merkle-tree": "1.0.0",
     "composer/semver": "^1.4.0|^3.2.0",
     "lastguest/murmurhash": "v2.0.0",
-    "mdanter/ecc": "^0.5.0",
+    "paragonie/ecc": "^2.1.0",
     "bitwasp/buffertools": "^0.5.0",
     "bitwasp/bech32": "^0.0.1"
   },


### PR DESCRIPTION
Fixes #919 

https://www.openwall.com/lists/oss-security/2024/04/24/4