### PR TITLE
compatibility for ArrayAccess interface

### DIFF
--- a/src/Script/Opcodes.php
+++ b/src/Script/Opcodes.php
@@ -350,8 +350,9 @@ class Opcodes implements \ArrayAccess
 
     /**
      * @param int $pos
+     * #[\ReturnTypeWillChange]
      */
-    public function offsetUnset($pos)
+    public function offsetUnset($pos): void
     {
         $this->errorNoWrite();
     }
@@ -359,8 +360,9 @@ class Opcodes implements \ArrayAccess
     /**
      * @param int $pos
      * @param mixed $value
+     * #[\ReturnTypeWillChange]
      */
-    public function offsetSet($pos, $value)
+    public function offsetSet($pos, $value): void
     {
         $this->errorNoWrite();
     }


### PR DESCRIPTION
fix: add PHP 8.1+ compatibility for ArrayAccess interface

- Add return type declarations and ReturnTypeWillChange attribute
- Update ArrayAccess interface implementation in Opcodes class
- Maintain backward compatibility with PHP 7.x